### PR TITLE
Enhancement: Prevent saving vendor settings when Terms & Conditions content is empty

### DIFF
--- a/includes/Dashboard/Templates/Settings.php
+++ b/includes/Dashboard/Templates/Settings.php
@@ -3,6 +3,7 @@
 namespace WeDevs\Dokan\Dashboard\Templates;
 
 use WeDevs\Dokan\Utilities\VendorUtil;
+use WeDevs\Dokan\Utilities\RichTextValidatorUtil;
 use WP_Error;
 
 /**
@@ -511,6 +512,22 @@ class Settings {
             }
         }
 
+        $enable_tnc = isset( $_POST['dokan_store_tnc_enable'] ) && 'on' === sanitize_text_field( wp_unslash( $_POST['dokan_store_tnc_enable'] ) );
+
+        if ( $enable_tnc ) {
+            $store_tnc = isset( $_POST['dokan_store_tnc'] ) ? wp_kses_post( wp_unslash( $_POST['dokan_store_tnc'] ) ) : '';
+
+            $store_tnc_clean = RichTextValidatorUtil::sanitize_richtext_content( $store_tnc );
+            $store_tnc_clean = trim( $store_tnc_clean );
+
+            if ( empty( $store_tnc_clean ) ) {
+                $error->add(
+                    'dokan_tnc_content',
+                    __( 'Please add Terms & Conditions content before saving the settings.', 'dokan-lite' )
+                );
+            }
+        }
+
         if ( $error->get_error_codes() ) {
             return $error;
         }
@@ -671,6 +688,19 @@ class Settings {
                 ];
             }
 
+            $store_tnc_raw = isset( $_POST['dokan_store_tnc'] ) ? wp_kses_post( wp_unslash( $_POST['dokan_store_tnc'] ) ) : '';
+
+            $store_tnc_processed = '';
+
+            if ( ! empty( $store_tnc_raw ) ) {
+                $store_tnc_clean = RichTextValidatorUtil::sanitize_richtext_content( $store_tnc_raw );
+                $store_tnc_clean = trim( $store_tnc_clean );
+
+                if ( ! empty( $store_tnc_clean ) ) {
+                    $store_tnc_processed = $store_tnc_clean;
+                }
+            }
+
             // Update store settings info.
             $dokan_settings = [
                 'store_name'               => isset( $_POST['dokan_store_name'] ) ? sanitize_text_field( wp_unslash( $_POST['dokan_store_name'] ) ) : '',
@@ -682,7 +712,7 @@ class Settings {
                 'show_email'               => isset( $_POST['setting_show_email'] ) ? sanitize_text_field( wp_unslash( $_POST['setting_show_email'] ) ) : 'no',
                 'gravatar'                 => isset( $_POST['dokan_gravatar'] ) ? absint( $_POST['dokan_gravatar'] ) : 0,
                 'enable_tnc'               => isset( $_POST['dokan_store_tnc_enable'] ) && 'on' === sanitize_text_field( wp_unslash( $_POST['dokan_store_tnc_enable'] ) ) ? 'on' : 'off',
-                'store_tnc'                => isset( $_POST['dokan_store_tnc'] ) ? wp_kses_post( wp_unslash( $_POST['dokan_store_tnc'] ) ) : '',
+                'store_tnc'                => $store_tnc_processed,
                 'dokan_store_time'         => apply_filters( 'dokan_store_time', $dokan_store_time ),
                 'dokan_store_time_enabled' => isset( $_POST['dokan_store_time_enabled'] ) && 'yes' === sanitize_text_field( wp_unslash( $_POST['dokan_store_time_enabled'] ) ) ? 'yes' : 'no',
                 'dokan_store_open_notice'  => isset( $_POST['dokan_store_open_notice'] ) ? sanitize_textarea_field( wp_unslash( $_POST['dokan_store_open_notice'] ) ) : '',

--- a/includes/Utilities/RichTextValidatorUtil.php
+++ b/includes/Utilities/RichTextValidatorUtil.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WeDevs\Dokan\Utilities;
+
+/**
+ * Utility class for cleaning and normalizing rich text content.
+ *
+ * @since DOKAN_SINCE
+ */
+class RichTextValidatorUtil {
+
+    /**
+     * Sanitize and clean rich text content.
+     *
+     * Strips all HTML tags, decodes HTML entities, and removes special/invisible
+     * characters such as BOMs, zero-width spaces, and control characters.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $text The text to sanitize and clean.
+     *
+     * @return string Sanitized and cleaned plain text.
+     */
+    public static function sanitize_richtext_content( string $text ): string {
+        $text = wp_strip_all_tags( $text );
+        $text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+        $text = self::replace_richtext_chars( $text );
+
+        /**
+         * Filter for sanitizing and cleaning rich text content.
+         *
+         * Allows external modification of the cleaned rich text content.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param string $text The cleaned text.
+         */
+        return apply_filters( 'dokan_sanitize_richtext_content', $text );
+    }
+
+    /**
+     * Replace rich text special characters.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @see sitepress-multilingual-cms/vendor/wpml/wpml/src/Core/Component/WordsToTranslate/Domain/Calculator/PrepareContent/Rules/UnicodeTrait.php
+     *
+     * @param string $text The text containing special characters.
+     *
+     * @return string Text with special characters replaced or removed.
+     */
+    protected static function replace_richtext_chars( string $text ): string {
+        // Remove UTF-8 BOM.
+        $text = preg_replace( '/^\xEF\xBB\xBF/', '', $text ) ?? '';
+
+        // Remove UTF-16 BOM.
+        $text = preg_replace( '/^(?:\xFE\xFF|\xFF\xFE)/', '', $text ) ?? '';
+
+        // Replace non-breaking space with normal space.
+        $text = str_replace( "\xC2\xA0", ' ', $text );
+
+        // Remove zero-width and invisible Unicode characters.
+        $text = preg_replace( '/[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}]/u', '', $text ) ?? '';
+
+        // Remove control characters except \t (\x09) and \n (\x0A).
+        $text = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $text ) ?? '';
+
+        return $text;
+    }
+}

--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -200,7 +200,7 @@ $args     = apply_filters( 'dokan_store_time_arguments', $args, $all_times );
             </div>
         </div>
         <div class="dokan-form-group" id="dokan_tnc_text">
-            <label class="dokan-w3 dokan-control-label" for="dokan_store_tnc"><?php esc_html_e( 'TOC Details', 'dokan-lite' ); ?></label>
+            <label class="dokan-w3 dokan-control-label" for="dokan_store_tnc"><?php esc_html_e( 'TOC Details', 'dokan-lite' ); ?> <span class="required">*</span></label>
             <div class="dokan-w8 dokan-text-left">
                 <?php
                 $settings = [


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

---

### Changes proposed in this Pull Request:

Previously, vendors could enable the **Terms & Conditions** option without providing any content.  
This resulted in a blank storefront page for customers, which appeared broken and caused confusion.

This pull request adds **backend form validation** to prevent vendors from saving settings when:
- Terms & Conditions are enabled
- But the T&C content field is empty or contains only HTML/whitespace/invisible characters

It also addresses several code quality issues found during review:
- Fixed a **regex bug** in `RichTextValidatorUtil` where `\x00-\x09` incorrectly removed tab characters (`\x09`) despite the comment stating tabs should be preserved. Corrected to `\x00-\x08`.
- Renamed `validate_richtext_content()` → `sanitize_richtext_content()` and updated the filter name accordingly, since the method cleans content rather than validating it.
- Added a class-level PHPDoc block to `RichTextValidatorUtil`.
- Added removal of zero-width and invisible Unicode characters (`U+200B`, `U+200C`, `U+200D`, `U+2060`, `U+FEFF`) which previously passed through undetected.
- Fixed grammar in the validation message: _"before save the settings"_ → _"before saving the settings"_.
- Replaced `<span style="color: red;">*</span>` with `<span class="required">*</span>` on the T&C label.
- Removed a redundant inline `<script>` block — existing JS in `script.js` already shows/hides the `#dokan_tnc_text` div (including the asterisk) based on checkbox state.

---

### Related Pull Request(s)

* N/A

---

### Closes

* Closes #

---

### How to test the changes in this Pull Request:

1. Go to Vendor Dashboard → Settings
2. Enable the **Terms & Conditions** checkbox
3. Leave the T&C content field empty
4. Click **Save Settings**
5. Verify that:
   - Settings are not saved
   - An error message is shown asking to add Terms & Conditions content before saving the settings
6. Add valid T&C content and save again
7. Verify settings save successfully and storefront T&C page renders correctly
8. Uncheck the Terms & Conditions checkbox and verify the required `*` asterisk disappears

---

### Changelog entry

**Title:**  
Prevent enabling vendor Terms & Conditions without content

**Description:**  
Previously, enabling Terms & Conditions without content caused a blank storefront page.  
This change adds backend validation to block saving when the content field is empty, fixes a regex bug that incorrectly removed tab characters, improves method naming for clarity, and extends invisible character removal to include zero-width Unicode characters.

---

### Before Changes

- Vendors could enable Terms & Conditions without providing content
- Storefront displayed a blank page for T&C
- Created confusion and reduced trust for customers
- Regex in `replace_richtext_chars()` incorrectly stripped tab characters
- Method named `validate_richtext_content()` despite performing sanitization, not validation
- Required asterisk used inline `style="color: red;"` instead of the standard `required` class

---

### After Changes

- Vendors cannot save settings with empty T&C content
- Clear, grammatically correct validation message shown in the dashboard
- Storefront no longer renders blank T&C pages
- Tab characters are correctly preserved during rich text cleaning
- Method and filter names accurately reflect their sanitization behaviour
- Zero-width and invisible Unicode characters are now stripped
- Required asterisk uses the standard `class="required"` and visibility is handled by existing JS

---

### Feature Video (optional)

N/A

---

### PR Self Review Checklist:

* [x] Code follows code style guidelines
* [x] Naming is clear and understandable
* [x] KISS principle is followed
* [x] DRY principle is respected
* [x] Code is readable and maintainable
* [x] No performance issues introduced
* [x] No unnecessary complexity
* [x] Grammar checked

---

### FOR PR REVIEWER ONLY:

* [ ] Correct — Does the change do what it's supposed to?
* [ ] Secure — All inputs are properly sanitized and validated
* [ ] Readable — Code is easy to understand and maintain
* [ ] Elegant — Fits well within existing architecture and style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Store settings now validate Terms & Conditions content with automatic sanitization of rich text to ensure data integrity.

* **Improvements**
  * Visual indicators now mark required fields in store settings forms for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->