### PR TITLE
Seller Address Fix

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -831,11 +831,13 @@ class Settings {
                         'email'   => '',
                         'phone'   => '',
                         'address' => '',
+                        'street_address' => '',
                     ],
                     'options' => [
                         'email'   => __( 'Email Address', 'dokan-lite' ),
                         'phone'   => __( 'Phone Number', 'dokan-lite' ),
                         'address' => __( 'Store Address', 'dokan-lite' ),
+                        'street_address' => __( 'Street Address', 'dokan-lite' ),
                     ],
                 ],
                 'disable_dokan_fontawesome' => [

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -241,12 +241,33 @@ class Customizer {
             ]
         );
 
+        $wp_customize->add_setting(
+            'dokan_appearance[hide_vendor_info][street_address]',
+            [
+                'default'              => '',
+                'type'                 => 'option',
+                'capability'           => $this->capability,
+                'sanitize_callback'    => [ $this, 'bool_to_string' ],
+                'sanitize_js_callback' => [ $this, 'empty_to_bool' ],
+            ]
+        );
+
         $wp_customize->add_control(
             'hide_vendor_address',
             [
                 'label'    => __( 'Hide store address', 'dokan-lite' ),
                 'section'  => 'dokan_store',
                 'settings' => 'dokan_appearance[hide_vendor_info][address]',
+                'type'     => 'checkbox',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'hide_vendor_street_address',
+            [
+                'label'    => __( 'Hide street address', 'dokan-lite' ),
+                'section'  => 'dokan_store',
+                'settings' => 'dokan_appearance[hide_vendor_info][street_address]',
                 'type'     => 'checkbox',
             ]
         );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2515,7 +2515,7 @@ function dokan_get_seller_address( $seller_id = 0, $get_array = false ) {
  *
  * @return string
  */
-function dokan_get_seller_short_address( $store_id, $line_break = true ) {
+function dokan_get_seller_short_address( $store_id, $full=true, $line_break = true ) {
     $store_address     = dokan_get_seller_address( $store_id, true );
     $address_classes   = [
         'street_1',
@@ -2527,14 +2527,16 @@ function dokan_get_seller_short_address( $store_id, $line_break = true ) {
     $short_address     = [];
     $formatted_address = '';
 
-    if ( ! empty( $store_address['street_1'] ) && empty( $store_address['street_2'] ) ) {
-        $short_address[] = "<span class='{$address_classes[0]}'> {$store_address['street_1']},</span>";
-    } elseif ( empty( $store_address['street_1'] ) && ! empty( $store_address['street_2'] ) ) {
-        $short_address[] = "<span class='{$address_classes[1]}'> {$store_address['street_2']},</span>";
-    } elseif ( ! empty( $store_address['street_1'] ) && ! empty( $store_address['street_2'] ) ) {
-        $short_address[] = "<span class='{$address_classes[0]} {$address_classes[1]}'> {$store_address['street_1']}, {$store_address['street_2']}</span>";
+    if ( !$full ) {
+        if ( ! empty( $store_address['street_1'] ) && empty( $store_address['street_2'] ) ) {
+            $short_address[] = "<span class='{$address_classes[0]}'> {$store_address['street_1']},</span>";
+        } elseif ( empty( $store_address['street_1'] ) && ! empty( $store_address['street_2'] ) ) {
+            $short_address[] = "<span class='{$address_classes[1]}'> {$store_address['street_2']},</span>";
+        } elseif ( ! empty( $store_address['street_1'] ) && ! empty( $store_address['street_2'] ) ) {
+            $short_address[] = "<span class='{$address_classes[0]} {$address_classes[1]}'> {$store_address['street_1']}, {$store_address['street_2']}</span>";
+        }
     }
-
+    
     if ( ! empty( $store_address['city'] ) && ! empty( $store_address['city'] ) ) {
         $short_address[] = "<span class='{$address_classes[2]}'> {$store_address['city']},</span>";
     }

--- a/templates/store-header.php
+++ b/templates/store-header.php
@@ -11,7 +11,8 @@ $today             = strtolower( $current_time->format( 'l' ) );
 
 $dokan_appearance = get_option( 'dokan_appearance' );
 $profile_layout   = empty( $dokan_appearance['store_header_template'] ) ? 'default' : $dokan_appearance['store_header_template'];
-$store_address    = dokan_get_seller_short_address( $store_user->get_id(), false );
+$show_street = dokan_is_vendor_info_hidden( 'street_address' );
+$store_address    = dokan_get_seller_short_address( $store_user->get_id(), $show_street, false );
 
 $dokan_store_time_enabled = isset( $store_info['dokan_store_time_enabled'] ) ? $store_info['dokan_store_time_enabled'] : '';
 $store_open_notice        = isset( $store_info['dokan_store_open_notice'] ) && ! empty( $store_info['dokan_store_open_notice'] ) ? $store_info['dokan_store_open_notice'] : __( 'Store Open', 'dokan-lite' );

--- a/templates/store-lists-loop.php
+++ b/templates/store-lists-loop.php
@@ -12,7 +12,8 @@
                     $is_store_featured        = $vendor->is_featured();
                     $store_phone              = $vendor->get_phone();
                     $store_info               = dokan_get_store_info( $seller->ID );
-                    $store_address            = dokan_get_seller_short_address( $seller->ID );
+                    $show_street              = dokan_is_vendor_info_hidden( 'street_address' );
+                    $store_address            = dokan_get_seller_short_address( $seller->ID, $show_street );
                     $store_banner_url         = $store_banner_id ? wp_get_attachment_image_src( $store_banner_id, $image_size ) : DOKAN_PLUGIN_ASSEST . '/images/default-store-banner.png';
                     $show_store_open_close    = dokan_get_option( 'store_open_close', 'dokan_appearance', 'on' );
                     $dokan_store_time_enabled = isset( $store_info['dokan_store_time_enabled'] ) ? $store_info['dokan_store_time_enabled'] : '';


### PR DESCRIPTION
Allows admin to hide street addresses across the site via a toggle in the appearance settings.

### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:
This pull request implements the Street Address Toggle functionality mentioned in this issue: #2125 

### Closes 
#2125 


### How to test the changes in this Pull Request:
Street Address toggle is added here:
![image](https://github.com/getdokan/dokan/assets/42970431/4040e056-ec8c-4a86-92d1-af15e3555bb6)

Toggling on, will hide the street address for all vendors on the store page as well as in the store listings. 

### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?
