### PR TITLE
fix: conditionally hide commission metabox for advertisement product orders

### DIFF
--- a/includes/Order/Admin/Hooks.php
+++ b/includes/Order/Admin/Hooks.php
@@ -563,9 +563,14 @@ class Hooks {
 
         $order         = dokan()->order->get( OrderUtil::get_post_or_order_id( $post ) );
         $has_sub_order = '1' === $order->get_meta( 'has_sub_order', true );
+        $show_commission_meta_box = apply_filters(
+            'dokan_show_commission_meta_box',
+            ! $has_sub_order,
+            $order
+        );
 
         // Check if the screen is order details page and if it is a child order.
-        if ( ! $has_sub_order ) {
+        if ( $show_commission_meta_box ) {
             add_meta_box(
                 'dokan_commission_box',
                 __( 'Commissions', 'dokan-lite' ),


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Related Pull Request(s)
* https://github.com/getdokan/dokan-pro/pull/4631


### Closes
* Closes https://github.com/getdokan/dokan-pro/issues/4455


### How to test the changes in this Pull Request:
* Test as described exsection in the isseue.
* Also test in other regular orders.

### Changelog entry
```text
- **fix:** Hide commission metabox for the orders that containing advertisement products
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filter to allow control over the visibility of the commission meta box on the order details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->