### PR TITLE
Add category_id to Product and ProductCommission for accurate commission calculation.

### DIFF
--- a/includes/Commission/ProductCommission.php
+++ b/includes/Commission/ProductCommission.php
@@ -84,9 +84,6 @@ class ProductCommission extends AbstractCommissionCalculator {
             $this->vendor_id = dokan_get_vendor_by_product( $this->product_id, true );
         }
 
-        /**
-         * @var Product $strategy
-         */
         $strategy = apply_filters( 'dokan_product_commission_strategies', new Product( $this->product_id, $this->vendor_id, $this->category_id ) );
 
         $commission_calculator = dokan_get_container()->get( Calculator::class );

--- a/includes/Commission/ProductCommission.php
+++ b/includes/Commission/ProductCommission.php
@@ -84,7 +84,10 @@ class ProductCommission extends AbstractCommissionCalculator {
             $this->vendor_id = dokan_get_vendor_by_product( $this->product_id, true );
         }
 
-        $strategy = apply_filters( 'dokan_product_commission_strategies', new Product( $this->product_id ) );
+        /**
+         * @var Product $strategy
+         */
+        $strategy = apply_filters( 'dokan_product_commission_strategies', new Product( $this->product_id, $this->vendor_id, $this->category_id ) );
 
         $commission_calculator = dokan_get_container()->get( Calculator::class );
         return $commission_calculator

--- a/includes/Commission/Strategies/Product.php
+++ b/includes/Commission/Strategies/Product.php
@@ -16,6 +16,7 @@ class Product extends AbstractStrategy {
     protected $product_id;
 
     protected $vendor_id;
+    protected ?int $category_id;
 
     /**
      * Product strategy source
@@ -31,9 +32,10 @@ class Product extends AbstractStrategy {
      *
      * @param $product_id
      */
-    public function __construct( $product_id, $vendor_id = 0 ) {
-        $this->product_id = $product_id;
-        $this->vendor_id = $vendor_id;
+    public function __construct( $product_id, $vendor_id = 0, $category_id = null ) {
+        $this->product_id  = $product_id;
+        $this->vendor_id   = $vendor_id;
+        $this->category_id = $category_id;
 
         parent::__construct();
     }
@@ -56,14 +58,17 @@ class Product extends AbstractStrategy {
      * Get category for the given product.
      *
      * @param int $product_id
-     * @return void
+     * @return void|int
      */
     protected function get_category_from_product( $product_id ) {
-        $product_categories = Helper::get_saved_products_category( $product_id );
-        $chosen_categories  = $product_categories['chosen_cat'];
-        $category_id        = reset( $chosen_categories );
+        if ( empty( $this->category_id ) && ! empty( $product_id ) ) {
+            $product_categories = Helper::get_saved_products_category( $product_id );
+            $chosen_categories  = $product_categories['chosen_cat'];
+            $category_id        = reset( $chosen_categories );
+            $this->category_id = $category_id;
+        }
 
-        return $category_id ? $category_id : 0;
+        return $this->category_id ? $this->category_id : 0;
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Closes
* Closes https://github.com/getdokan/dokan-pro/issues/4583


### How to test the changes in this Pull Request:
* create or edit product in vendor dashboard and check when change category for different category if the earning shows as expected.
* Order them and check if the commission is working as expected.
* check refund also.


### Changelog entry
```text
- **fix:** Display correct earning in vendor dashboard product add/edit page for different category.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved commission calculation by incorporating vendor and category information for each product.
  
* **Performance**
  * Enhanced efficiency by caching the product category during commission calculations, reducing redundant lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->