### PR TITLE
fix: Prevent incorrect sub-order status updates

### DIFF
--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -101,12 +101,17 @@ class Hooks {
             [ '%d' ]
         );
 
-        // if any child orders found, change the orders as well
+        // Update sub-order statuses
         $sub_orders = dokan()->order->get_child_orders( $order_id );
         if ( $sub_orders ) {
             foreach ( $sub_orders as $sub_order ) {
                 if ( is_callable( [ $sub_order, 'update_status' ] ) ) {
-                    $sub_order->update_status( $new_status );
+                    $current_status = $sub_order->get_status();
+                    if ( $this->is_status_change_allowed( $current_status, $new_status ) ) {
+                        $sub_order->update_status( $new_status );
+                    } else {
+                        $this->log_skipped_status_update( $sub_order->get_id(), $current_status, $new_status );
+                    }
                 }
             }
         }
@@ -133,6 +138,98 @@ class Hooks {
             [ '%s' ],
             [ '%d', '%s' ]
         );
+    }
+
+    /**
+     * Check if a status change is allowed for a sub-order.
+     *
+     * This method determines whether a sub-order can transition from its current status
+     * to a new status, based on a configurable whitelist of allowed transitions.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $current_status The current status of the sub-order (should include 'wc-' prefix).
+     * @param string $new_status     The new status to check (should include 'wc-' prefix).
+     *
+     * @return bool True if the status change is allowed, false otherwise.
+     */
+    private function is_status_change_allowed( string $current_status, string $new_status ): bool {
+        // Ensure both statuses have 'wc-' prefix
+        $current_status = $this->maybe_add_wc_prefix( $current_status );
+        $new_status     = $this->maybe_add_wc_prefix( $new_status );
+
+        // Define the default whitelist of allowed status transitions
+        $default_whitelist = [
+            'wc-pending'    => [ 'any' ],
+            'wc-on-hold'    => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-completed', 'wc-failed' ],
+            'wc-processing' => [ 'wc-completed', 'wc-failed', 'wc-cancelled', 'wc-refunded' ],
+            'wc-completed'  => [ 'wc-refunded' ],
+            'wc-failed'     => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-failed', 'wc-cancelled', 'wc-refunded' ],
+            'wc-cancelled'  => [],
+            'wc-refunded'   => [],
+        ];
+
+        /**
+         * Filter the whitelist of allowed status transitions for sub-orders.
+         *
+         * This filter allows developers to customize the whitelist that determines
+         * which status transitions are allowed for sub-orders when the main order
+         * status is updated. By modifying this whitelist, you can control how
+         * sub-order statuses are updated in relation to the main order.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array $whitelist An associative array where keys are current statuses
+         *                         and values are arrays of allowed new statuses.
+         *                         The special value 'any' allows transition to any status.
+         *
+         * @return array Modified whitelist of allowed status transitions.
+         */
+        $whitelist = apply_filters( 'dokan_sub_order_status_update_whitelist', $default_whitelist );
+
+        // If the current status is not in the whitelist, status change is not allowed
+        if ( ! isset( $whitelist[ $current_status ] ) ) {
+            return false;
+        }
+
+        // If 'any' is allowed for the current status, all transitions are allowed
+        if ( in_array( 'any', $whitelist[ $current_status ], true ) ) {
+            return true;
+        }
+
+        // Check if the new status is in the list of allowed transitions
+        return in_array( $new_status, $whitelist[ $current_status ], true );
+    }
+
+    /**
+     * Ensure a status string has the 'wc-' prefix.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $status The status string to check.
+     *
+     * @return string The status string with 'wc-' prefix added if it was missing.
+     */
+    private function maybe_add_wc_prefix( string $status ): string {
+        return strpos( $status, 'wc-' ) === 0 ? $status : 'wc-' . $status;
+    }
+
+    /**
+     * Log a skipped status update for a sub-order.
+     *
+     * This method logs a message to the error log when a status update for a sub-order
+     * is skipped because the status change is not allowed.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int    $order_id      The ID of the sub-order.
+     * @param string $current_status The current status of the sub-order.
+     * @param string $new_status     The new status that was not allowed.
+     *
+     * @return void
+     */
+    private function log_skipped_status_update( int $order_id, string $current_status, string $new_status ) {
+        dokan_log( sprintf( 'Dokan: Skipped status update for sub-order %d from %s to %s', $order_id, $current_status, $new_status ) );
     }
 
     /**

--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -164,7 +164,7 @@ class Hooks {
             'wc-on-hold'    => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-completed', 'wc-failed' ],
             'wc-processing' => [ 'wc-completed', 'wc-failed', 'wc-cancelled', 'wc-refunded' ],
             'wc-completed'  => [ 'wc-refunded' ],
-            'wc-failed'     => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-failed', 'wc-cancelled', 'wc-refunded' ],
+            'wc-failed'     => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-failed', 'wc-cancelled' ],
             'wc-cancelled'  => [],
             'wc-refunded'   => [],
         ];


### PR DESCRIPTION
### All Submissions:
* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:
This PR addresses an issue where sub-order statuses were being incorrectly updated when the main order status changed. Specifically, it prevents cancelled sub-orders from being marked as completed when the main order is completed.

Key changes:
1. Implemented a new `is_status_change_allowed` method to validate status transitions.
2. Added a `dokan_sub_order_status_update_whitelist` filter for customizable status transition rules.
3. Updated the `on_order_status_change` method to respect sub-order status constraints.
4. Added unit tests and documentation for the new validation logic.

### Related Pull Request(s)
* N/A

### Closes 
* Closes #2341

### How to test the changes in this Pull Request:
1. Create a main order with multiple sub-orders from different vendors.
2. Cancel one of the sub-orders from the vendor dashboard.
3. From the admin dashboard, mark the main order as completed.
4. Verify that the previously cancelled sub-order remains cancelled and is not marked as completed.
5. Test various other status transitions to ensure they behave as expected according to the whitelist.

### Changelog entry
*Fix: Prevent incorrect sub-order status updates*

Previously, when a main order was marked as completed, all sub-orders would be automatically marked as completed, regardless of their current status. This could lead to cancelled sub-orders being incorrectly marked as completed. This PR implements a flexible system to validate status transitions, ensuring that sub-order statuses are updated correctly based on their current status and a configurable set of rules.

### Before Changes
When a main order was marked as completed, all sub-orders, including cancelled ones, would be marked as completed.

![Screenshot 2024-08-28 at 3 55 01 PM](https://github.com/user-attachments/assets/3677f3e2-0171-4663-b208-66529d854ce4)
![Screenshot 2024-08-28 at 3 55 55 PM](https://github.com/user-attachments/assets/d2258fb2-f943-49ec-90f8-fa35b5eaa2bc)

### After Changes
When a main order is marked as completed, sub-orders are only updated if the transition is allowed according to the defined rules. Cancelled sub-orders remain cancelled.

![Screenshot 2024-08-28 at 3 49 43 PM](https://github.com/user-attachments/assets/d55da620-1948-4af5-8245-8a602eb94a22)

### Feature Video (optional)
N/A

### PR Self Review Checklist:
- [x] Code follows style guidelines
- [x] Naming is clear and self-explanatory
- [x] Code is as simple as possible while fulfilling requirements
- [x] No code duplication
- [x] Code is readable and well-structured
- [x] Performance considerations have been taken into account
- [x] Complex constructions are refactored or commented
- [x] No grammar errors in comments and documentation

### FOR PR REVIEWER ONLY:
> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.
> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.
* [ ] Correct — Does the change do what it's supposed to?
* [ ] Secure — Would a nefarious party find some way to exploit this change?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced order status management by introducing conditional checks for sub-order status updates, ensuring only valid transitions are executed.
	- Added logging for skipped status updates to improve tracking and transparency.

- **Improvements**
	- Increased robustness of the order management system by enforcing rules around status transitions for sub-orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->