### PR TITLE
Reduce repeated option reads during dashboard navigation URL resolution

### DIFF
--- a/includes/VendorNavMenuChecker.php
+++ b/includes/VendorNavMenuChecker.php
@@ -42,6 +42,15 @@ class VendorNavMenuChecker {
     protected array $forcefully_resolved_dependencies = [];
 
     /**
+     * Request-scoped map of react_route => url for fast lookup.
+     *
+     * @since 4.0.0
+     *
+     * @var array<string,string>
+     */
+    protected $react_route_url_map = [];
+
+    /**
      * Constructor.
      */
 
@@ -72,20 +81,29 @@ class VendorNavMenuChecker {
      *
      * @return array
      */
-
     public function convert_to_react_menu( array $menu_items ): array {
-        return array_map(
-            function ( $item ) {
-                if ( ! empty( $item['react_route'] ) && $this->is_dependency_resolved( $item['react_route'] ) ) {
-                    $item['url'] = $this->get_url_for_route( $item['react_route'] );
-                }
-                if ( isset( $item['submenu'] ) ) {
-                    $item['submenu'] = $this->convert_to_react_menu( $item['submenu'] );
-                }
-
-                return $item;
-            }, $menu_items
-        );
+    	return array_map(
+    		function ( $item ) {
+    			if ( ! empty( $item['react_route'] ) && $this->is_dependency_resolved( $item['react_route'] ) ) {
+    				$item['url'] = $this->get_url_for_route( $item['react_route'] );
+    			}
+    
+    			// Build request-scoped map for fast lookups in maybe_rewrite_to_react_route().
+    			if ( ! empty( $item['react_route'] ) && ! empty( $item['url'] ) && is_string( $item['react_route'] ) ) {
+    				$route = trim( (string) $item['react_route'], '/' );
+    				if ( $route !== '' ) {
+    					$this->react_route_url_map[ $route ] = (string) $item['url'];
+    				}
+    			}
+    
+    			if ( isset( $item['submenu'] ) ) {
+    				$item['submenu'] = $this->convert_to_react_menu( $item['submenu'] );
+    			}
+    
+    			return $item;
+    		},
+    		$menu_items
+    	);
     }
 
     /**
@@ -95,46 +113,45 @@ class VendorNavMenuChecker {
      *
      * @param string $url URL.
      * @param string $name Name.
-     * @param bool $new_url New URL.
+     * @param bool   $new_url New URL.
      *
      * @return string
      */
-
     public function maybe_rewrite_to_react_route( string $url, $name, $new_url ): string {
-        $name = (string) $name;
-        if ( $name === '' || $name === 'new' ) {
-            return $url;
-        }
-        if ( $new_url ) {
-            return $url;
-        }
-        if ( strpos( $url, '#' ) !== false ) {
-            return $url;
-        }
-
-        remove_filter( 'dokan_get_navigation_url', [ $this, 'maybe_rewrite_to_react_route' ], 5 );
-            // Check if the top level menu exists and has a react route
-        $menus = dokan_get_dashboard_nav();
-
-		foreach ( $menus as $menu ) {
-			$react_route = $menu['react_route'] ?? '';
-			if ( $react_route === $name ) {
-				$url = $menu['url'];
-			}
-
-			if ( isset( $menu['submenu'] ) && is_array( $menu['submenu'] ) ) {
-				foreach ( $menu['submenu'] as $submenu ) {
-					$react_route = $submenu['react_route'] ?? '';
-					if ( $react_route === $name ) {
-						$url = $submenu['url'];
-					}
-				}
-			}
-		}
-
-		add_filter( 'dokan_get_navigation_url', [ $this, 'maybe_rewrite_to_react_route' ], 5, 3 );
-
-        return $url;
+    	$name = trim( (string) $name, '/' );
+    
+    	if ( $name === '' || $name === 'new' ) {
+    		return $url;
+    	}
+    
+    	if ( $new_url ) {
+    		return $url;
+    	}
+    
+    	if ( strpos( $url, '#' ) !== false ) {
+    		return $url;
+    	}
+    
+    	// Fast path: if already mapped during this request, return immediately.
+    	if ( isset( $this->react_route_url_map[ $name ] ) ) {
+    		return $this->react_route_url_map[ $name ];
+    	}
+    
+    	// If the map isn't built yet this request, build it once.
+    	if ( empty( $this->react_route_url_map ) ) {
+    		remove_filter( 'dokan_get_navigation_url', [ $this, 'maybe_rewrite_to_react_route' ], 5 );
+    
+    		// This triggers convert_to_react_menu(), which will populate $this->react_route_url_map.
+    		dokan_get_dashboard_nav();
+    
+    		add_filter( 'dokan_get_navigation_url', [ $this, 'maybe_rewrite_to_react_route' ], 5, 3 );
+    	}
+    
+    	if ( isset( $this->react_route_url_map[ $name ] ) ) {
+    		return $this->react_route_url_map[ $name ];
+    	}
+    
+    	return $url;
     }
 
     /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2022,24 +2022,36 @@ add_filter( 'get_avatar_url', 'dokan_get_avatar_url', 99, 3 );
  * @return string url
  */
 function dokan_get_navigation_url( $name = '', $new_url = false ) {
-    $page_id = (int) dokan_get_option( 'dashboard', 'dokan_pages', 0 );
+	static $memo = [];
 
-    if ( ! $page_id ) {
-        return '';
-    }
+	$name    = is_scalar( $name ) ? (string) $name : '';
+	$new_url = (bool) $new_url;
 
-    $url = rtrim( get_permalink( $page_id ), '/' ) . '/';
+	$key = $name . '|' . ( $new_url ? '1' : '0' );
+	if ( isset( $memo[ $key ] ) ) {
+		return $memo[ $key ];
+	}
 
-    if ( ! empty( $name ) && ! $new_url ) {
-        $url = dokan_add_subpage_to_url( $url, $name . '/' );
-    }
+	// Page id is the key expensive option read seen in hot paths.
+	$page_id = (int) dokan_get_option( 'dashboard', 'dokan_pages', 0 );
 
-    if ( $new_url ) {
-        $url = dokan_add_subpage_to_url( $url, 'new/' );
-        $url = $url . '#' . $name . '/';
-    }
+	if ( ! $page_id ) {
+		$memo[ $key ] = '';
+		return '';
+	}
 
-    return apply_filters( 'dokan_get_navigation_url', esc_url( $url ), $name, $new_url );
+	$url = rtrim( get_permalink( $page_id ), '/' ) . '/';
+
+	if ( $new_url ) {
+		$url = dokan_add_subpage_to_url( $url, 'new/' );
+		$url = $url . '#' . trim( $name, '/' ) . '/';
+	} elseif ( $name !== '' ) {
+		$url = dokan_add_subpage_to_url( $url, $name . '/' );
+	}
+
+	$memo[ $key ] = apply_filters( 'dokan_get_navigation_url', esc_url( $url ), $name, $new_url );
+
+	return $memo[ $key ];
 }
 
 /**


### PR DESCRIPTION
### All Submissions

* [x] The code follows WordPress coding standards.
* [x] The code satisfies the intended behavior and requirements.
* [x] The code includes appropriate inline documentation.
* [ ] PHPCS tests were run locally.

---

### Changes proposed in this Pull Request

This pull request reduces repeated work during Dokan dashboard navigation URL resolution by introducing request-scoped optimizations:

1. Adds request-scoped memoization to `dokan_get_navigation_url()` to avoid repeated option reads and permalink computation within a single request.
2. Avoids repeated dashboard navigation rebuilds inside `VendorNavMenuChecker::maybe_rewrite_to_react_route()` by using a request-scoped `react_route => url` lookup map populated during menu conversion.

These changes do not introduce persistent caching and do not alter URL structure or menu discovery behavior.

---

### How to test the changes in this Pull Request

1. Visit any page that triggers multiple calls to `dokan_get_navigation_url()` during a single request (e.g. Dokan dashboard navigation rendering).
2. Verify that returned navigation URLs remain unchanged.
3. Optionally instrument function calls or option reads to confirm reduced repeated execution within the same request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized navigation URL resolution and lookup performance through request-scoped caching and memoization, reducing computational overhead on navigation-heavy operations and improving overall app responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->