### PR TITLE
fix: update commission calculation methods for admin and vendor earnings and add filter on them and remove that filter from get_earning_by_order

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -38,3 +38,6 @@ event.json
 postcss.config.js
 webpack.config.js
 tailwind.config.js
+webpack-dependency-mapping.js
+webpack-entries.js
+base-tailwind.config.js

--- a/includes/Commission.php
+++ b/includes/Commission.php
@@ -238,11 +238,7 @@ class Commission {
             return new WP_Error( 'commission_calculation_failed', __( 'Commission calculation failed', 'dokan-lite' ), [ 'status' => 500 ] );
         }
 
-        $earning_or_commission = 'admin' === $context ? $order_commission->get_admin_total_earning() : $order_commission->get_vendor_total_earning();
-
-        $earning_or_commission = apply_filters_deprecated( 'dokan_order_admin_commission', [ $earning_or_commission, $order, $context ], '2.9.21', 'dokan_get_earning_by_order' );
-
-        return apply_filters( 'dokan_get_earning_by_order', $earning_or_commission, $order, $context );
+        return 'admin' === $context ? $order_commission->get_admin_commission() : $order_commission->get_vendor_earning();
     }
 
     /**

--- a/includes/Commission/OrderCommission.php
+++ b/includes/Commission/OrderCommission.php
@@ -288,7 +288,9 @@ class OrderCommission extends AbstractCommissionCalculator implements OrderCommi
      * @return float|int
      */
     public function get_vendor_earning(): float {
-        return $this->get_vendor_net_earning() + $this->get_total_vendor_fees();
+        $vendor_earning = $this->get_vendor_net_earning() + $this->get_total_vendor_fees();
+
+        return apply_filters( 'dokan_get_earning_by_order', $vendor_earning, $this->get_order(), self::SELLER );
     }
 
     /**
@@ -447,7 +449,9 @@ class OrderCommission extends AbstractCommissionCalculator implements OrderCommi
      * @return float
      */
 	public function get_admin_commission(): float {
-		return $this->get_admin_net_commission() + $this->get_total_admin_fees();
+        $admin_commission = $this->get_admin_net_commission() + $this->get_total_admin_fees();
+
+        return apply_filters( 'dokan_get_earning_by_order', $admin_commission, $this->get_order(), self::ADMIN );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Closes 

* Closes #2722


### How to test the changes in this Pull Request:
Consume `dokan_get_earning_by_order` filter and add a fee and watch the order details page if fee was added successfully.
And test also the refund.
```php
add_filter( 'dokan_get_earning_by_order', function( $earning, $order, $context ) {
    if ( $context === 'admin' ) {
        $fees = 50 // adding an exra fee.
        $earning += $fees;
    }

    return $earning;
}, 10, 3 );
```


### Changelog entry
```text
- **fix:** Added missing 'dokan_get_earning_by_order' hook in order commission calculation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an extension point allowing external code to modify vendor earnings and admin commission values before they are returned.

- **Chores**
  - Updated distribution settings to exclude additional build configuration files from deployment packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->