### PR TITLE
Fix ensure shipping fees are calculated as floats in OrderCommission

### DIFF
--- a/includes/Commission/OrderCommission.php
+++ b/includes/Commission/OrderCommission.php
@@ -182,7 +182,7 @@ class OrderCommission extends AbstractCommissionCalculator implements OrderCommi
      */
     public function get_admin_shipping_fee(): float {
         if ( self::ADMIN === dokan()->fees->get_shipping_fee_recipient( $this->order ) ) {
-            return $this->order->get_shipping_total() - $this->get_shipping_refunded();
+            return floatval( $this->order->get_shipping_total() ) - floatval( $this->get_shipping_refunded() );
         }
 
         return 0;
@@ -244,7 +244,7 @@ class OrderCommission extends AbstractCommissionCalculator implements OrderCommi
      */
     public function get_vendor_shipping_fee(): float {
         if ( self::SELLER === dokan()->fees->get_shipping_fee_recipient( $this->order ) ) {
-            return $this->order->get_shipping_total() - $this->get_shipping_refunded();
+            return floatval( $this->order->get_shipping_total() ) - floatval( $this->get_shipping_refunded() );
         }
 
         return 0;
@@ -333,7 +333,7 @@ class OrderCommission extends AbstractCommissionCalculator implements OrderCommi
         }
 
         return [
-            'fee'     => $gateway_fee,
+            'fee'     => floatval( $gateway_fee ),
             'paid_by' => $gateway_fee_paid_by,
         ];
     }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request


### Closes 

* Closes https://github.com/getdokan/dokan-pro/issues/4395

### Changelog entry
```
- **fix:** Added number value data type casting in order commission.
```