### PR TITLE
feat: Update order status allowed list with WooCommerce custom statuses

### DIFF
--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -155,37 +155,8 @@ class Hooks {
         $current_status = $this->maybe_add_wc_prefix( $current_status );
         $new_status     = $this->maybe_add_wc_prefix( $new_status );
 
-        // Get the current allowlist of status transitions
-        $allowlist = $this->get_order_status_allowlist();
-
-        // If 'any' is allowed for the current status, all transitions are allowed
-        if ( in_array( 'any', $allowlist[ $current_status ], true ) ) {
-            return true;
-        }
-
-        // Check if the new status is in the list of allowed transitions
-        return in_array( $new_status, $allowlist[ $current_status ], true );
-    }
-
-    /**
-     * Get the list of allowed order status transitions.
-     *
-     * This method returns an array of allowed order status transitions.
-     * It combines default transitions with custom WooCommerce order statuses
-     * and allows for extensibility through filters.
-     *
-     * @since 3.12.2
-     *
-     * @return array An associative array where keys are current statuses
-     *               and values are arrays of allowed new statuses.
-     */
-    private function get_order_status_allowlist(): array {
-        // Define the default transition rules
-        $default_transitions = [
-            // Allow checkout-draft to transition to any status
-            'checkout-draft' => [ 'any' ],
-
-            // Basic order flow
+        // Define the default whitelist of allowed status transitions
+        $default_whitelist = [
             'wc-pending'    => [ 'any' ],
             'wc-on-hold'    => [ 'wc-pending', 'wc-on-hold', 'wc-processing', 'wc-completed', 'wc-failed' ],
             'wc-processing' => [ 'wc-completed', 'wc-failed', 'wc-cancelled', 'wc-refunded' ],
@@ -195,36 +166,36 @@ class Hooks {
             'wc-refunded'   => [],
         ];
 
-        // Get all registered WooCommerce order statuses
-        $wc_statuses = wc_get_order_statuses();
-
-        // Create allowlist from WooCommerce statuses
-        $allowlist = [];
-        foreach ( $wc_statuses as $status_key => $status_label ) {
-            if ( ! isset( $default_transitions[ $status_key ] ) ) {
-                // For custom statuses, allow transitions to default processing statuses
-                $allowlist[ $status_key ] = [ 'any' ];
-            } else {
-                // Use default transitions for standard statuses
-                $allowlist[ $status_key ] = $default_transitions[ $status_key ];
-            }
-        }
-
         /**
-         * Filter the allowlist of permitted order status transitions.
+         * Filter the whitelist of allowed status transitions for sub-orders.
          *
-         * Allows customization of which status transitions are permitted for sub-orders
-         * when the main order status is updated.
+         * This filter allows developers to customize the whitelist that determines
+         * which status transitions are allowed for sub-orders when the main order
+         * status is updated. By modifying this whitelist, you can control how
+         * sub-order statuses are updated in relation to the main order.
          *
          * @since 3.12.2
          *
-         * @param array $allowlist An associative array where keys are current statuses
-         *                        and values are arrays of allowed new statuses.
-         *                        Use 'any' to allow transition to any status.
+         * @param array $whitelist An associative array where keys are current statuses
+         *                         and values are arrays of allowed new statuses.
+         *                         The special value 'any' allows transition to any status.
          *
-         * @return array Modified allowlist of allowed status transitions.
+         * @return array Modified whitelist of allowed status transitions.
          */
-        return apply_filters( 'dokan_sub_order_status_update_allowlist', $allowlist );
+        $whitelist = apply_filters( 'dokan_sub_order_status_update_whitelist', $default_whitelist );
+
+        // Allow any status change if the current status is not in the whitelist or the new status is not allowed
+        if ( ! array_key_exists( $current_status, $whitelist ) || ! array_key_exists( $new_status, $whitelist ) ) {
+            return true;
+        }
+
+        // If 'any' is allowed for the current status, all transitions are allowed
+        if ( in_array( 'any', $whitelist[ $current_status ], true ) ) {
+            return true;
+        }
+
+        // Check if the new status is in the list of allowed transitions
+        return in_array( $new_status, $whitelist[ $current_status ], true );
     }
 
     /**

--- a/tests/php/src/Orders/OrderStatusChangeTest.php
+++ b/tests/php/src/Orders/OrderStatusChangeTest.php
@@ -149,51 +149,10 @@ class OrderStatusChangeTest extends DokanTestCase {
      * Create test order with initial status
      */
     private function create_order( string $status ) {
-        $order_id = $this->create_multi_vendor_order(
-            [
-				'item_fee_list' => [
-					[
-						'name' => 'Extra Charge',
-						'amount' => 10,
-					],
-				],
-				'shipping_item_list' => [
-					[
-						'name' => 'Shipping Fee 1',
-						'amount' => 15,
-						'seller_id' => $this->seller_id1,
-					],
-					[
-						'name' => 'Shipping Fee 2',
-						'amount' => 5,
-						'seller_id' => $this->seller_id2,
-					],
-				],
-				'status'      => $status,
-				'customer_id' => $this->customer_id,
-				'line_items'  => array(
-					array(
-						'product' => [
-							'name' => 'Test Product 1',
-							'regular_price' => 5,
-							'price' => 5,
-							'seller_id' => $this->seller_id1,
-						],
-						'quantity'   => 3,
-					),
-					array(
-						'product' => [
-							'name' => 'Test Product 2',
-							'regular_price' => 10,
-							'price' => 10,
-							'seller_id' => $this->seller_id2,
-						],
-						'quantity'   => 2,
-					),
-				),
+        $params = $this->get_multi_vendor_order_data();
+        $params['status'] = $status;
 
-			]
-        );
+        $order_id = $this->create_multi_vendor_order( $params );
 
         return wc_get_order( $order_id );
     }

--- a/tests/php/src/Orders/OrderStatusChangeTest.php
+++ b/tests/php/src/Orders/OrderStatusChangeTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Orders;
+
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group order-status
+ */
+class OrderStatusChangeTest extends DokanTestCase {
+    protected $is_unit_test = true;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->setup_users();
+    }
+
+    /**
+     * Test standard status transitions that should be allowed
+     *
+     * @dataProvider allowed_status_transitions
+     *
+     * @param string $from The initial status
+     * @param string $to The status to transition to
+     */
+    public function test_allowed_status_transitions( string $from, string $to ) {
+        $this->verify_status_transition( $from, $to, true );
+    }
+
+    /**
+     * Test status transitions that should be blocked
+     *
+     * @dataProvider not_allowed_status_transitions
+     *
+     * @param string $from The initial status
+     * @param string $to The status to transition to
+     */
+    public function test_blocked_status_transitions( string $from, string $to ) {
+        $this->verify_status_transition( $from, $to, false );
+    }
+
+    /**
+     * Test custom status transitions
+     *
+     * @dataProvider custom_status_transitions
+     *
+     * @param string $from The initial status
+     * @param string $to The status to transition to
+     */
+    public function test_custom_status_transitions( string $from, string $to ) {
+        $this->verify_status_transition( $from, $to, true );
+    }
+
+    /**
+     * Test that sub-orders follow parent order status changes when allowed
+     */
+    public function test_sub_orders_status_sync() {
+        $order = $this->create_order( 'pending' );
+
+        $order->update_status( 'processing' );
+
+        // Verify parent order status
+        $this->assertEquals( 'processing', $order->get_status() );
+
+        // Refresh sub-orders
+        $sub_orders = dokan()->order->get_child_orders( $order->get_id() );
+
+        // Verify all sub-orders followed the status change
+        foreach ( $sub_orders as $sub_order ) {
+            $this->assertEquals( 'processing', $sub_order->get_status() );
+        }
+    }
+
+    /**
+     * Test the 'any' status transition rule for pending orders
+     *
+     * @dataProvider pending_to_any_status
+     *
+     * @param string $from The initial status
+     * @param string $to The status to transition to
+     */
+    public function test_pending_to_any_status( string $from, string $to ) {
+        $this->verify_status_transition( $from, $to, true );
+    }
+
+    /**
+     * Test status transitions with custom whitelist filter
+     */
+    public function test_custom_whitelist_filter() {
+        add_filter(
+            'dokan_sub_order_status_update_whitelist', function ( $whitelist ) {
+				$whitelist['wc-completed'][] = 'wc-processing';
+				return $whitelist;
+			}
+        );
+
+        // This should now be allowed due to our custom filter
+        $this->verify_status_transition( 'completed', 'processing', true );
+
+        // Cleanup
+        remove_all_filters( 'dokan_sub_order_status_update_whitelist' );
+    }
+
+    /**
+     * Helper method to verify status transitions
+     */
+    private function verify_status_transition( $from_status, $to_status, $should_change ) {
+        $order = $this->create_order( $from_status );
+        $sub_orders = dokan()->order->get_child_orders( $order->get_id() );
+
+        // Verify initial status
+        $this->assertEquals( $from_status, $order->get_status() );
+        foreach ( $sub_orders as $sub_order ) {
+            $this->assertEquals( $from_status, $sub_order->get_status() );
+        }
+
+        // Attempt status change
+        $order->update_status( $to_status );
+
+        // Verify parent order status
+        $this->assertEquals( $to_status, $order->get_status() );
+
+        // Refresh sub-orders
+        $sub_orders = dokan()->order->get_child_orders( $order->get_id() );
+
+        // If should change is true, verify new status, otherwise verify old status maintained
+        $expected_status = $should_change ? $to_status : $from_status;
+
+        foreach ( $sub_orders as $sub_order ) {
+            $this->assertEquals( $expected_status, $sub_order->get_status() );
+        }
+    }
+
+    /**
+     * Create test order with initial status
+     */
+    private function create_order( string $status ) {
+        $order_id = $this->create_multi_vendor_order(
+            [
+				'item_fee_list' => [
+					[
+						'name' => 'Extra Charge',
+						'amount' => 10,
+					],
+				],
+				'shipping_item_list' => [
+					[
+						'name' => 'Shipping Fee 1',
+						'amount' => 15,
+						'seller_id' => $this->seller_id1,
+					],
+					[
+						'name' => 'Shipping Fee 2',
+						'amount' => 5,
+						'seller_id' => $this->seller_id2,
+					],
+				],
+				'status'      => $status,
+				'customer_id' => $this->customer_id,
+				'line_items'  => array(
+					array(
+						'product' => [
+							'name' => 'Test Product 1',
+							'regular_price' => 5,
+							'price' => 5,
+							'seller_id' => $this->seller_id1,
+						],
+						'quantity'   => 3,
+					),
+					array(
+						'product' => [
+							'name' => 'Test Product 2',
+							'regular_price' => 10,
+							'price' => 10,
+							'seller_id' => $this->seller_id2,
+						],
+						'quantity'   => 2,
+					),
+				),
+
+			]
+        );
+
+        return wc_get_order( $order_id );
+    }
+
+    /**
+     * Data provider for allowed status transitions
+     */
+    public function allowed_status_transitions(): array {
+        return [
+            [ 'pending', 'processing' ],
+            [ 'pending', 'on-hold' ],
+            [ 'on-hold', 'processing' ],
+            [ 'processing', 'completed' ],
+            [ 'processing', 'cancelled' ],
+            [ 'completed', 'refunded' ],
+        ];
+    }
+
+    /**
+     * Data provider for blocked status transitions
+     */
+    public function not_allowed_status_transitions(): array {
+        return [
+            [ 'completed', 'processing' ],
+            [ 'refunded', 'completed' ],
+            [ 'cancelled', 'processing' ],
+        ];
+    }
+
+    /**
+     * Data provider for pending to any status transitions
+     */
+    public function pending_to_any_status(): array {
+        return [
+            [ 'pending', 'processing' ],
+            [ 'pending', 'on-hold' ],
+            [ 'pending', 'completed' ],
+            [ 'pending', 'cancelled' ],
+            [ 'pending', 'refunded' ],
+            [ 'pending', 'checkout-draft' ],
+        ];
+    }
+
+    /**
+     * Data provider for custom status transitions
+     */
+    public function custom_status_transitions(): array {
+        return [
+            [ 'pending', 'checkout-draft' ],
+            [ 'checkout-draft', 'processing' ],
+        ];
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        remove_all_filters( 'dokan_sub_order_status_update_whitelist' );
+    }
+}

--- a/tests/php/src/Orders/OrderStatusChangeTest.php
+++ b/tests/php/src/Orders/OrderStatusChangeTest.php
@@ -8,12 +8,6 @@ use WeDevs\Dokan\Test\DokanTestCase;
  * @group order-status
  */
 class OrderStatusChangeTest extends DokanTestCase {
-    protected $is_unit_test = true;
-
-    public function setUp(): void {
-        parent::setUp();
-        $this->setup_users();
-    }
 
     /**
      * Test standard status transitions that should be allowed
@@ -48,6 +42,15 @@ class OrderStatusChangeTest extends DokanTestCase {
      * @param string $to The status to transition to
      */
     public function test_custom_status_transitions( string $from, string $to ) {
+        add_filter(
+            'wc_order_statuses', function ( $statuses ) {
+				$statuses['wc-checkout-draft'] = _x( 'Checkout Draft', 'Order status', 'dokan-lite' );
+				$statuses['wc-delivered'] = _x( 'Delivered', 'Order status', 'dokan-lite' );
+
+				return $statuses;
+			}
+        );
+
         $this->verify_status_transition( $from, $to, true );
     }
 
@@ -80,6 +83,13 @@ class OrderStatusChangeTest extends DokanTestCase {
      * @param string $to The status to transition to
      */
     public function test_pending_to_any_status( string $from, string $to ) {
+        add_filter(
+            'wc_order_statuses', function ( $statuses ) {
+            $statuses['wc-checkout-draft'] = _x( 'Checkout Draft', 'Order status', 'dokan-lite' );
+
+            return $statuses;
+        }
+        );
         $this->verify_status_transition( $from, $to, true );
     }
 
@@ -230,11 +240,13 @@ class OrderStatusChangeTest extends DokanTestCase {
         return [
             [ 'pending', 'checkout-draft' ],
             [ 'checkout-draft', 'processing' ],
+            [ 'checkout-draft', 'delivered' ],
         ];
     }
 
     public function tearDown(): void {
         parent::tearDown();
         remove_all_filters( 'dokan_sub_order_status_update_whitelist' );
+        remove_all_filters( 'wc_order_statuses' );
     }
 }

--- a/tests/php/src/Orders/OrderStatusChangeTest.php
+++ b/tests/php/src/Orders/OrderStatusChangeTest.php
@@ -36,6 +36,8 @@ class OrderStatusChangeTest extends DokanTestCase {
     /**
      * Test custom status transitions
      *
+     * @see \Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders
+     *
      * @dataProvider custom_status_transitions
      *
      * @param string $from The initial status
@@ -77,6 +79,8 @@ class OrderStatusChangeTest extends DokanTestCase {
     /**
      * Test the 'any' status transition rule for pending orders
      *
+     * @see \Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders
+     *
      * @dataProvider pending_to_any_status
      *
      * @param string $from The initial status
@@ -85,10 +89,10 @@ class OrderStatusChangeTest extends DokanTestCase {
     public function test_pending_to_any_status( string $from, string $to ) {
         add_filter(
             'wc_order_statuses', function ( $statuses ) {
-            $statuses['wc-checkout-draft'] = _x( 'Checkout Draft', 'Order status', 'dokan-lite' );
+				$statuses['wc-checkout-draft'] = _x( 'Checkout Draft', 'Order status', 'dokan-lite' );
 
-            return $statuses;
-        }
+				return $statuses;
+			}
         );
         $this->verify_status_transition( $from, $to, true );
     }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

This PR updates the order status transition system to include custom WooCommerce order statuses. The main changes include:

1. Refactored the status transition logic to use a dedicated method `get_order_status_allowlist()`
2. Added support for all registered WooCommerce order statuses
3. Improved code organization and documentation
4. Changed terminology from "whitelist" to "allowlist" for inclusive language
5. Added better handling of custom order statuses with default transition to 'any'

### Related Pull Request(s)

* N/A

### Closes 

* No specific issue referenced

### How to test the changes in this Pull Request:

1. Create a custom order status in WooCommerce
2. Create a main order and verify it creates sub-orders
3. Change the main order status to your custom status
4. Verify that sub-orders can transition to the custom status
5. Test transitions between different statuses to ensure they follow the defined rules

### Changelog entry

*feat: Update order status allowed list with WooCommerce custom statuses*

Previous behavior required manual addition of new order statuses to the transition allowlist. The new implementation automatically includes all WooCommerce order statuses and provides more flexible transition rules, with custom statuses defaulting to allow any transition state.

### Before Changes

- Order status transitions were limited to predefined statuses
- Custom WooCommerce order statuses required manual addition to the transition list
- Less flexible handling of status transitions

### After Changes

- Automatic inclusion of all WooCommerce order statuses
- More flexible transition rules for custom statuses
- Improved code organization and documentation
- Better maintainability with separated status allowlist logic

### Feature Video

N/A

### PR Self Review Checklist:

- [x] Code follows WordPress coding standards
- [x] Clear naming conventions used throughout
- [x] Logic is simple and straightforward (KISS principle)
- [x] No code duplication (DRY principle)
- [x] Code is readable and well-structured
- [x] Performance considerations taken into account
- [x] Code is self-explanatory with proper documentation
- [x] No grammar errors in comments and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced order status transition handling, allowing more flexible transitions based on current and new statuses.
	- Introduced a comprehensive test suite to validate order status transitions and ensure synchronization between parent and sub-orders.

- **Bug Fixes**
	- Improved functionality of status transition logic.

- **Documentation**
	- Updated comments to clarify the new logic for status transitions and ensure consistency throughout the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->