### PR TITLE
Implement order trash and untrash handling for Dokan

### DIFF
--- a/includes/Order/Controller.php
+++ b/includes/Order/Controller.php
@@ -37,11 +37,11 @@ class Controller {
         $this->container['email_hooks']    = new EmailHooks();
         $this->container['cache']          = new OrderCache();
         $this->container['frontend_hooks'] = new Frontend\Hooks();
+        $this->container['event_listener'] = new OrderEventListener();
 
         if ( is_admin() ) {
-            $this->container['permission']     = new Admin\Permissions();
-            $this->container['admin_hooks']    = new Admin\Hooks();
-            $this->container['event_listener'] = new OrderEventListener();
+            $this->container['permission']  = new Admin\Permissions();
+            $this->container['admin_hooks'] = new Admin\Hooks();
         }
 
         if ( wp_doing_ajax() ) {

--- a/includes/Order/Controller.php
+++ b/includes/Order/Controller.php
@@ -39,8 +39,9 @@ class Controller {
         $this->container['frontend_hooks'] = new Frontend\Hooks();
 
         if ( is_admin() ) {
-            $this->container['permission']  = new Admin\Permissions();
-            $this->container['admin_hooks'] = new Admin\Hooks();
+            $this->container['permission']     = new Admin\Permissions();
+            $this->container['admin_hooks']    = new Admin\Hooks();
+            $this->container['event_listener'] = new OrderEventListener();
         }
 
         if ( wp_doing_ajax() ) {

--- a/includes/Order/OrderEventListener.php
+++ b/includes/Order/OrderEventListener.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace WeDevs\Dokan\Order;
+
+use WC_Order;
+
+class OrderEventListener {
+
+    public function __construct() {
+        add_action( 'woocommerce_trash_order', array( $this, 'after_order_trash' ), 10, 1 );
+        add_action( 'woocommerce_untrash_order', array( $this, 'after_order_untrash' ), 10, 1 );
+    }
+
+    /**
+     * Perform actions after an order is trashed
+     *
+     * @param int $order_id ID of the trashed order
+     */
+    public function after_order_trash( int $order_id ) {
+        global $wpdb;
+
+        $order = wc_get_order( $order_id );
+        if ( ! $order instanceof WC_Order ) {
+            return;
+        }
+
+        // Update Dokan tables
+        $wpdb->update(
+            $wpdb->prefix . 'dokan_orders',
+            array( 'order_status' => 'wc-trashed' ),
+            array( 'order_id' => $order_id ),
+            array( '%s' ),
+            array( '%d' )
+        );
+
+        $wpdb->update(
+            $wpdb->prefix . 'dokan_vendor_balance',
+            array( 'status' => 'wc-trashed' ),
+            array(
+				'trn_id' => $order_id,
+				'trn_type' => 'dokan_orders',
+            ),
+            array( '%s' ),
+            array( '%d', '%s' )
+        );
+
+        dokan_log( "Order {$order_id} has been trashed in Dokan order and vendor balance tables." );
+    }
+
+    /**
+     * Perform actions after an order is untrashed (restored)
+     *
+     * @param int $order_id ID of the restored order
+     */
+    public function after_order_untrash( int $order_id ) {
+        global $wpdb;
+
+        $order = wc_get_order( $order_id );
+        if ( ! $order instanceof WC_Order ) {
+            dokan_log( "Failed to fetch order {$order_id} after untrash." );
+            return;
+        }
+
+        $previous_status = $order->get_meta( '_wp_trash_meta_status' );
+        if ( empty( $previous_status ) ) {
+            $previous_status = 'wc-pending';
+        }
+
+        if ( strpos( $previous_status, 'wc-' ) === false ) {
+            $previous_status = 'wc-' . $previous_status;
+        }
+
+        // Update Dokan tables
+        $wpdb->update(
+            $wpdb->prefix . 'dokan_orders',
+            array( 'order_status' => $previous_status ),
+            array( 'order_id' => $order_id ),
+            array( '%s' ),
+            array( '%d' )
+        );
+
+        $wpdb->update(
+            $wpdb->prefix . 'dokan_vendor_balance',
+            array( 'status' => $previous_status ),
+            array(
+				'trn_id' => $order_id,
+				'trn_type' => 'dokan_orders',
+            ),
+            array( '%s' ),
+            array( '%d', '%s' )
+        );
+
+        dokan_log( "Order {$order_id} has been restored in Dokan order and vendor balance tables with status: {$previous_status}" );
+    }
+}

--- a/includes/Order/OrderEventListener.php
+++ b/includes/Order/OrderEventListener.php
@@ -25,10 +25,15 @@ class OrderEventListener {
             return;
         }
 
+        $status = $order->get_status( 'edit' );
+        if ( strpos( $status, 'wc-' ) === false ) {
+            $status = 'wc-' . $status;
+        }
+
         // Update Dokan tables
         $wpdb->update(
             $wpdb->prefix . 'dokan_orders',
-            array( 'order_status' => 'wc-trashed' ),
+            array( 'order_status' => $status ),
             array( 'order_id' => $order_id ),
             array( '%s' ),
             array( '%d' )
@@ -36,7 +41,7 @@ class OrderEventListener {
 
         $wpdb->update(
             $wpdb->prefix . 'dokan_vendor_balance',
-            array( 'status' => 'wc-trashed' ),
+            array( 'status' => $status ),
             array(
 				'trn_id' => $order_id,
 				'trn_type' => 'dokan_orders',
@@ -62,11 +67,7 @@ class OrderEventListener {
             return;
         }
 
-        $previous_status = $order->get_meta( '_wp_trash_meta_status' );
-        if ( empty( $previous_status ) ) {
-            $previous_status = 'wc-pending';
-        }
-
+        $previous_status = $order->get_status( 'edit' );
         if ( strpos( $previous_status, 'wc-' ) === false ) {
             $previous_status = 'wc-' . $previous_status;
         }

--- a/includes/Order/OrderEventListener.php
+++ b/includes/Order/OrderEventListener.php
@@ -21,6 +21,7 @@ class OrderEventListener {
 
         $order = wc_get_order( $order_id );
         if ( ! $order instanceof WC_Order ) {
+            dokan_log( "Failed to fetch order {$order_id} during trash operation." );
             return;
         }
 

--- a/tests/php/src/Order/OrderEventListenerTest.php
+++ b/tests/php/src/Order/OrderEventListenerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Order;
+
+use WeDevs\Dokan\Order\OrderEventListener;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group order-event-listener
+ *
+ * @note by default the withdrawal option is enable for completed order.
+ */
+class OrderEventListenerTest extends DokanTestCase {
+
+    private $order_event_listener;
+    private $seller_id;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->order_event_listener = new OrderEventListener();
+        $this->seller_id = $this->factory()->seller->create();
+    }
+
+    public function test_processing_order_with_trash_event() {
+        $order_id = $this->create_order( 'processing' );
+        $vendor_id = dokan_get_seller_id_by_order( $order_id );
+        $initial_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+
+        $processing_order = wc_get_order( $order_id );
+        $processing_order->delete();
+
+        $this->order_event_listener->after_order_trash( $order_id );
+
+        $trash_order = wc_get_order( $order_id );
+        $this->assertEquals( 'trash', $trash_order->get_status() );
+
+        $current_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+        $this->assertEquals( $initial_balance, $current_balance );
+    }
+
+    public function test_completed_order_with_trash_event() {
+        $order_id = $this->create_order( 'completed' );
+        $vendor_id = dokan_get_seller_id_by_order( $order_id );
+        $initial_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+
+        $completed_order = wc_get_order( $order_id );
+        $completed_order->delete();
+
+        $this->order_event_listener->after_order_trash( $order_id );
+
+        $trash_order = wc_get_order( $order_id );
+        $this->assertEquals( 'trash', $trash_order->get_status() );
+
+        $current_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+        $this->assertEquals( 0, $current_balance );
+        $this->assertLessThan( $initial_balance, $current_balance );
+    }
+
+    public function test_processing_order_with_untrash_event() {
+        $order_id = $this->create_order( 'processing' );
+        $vendor_id = dokan_get_seller_id_by_order( $order_id );
+        $initial_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+
+        $processing_order = wc_get_order( $order_id );
+        $processing_order->delete();
+
+        $this->order_event_listener->after_order_trash( $order_id );
+
+        $trash_order = wc_get_order( $order_id );
+        $trash_order->set_status( 'processing' );
+        $trash_order->save();
+
+        $this->order_event_listener->after_order_untrash( $order_id );
+
+        $untrash_order = wc_get_order( $order_id );
+        $this->assertEquals( 'processing', $untrash_order->get_status() );
+
+        $current_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+        $this->assertEquals( $initial_balance, $current_balance );
+    }
+
+    public function test_completed_order_with_untrash_event() {
+        $order_id = $this->create_order( 'completed' );
+        $vendor_id = dokan_get_seller_id_by_order( $order_id );
+        $initial_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+
+        $completed_order = wc_get_order( $order_id );
+        $completed_order->delete();
+
+        $this->order_event_listener->after_order_trash( $order_id );
+
+        $trash_order = wc_get_order( $order_id );
+        $trash_order->set_status( 'completed' );
+        $trash_order->save();
+
+        $this->order_event_listener->after_order_untrash( $order_id );
+
+        $untrash_order = wc_get_order( $order_id );
+        $this->assertEquals( 'completed', $untrash_order->get_status() );
+
+        $current_balance = dokan()->vendor->get( $vendor_id )->get_earnings( false );
+        $this->assertEquals( $initial_balance, $current_balance );
+    }
+
+    private function create_order( $status ) {
+        $order_id = $this->factory()->order->set_seller_id( $this->seller_id )->create();
+        $order = wc_get_order( $order_id );
+        $order->set_status( $status );
+        $order->save();
+
+        return $order_id;
+    }
+}

--- a/tests/php/src/Order/OrderEventListenerTest.php
+++ b/tests/php/src/Order/OrderEventListenerTest.php
@@ -29,8 +29,6 @@ class OrderEventListenerTest extends DokanTestCase {
         $processing_order = wc_get_order( $order_id );
         $processing_order->delete();
 
-        $this->order_event_listener->after_order_trash( $order_id );
-
         $trash_order = wc_get_order( $order_id );
         $this->assertEquals( 'trash', $trash_order->get_status() );
 
@@ -45,8 +43,6 @@ class OrderEventListenerTest extends DokanTestCase {
 
         $completed_order = wc_get_order( $order_id );
         $completed_order->delete();
-
-        $this->order_event_listener->after_order_trash( $order_id );
 
         $trash_order = wc_get_order( $order_id );
         $this->assertEquals( 'trash', $trash_order->get_status() );
@@ -64,13 +60,9 @@ class OrderEventListenerTest extends DokanTestCase {
         $processing_order = wc_get_order( $order_id );
         $processing_order->delete();
 
-        $this->order_event_listener->after_order_trash( $order_id );
-
         $trash_order = wc_get_order( $order_id );
         $trash_order->set_status( 'processing' );
         $trash_order->save();
-
-        $this->order_event_listener->after_order_untrash( $order_id );
 
         $untrash_order = wc_get_order( $order_id );
         $this->assertEquals( 'processing', $untrash_order->get_status() );
@@ -87,13 +79,9 @@ class OrderEventListenerTest extends DokanTestCase {
         $completed_order = wc_get_order( $order_id );
         $completed_order->delete();
 
-        $this->order_event_listener->after_order_trash( $order_id );
-
         $trash_order = wc_get_order( $order_id );
         $trash_order->set_status( 'completed' );
         $trash_order->save();
-
-        $this->order_event_listener->after_order_untrash( $order_id );
 
         $untrash_order = wc_get_order( $order_id );
         $this->assertEquals( 'completed', $untrash_order->get_status() );


### PR DESCRIPTION
### All Submissions:
* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:
This PR updates the OrderEventListener class to properly handle order trashing and untrashing in accordance with WooCommerce's HPOS feature. It ensures that when an order is trashed or untrashed, the status is correctly updated in both WooCommerce and Dokan-specific tables, maintaining consistency across the systems.

### Related Pull Request(s)
* N/A

### Closes 
* Closes https://github.com/getdokan/client-issue/issues/157

### How to test the changes in this Pull Request:
1. Enable HPOS in WooCommerce settings.
2. Create a test order.
3. Trash the order and verify that the status is updated correctly in both WooCommerce and Dokan tables.
4. Untrash the order and verify that the status is restored correctly in both WooCommerce and Dokan tables.
5. Check the error logs to ensure proper logging of trash/untrash actions.

### Changelog entry
*Implement order trash and untrash handling for Dokan*

This PR updates the OrderEventListener to properly handle order trashing and untrashing. It ensures that order statuses are correctly synchronized between WooCommerce and Dokan-specific tables, implements WooCommerce's trash metadata handling, and adds error logging for improved debugging.

### Before Changes
Previously, the OrderEventListener did not properly handle order trashing and untrashing when HPOS was enabled, potentially leading to inconsistencies between WooCommerce and Dokan order statuses.

### After Changes
With these changes, order trashing and untrashing are properly handled, ensuring consistency between WooCommerce and Dokan order statuses. The implementation follows WooCommerce's approach for trash metadata handling and includes error logging for better debugging.

### Feature Video (optional)
N/A

### PR Self Review Checklist:
* [x] Code follows style guidelines
* [x] Naming is clear and self-explanatory
* [x] Code is as simple as possible while meeting requirements
* [x] No unnecessary code repetition
* [x] Code is readable and well-structured
* [x] Performance considerations have been taken into account
* [x] Complex constructions are explained with comments
* [x] No grammar errors in comments and logs

### FOR PR REVIEWER ONLY:
* [ ] Correct — Does the change do what it's supposed to?
* [ ] Secure — Are all inputs properly sanitized and escaped?
* [ ] Readable — Is the code easy to understand?
* [ ] Elegant — Does the change fit within the overall style and architecture?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an event listener for managing WooCommerce order actions, specifically for when orders are trashed or restored.
	- Enhanced admin functionality by integrating the new event listener into the existing order management system.

- **Bug Fixes**
	- Improved order status handling in the database to ensure accurate updates when orders are trashed or untrashed.

- **Tests**
	- Added a comprehensive suite of unit tests for the new event listener to validate order trashing and restoring functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->