### PR TITLE
Fix: empty spaces before the store url in the vendor registration form

### DIFF
--- a/templates/account/update-customer-to-vendor.php
+++ b/templates/account/update-customer-to-vendor.php
@@ -41,10 +41,7 @@ $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'stor
             <label for="seller-url" class="pull-left"><?php esc_html_e( 'Shop URL', 'dokan-lite' ); ?> <span class="required">*</span></label>
             <strong id="url-alart-mgs" class="pull-right"></strong>
             <input type="text" class="input-text form-control" name="shopurl" id="seller-url" value="<?php echo esc_attr( $shop_url ); ?>" required="required" />
-            <small>
-                <?php echo esc_url( $home_url . '/' . $custom_store_url ) . '/'; ?>
-                <strong id="url-alart"></strong>
-            </small>
+            <small><?php echo esc_url( $home_url . '/' . $custom_store_url ) . '/'; ?><strong id="url-alart"></strong></small>
         </p>
 
         <p class="form-row form-group form-row-wide">

--- a/templates/account/vendor-registration.php
+++ b/templates/account/vendor-registration.php
@@ -1,4 +1,13 @@
-<?php function_exists( 'wc_print_notices' ) ? wc_print_notices() : ''; ?>
+<?php
+
+if ( function_exists( 'wc_print_notices' ) ) {
+    wc_print_notices();
+}
+
+$home_url         = untrailingslashit( home_url() );
+$custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+
+?>
 
 <form id="dokan-vendor-register" method="post" class="register dokan-vendor-register">
 
@@ -57,7 +66,7 @@
         <label for="seller-url" class="pull-left"><?php esc_html_e( 'Shop URL', 'dokan-lite' ); ?> <span class="required">*</span></label>
         <strong id="url-alart-mgs" class="pull-right"></strong>
         <input type="text" class="input-text form-control" name="shopurl" id="seller-url" value="<?php echo ! empty( $data['shopurl'] ) ? esc_attr( $data['shopurl'] ) : ''; ?>" required="required" />
-        <small><?php echo esc_url( home_url() . '/' . dokan_get_option( 'custom_store_url', 'dokan_general', 'store' ) ); ?>/<strong id="url-alart"></strong></small>
+        <small><?php echo esc_url( $home_url . '/' . $custom_store_url ) . '/'; ?><strong id="url-alart"></strong></small>
     </p>
 
     <?php

--- a/templates/global/seller-registration-form.php
+++ b/templates/global/seller-registration-form.php
@@ -32,10 +32,7 @@ $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'stor
         <label for="seller-url" class="pull-left"><?php esc_html_e( 'Shop URL', 'dokan-lite' ); ?> <span class="required">*</span></label>
         <strong id="url-alart-mgs" class="pull-right"></strong>
         <input type="text" class="input-text form-control" name="shopurl" id="seller-url" value="<?php echo ! empty( $data['shopurl'] ) ? esc_attr( $data['shopurl'] ) : ''; ?>" required="required" />
-        <small>
-            <?php echo esc_url( $home_url . '/' . $custom_store_url ) . '/'; ?>
-            <strong id="url-alart"></strong>
-        </small>
+        <small><?php echo esc_url( $home_url . '/' . $custom_store_url ) . '/'; ?><strong id="url-alart"></strong></small>
     </p>
 
     <?php


### PR DESCRIPTION
### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

This PR fixes an issue where empty spaces appear before the store URL in the vendor registration form. The change involves trimming any leading or trailing whitespace from the store URL input before processing or saving it.

### Related Pull Request(s)

* https://github.com/getdokan/dokan/pull/2319

### Closes 

* Closes

### How to test the changes in this Pull Request:

1. Navigate to the vendor registration form.
2. In the store URL field, enter a valid URL with leading and/or trailing spaces.
3. Submit the form and verify that the spaces are removed from the final store URL.
4. Check the database to ensure the stored URL doesn't contain any leading or trailing spaces.
5. Test with various combinations of spaces (leading, trailing, and both) to ensure consistent behavior.

### Changelog entry

*Fix: Remove empty spaces before store URL in vendor registration form*

Previously, if a user entered spaces before or after the store URL in the vendor registration form, these spaces were retained, potentially causing issues with the store URL. This PR implements a fix to trim any leading or trailing whitespace from the store URL input, ensuring a clean and valid URL is always saved.

### Before Changes

When a user enters spaces before or after the store URL in the vendor registration form, these spaces are retained in the saved URL. This can lead to invalid URLs or unexpected behavior when accessing the store.

### After Changes

After implementing the fix, any spaces entered before or after the store URL in the vendor registration form are automatically removed. The saved URL is clean and valid, improving the user experience and preventing potential URL-related issues.

### Feature Video (optional)

N/A

### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.

### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it's supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved layout of the shop URL in the seller registration form for a more compact and visually appealing design.
	- Enhanced readability and maintainability in the vendor registration form with clearer variable management.
- **Bug Fixes**
	- Enhanced readability in the account update form by consolidating the URL display without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->