### PR TITLE
fix: under wooCommerce my-account registration section, `I am a customer` was forced to be set as default value

### DIFF
--- a/assets/src/js/vendor-registration.js
+++ b/assets/src/js/vendor-registration.js
@@ -39,22 +39,25 @@ var Dokan_Vendor_Registration = {
     },
 
     showSellerForm: function() {
-        var value = $(this).val();
+        let value = $(this).val();
+        if ( value.length === 0 ) {
+            value = dokanRegistrationI18n.defaultRole;
+        }
 
-        if ( value === 'seller') {
-            $('.show_if_seller').find( 'input, select' ).removeAttr( 'disabled' );
+        if ( value === 'seller' ) {
+            $('.show_if_seller').find( 'input, select' ).prop( 'disabled', false );
             $('.show_if_seller').slideDown();
 
             if ( $( '.tc_check_box' ).length > 0 ) {
-                $('button[name=register]').attr('disabled','disabled');
+                $('button[name=register]').prop('disabled',true);
             }
             $('.user-role .dokan-role-seller').prop("checked",true);
         } else {
-            $('.show_if_seller').find( 'input, select' ).attr( 'disabled', 'disabled' );
+            $('.show_if_seller').find( 'input, select' ).prop( 'disabled', true );
             $('.show_if_seller').slideUp();
 
             if ( $( '.tc_check_box' ).length > 0 ) {
-                $( 'button[name=register]' ).removeAttr( 'disabled' );
+                $( 'button[name=register]' ).prop( 'disabled', false );
             }
             $('.user-role .dokan-role-customer').prop("checked",true);
         }
@@ -196,8 +199,6 @@ var Dokan_Vendor_Registration = {
 $(function() {
     window.Dokan_Vendor_Registration = Dokan_Vendor_Registration;
     window.Dokan_Vendor_Registration.init();
-
-    $('.show_if_seller').find( 'input, select' ).attr( 'disabled', 'disabled' );
 
     // trigger change if there is an error while registering
     var shouldTrigger = $( '.woocommerce ul' ).hasClass( 'woocommerce-error' ) && ! $( '.show_if_seller' ).is( ':hidden' );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -638,9 +638,13 @@ class Assets {
         wp_localize_script( 'dokan-i18n-jed', 'dokan', $localize_data );
 
         // localized vendor-registration script
-        wp_localize_script( 'dokan-vendor-registration', 'dokanRegistrationI18n', [
-            'defaultRole' => dokan_get_seller_registration_default_role(),
-        ] );
+        wp_localize_script(
+            'dokan-vendor-registration',
+            'dokanRegistrationI18n',
+            [
+                'defaultRole' => dokan_get_seller_registration_default_role(),
+            ]
+        );
 
         // load only in dokan dashboard and product edit page
         if ( ( dokan_is_seller_dashboard() || ( get_query_var( 'edit' ) && is_singular( 'product' ) ) ) || apply_filters( 'dokan_forced_load_scripts', false ) ) {

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -637,6 +637,11 @@ class Assets {
 
         wp_localize_script( 'dokan-i18n-jed', 'dokan', $localize_data );
 
+        // localized vendor-registration script
+        wp_localize_script( 'dokan-vendor-registration', 'dokanRegistrationI18n', [
+            'defaultRole' => dokan_get_seller_registration_default_role(),
+        ] );
+
         // load only in dokan dashboard and product edit page
         if ( ( dokan_is_seller_dashboard() || ( get_query_var( 'edit' ) && is_singular( 'product' ) ) ) || apply_filters( 'dokan_forced_load_scripts', false ) ) {
             $this->dokan_dashboard_scripts();

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -541,7 +541,7 @@ function dokan_get_chosen_taxonomy_attributes() {
 
 function dokan_seller_reg_form_fields() {
     $data       = dokan_get_seller_registration_form_data();
-    $role       = isset( $data['role'] ) ? $data['role'] : 'customer';
+    $role       = $data['role'];
     $role_style = ( $role === 'customer' ) ? 'display:none' : '';
 
     dokan_get_template_part(
@@ -683,6 +683,21 @@ function dokan_store_contact_widget() {
 }
 
 /**
+ * Get seller registration form default role
+ *
+ * @since DOKAN_SINCE
+ *
+ * @return string values can be 'customer' or 'seller'
+ */
+function dokan_get_seller_registration_default_role(): string {
+    $default_role = apply_filters( 'dokan_seller_registration_default_role', 'customer' );
+    if ( ! in_array( $default_role, [ 'customer', 'seller' ], true ) ) {
+        $default_role = 'customer';
+    }
+    return $default_role;
+}
+
+/**
  * Get Dokan seller registration form data
  *
  * @since 3.7.0
@@ -691,6 +706,7 @@ function dokan_store_contact_widget() {
  */
 function dokan_get_seller_registration_form_data() {
     $set_password = get_option( 'woocommerce_registration_generate_password', 'no' ) !== 'yes';
+    $default_role = dokan_get_seller_registration_default_role();
 
     // prepare form data
     $data = [
@@ -701,6 +717,7 @@ function dokan_get_seller_registration_form_data() {
         'phone'    => '',
         'shopname' => '',
         'shopurl'  => '',
+        'role'     => $default_role,
     ];
 
     if ( $set_password ) {
@@ -717,6 +734,7 @@ function dokan_get_seller_registration_form_data() {
             'password' => isset( $_POST['password'] ) ? wp_unslash( $_POST['password'] ) : '', // phpcs:ignore
             'shopname' => isset( $_POST['shopname'] ) ? sanitize_text_field( wp_unslash( $_POST['shopname'] ) ) : '',
             'shopurl'  => isset( $_POST['shopurl'] ) ? sanitize_title( wp_unslash( $_POST['shopurl'] ) ) : '',
+            'role'     => isset( $_POST['role'] ) && in_array( $_POST['role'], [ 'customer', 'seller' ], true ) ? sanitize_text_field( wp_unslash( $_POST['role'] ) ) : $default_role,
         ];
         if ( $set_password ) {
             $data['password'] = isset( $_POST['password'] ) ? wp_unslash( $_POST['password'] ) : ''; // phpcs:ignore;


### PR DESCRIPTION
### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes https://github.com/getdokan/dokan/issues/2203


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

```
- fix: under wooCommerce my-account registration section, `I am a customer` was forced to be set as the default value. With this PR this problem has been fixed.
- new: added a new filter to set a default value for I am a customer / I am a vendor radio button.
```

### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?
