### PR TITLE
enhance: migrate admin dashboard list tables to Plugin UI DataViews

### DIFF
--- a/src/admin/dashboard/components/Layout.tsx
+++ b/src/admin/dashboard/components/Layout.tsx
@@ -25,7 +25,10 @@ const Layout = ( {
                 pluginId="dokan-admin-dashboard"
                 tokens={ pluginUITokens }
             >
-                { children }
+                { /* Plugin UI WordPress styles are scoped to .dokan-admin-dashboard-layout (see base-tailwind.css). */ }
+                <div className="dokan-admin-dashboard-layout">
+                    { children }
+                </div>
                 <PluginArea scope={ 'dokan-admin-dashboard-' + route.id } />
             </ThemeProvider>
             <DokanToaster />

--- a/src/admin/dashboard/components/Layout.tsx
+++ b/src/admin/dashboard/components/Layout.tsx
@@ -3,6 +3,9 @@ import { PluginArea } from '@wordpress/plugins';
 import { DokanToaster } from '@getdokan/dokan-ui';
 import { pluginUITokens } from '@src/layout';
 import { ThemeProvider } from '@wedevs/plugin-ui';
+import { useEffect } from '@wordpress/element';
+import { setLocaleData } from '@wordpress/i18n';
+import { getTranslatedStrings } from '@src/components/dataviews/DataViewTable';
 import { DokanAdminRoute } from './Dashboard';
 
 const Layout = ( {
@@ -12,6 +15,10 @@ const Layout = ( {
     children: React.ReactNode;
     route: DokanAdminRoute;
 } ) => {
+    useEffect( () => {
+        setLocaleData( getTranslatedStrings(), 'default' );
+    }, [] );
+
     return (
         <SlotFillProvider>
             <ThemeProvider

--- a/src/components/dataviews/getActionLabel.tsx
+++ b/src/components/dataviews/getActionLabel.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+const getActionLabel = ( icon: ReactNode, label: string ): JSX.Element => (
+    <span className="dokan-layout">
+        <span className="inline-flex items-center gap-2.5">
+            { icon }
+            { label }
+        </span>
+    </span>
+);
+
+export default getActionLabel;

--- a/src/components/dataviews/style.scss
+++ b/src/components/dataviews/style.scss
@@ -59,6 +59,12 @@
                 tr th:last-child {
                     padding-right: 20px;
                 }
+
+                tbody tr td {
+                    min-height: 65px;
+                    padding-top: 14px;
+                    padding-bottom: 14px;
+                }
             }
             .components-button.is-compact.has-icon:not(.has-text) {
                 width: auto;
@@ -87,6 +93,44 @@
                         line-height: 1;
                     }
                 }
+            }
+        }
+
+        // Plugin UI wrapper rendered by the new DataViews component.
+        // Restores admin-table polish (row height, bulk-bar borders, pagination padding)
+        // that the legacy AdminDataViews wrapper used to provide.
+        .pui-root-dataviews {
+            .dataviews-bulk-actions-footer__action-buttons {
+                gap: 10px;
+
+                .components-button.is-compact:not(:last-child) {
+                    border: 1px solid #e9e9e9;
+                    border-radius: 6px;
+                    line-height: 1;
+                    padding: 6px 10px;
+                }
+            }
+
+            .components-flex.components-h-stack.dataviews-pagination {
+                width: 100%;
+                justify-content: space-between;
+                padding: 15px 20px;
+            }
+
+            // Data rows: keep visual rhythm at 65px even for single-line rows.
+            table.dataviews-view-table tbody tr td {
+                min-height: 65px;
+                padding-top: 14px;
+                padding-bottom: 14px;
+            }
+
+            // Skeleton rows (rendered while isLoading): match the data row rhythm.
+            > div table tbody tr td.h-12 {
+                height: 65px;
+            }
+            > div table tbody tr td {
+                height: 65px;
+                min-height: 65px;
             }
         }
     }

--- a/src/components/dataviews/style.scss
+++ b/src/components/dataviews/style.scss
@@ -97,9 +97,23 @@
         }
 
         // Plugin UI wrapper rendered by the new DataViews component.
-        // Restores admin-table polish (row height, bulk-bar borders, pagination padding)
-        // that the legacy AdminDataViews wrapper used to provide.
+        // Restores admin-table polish (single white card containing tabs +
+        // filters + table + pagination) that the legacy AdminDataViews
+        // wrapper used to provide.
         .pui-root-dataviews {
+            background-color: #fff;
+            border-radius: 10px;
+            box-shadow: 0px 1px 3px 0px #0000001a;
+            overflow: hidden;
+
+            // Inner table wrapper: drop the duplicate card styling now that
+            // the outer wrapper carries the rounded corners + shadow.
+            .dataviews-wrapper {
+                box-shadow: none;
+                border-radius: 0;
+                background-color: transparent;
+            }
+
             .dataviews-bulk-actions-footer__action-buttons {
                 gap: 10px;
 

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -10,6 +10,7 @@ export { DataViews } from '@wedevs/plugin-ui';
 export { default as DokanModal } from './modals/DokanModal';
 export { default as SortableList } from './sortable-list';
 export { default as ListEmpty } from './dataviews/ListEmpty';
+export { default as getActionLabel } from './dataviews/getActionLabel';
 
 export { default as Forbidden } from './../layout/403';
 export { default as NotFound } from './../layout/404';


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

This is the parent/coordination PR for migrating every admin (React) dashboard list table off the legacy `AdminDataViews` wrapper (`dokan/src/components/dataviews/AdminDataViewTable.tsx`) and onto the unified `DataViews` component re-exported from `@dokan/components` (sourced from `@wedevs/plugin-ui`) — the same component the vendor dashboard already uses since v5.

Shared infrastructure landed on this branch:

- New `getActionLabel()` helper in `dokan/src/components/dataviews/getActionLabel.tsx` — wraps icon + label JSX so `@wordpress/dataviews` `MenuItemTrigger` and bulk-action `ActionTrigger` keep rendering icons (the underlying components only render `action.label`, so icons must live inside the label callback).
- `setLocaleData( getTranslatedStrings(), 'default' )` lifted once into the admin Dashboard `Layout.tsx`, so every migrated page picks up DataViews i18n without duplicating the call.
- Admin DataViews CSS overrides in `dokan/src/components/dataviews/style.scss` — restores the single white-card look (background, 10px radius, shadow), the 65px row rhythm, the bulk-action bar buttons with borders, and the pagination layout.
- `Layout.tsx` wraps children in a `.dokan-admin-dashboard-layout` div so plugin-ui's WordPress-scoped CSS (`:is(#dokan-vendor-dashboard-root, .dokan-admin-dashboard-layout, …) .pui-root-dataviews { … }`) applies to every admin route — not just the dashboard root.

Sub-PRs (one per page) target this branch and contain the per-page migration for each admin table.

> **Hard constraint that applied to every page:** this is a wrapper-component swap, **not a redesign**. Every existing feature was preserved — status counts, filters, modals, custom buttons (Withdraw's Export, RFQ's split layout), polling, sorting, search, pagination, per-row icons.

### Related Pull Request(s)

* dokan-pro counterpart parent: https://github.com/getdokan/dokan-pro/pull/5633

### Closes

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/1844

### How to test the changes in this Pull Request:

1. Build assets: `npm install && npm run build`.
2. Open WP Admin → Dokan dashboard. Visit each migrated page in turn:
   - Withdraw, Reverse Withdrawal, Vendors (covered by sub-PRs in this batch).
3. On each page verify: tabs switch + counts update, status filter persists in `view.status`, search debounces, pagination works, every row action shows its icon + label, bulk actions appear with icons + borders, custom buttons (Export on Withdraw) still appear in the right spot.
4. Resize to mobile width — table collapses to list layout via Plugin UI's responsive default.
5. Confirm DataViews built-in UI strings (Search, No items, Showing X of Y, pagination labels) are translated.
6. Confirm the table, tabs, and filter all share the same white card with rounded corners and shadow on every admin page.

### Changelog entry

*Migrate admin dashboard list tables to Plugin UI DataViews*

Replaces the legacy `AdminDataViews` wrapper with the unified `DataViews` component already used by the vendor dashboard. Adds shared infrastructure: a `getActionLabel` helper that preserves row + bulk action icons, a single `setLocaleData` call in the admin Dashboard layout, scoped CSS overrides that restore the admin table polish (65px row rhythm, single white-card look, bulk-action bar, pagination), and a `.dokan-admin-dashboard-layout` wrapper so plugin-ui's scoped WordPress styles apply on every admin route. Per-page migrations land via stacked sub-PRs.

### Before Changes

Admin tables used the in-house `AdminDataViews` wrapper (`dokan/src/components/dataviews/AdminDataViewTable.tsx`), diverging from the vendor dashboard which already uses `DataViews` from `@wedevs/plugin-ui`. Tabs, filter, and table did not share a unified card. Action icons relied on a JSX-wrapped label.

### After Changes

Admin tables now use the same `DataViews` component as the vendor dashboard. Tabs + filter + table render in a single white card on every admin page. Row + bulk action icons render via the dedicated `icon` prop wrapped through `getActionLabel`.

### Feature Video (optional)

n/a

### PR Self Review Checklist:

* Code style follows WPCS / project conventions.
* Naming matches existing components (`getActionLabel`, `dokan-admin-dashboard-layout`).
* KISS: helper is one short JSX wrapper; SCSS overrides scoped to `.pui-root-dataviews` under `.dokan-admin-dashboard-datatable`.
* DRY: shared helper + Layout wrapper avoid duplicating the locale-setup and icon-wrapping per page.

### FOR PR REVIEWER ONLY:

* [ ] Correct — tabs, filter, search, pagination, status counts, modals, bulk actions, per-row actions all still work on every migrated page.
* [ ] Secure — no new escaping concerns; the migration is React-only and reuses existing REST endpoints.
* [ ] Readable — `getActionLabel` is a 7-line helper; SCSS overrides are commented.
* [ ] Elegant — sub-PRs land cleanly into this branch with their per-page diffs only.
