### PR TITLE
fix: stop loading legacy dashboard assets on the new SPA layout

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -882,8 +882,18 @@ class Assets {
             ]
         );
 
-        // load only in dokan dashboard and product edit page
-        if ( ( dokan_is_seller_dashboard() || ( get_query_var( 'edit' ) && is_singular( 'product' ) ) ) || apply_filters( 'dokan_forced_load_scripts', false ) ) {
+        // Skip the legacy dashboard asset bundle (jQuery UI, Select2, Flot, etc.) when the
+        // new React SPA replaces the page it would target. The SPA bundle declares no
+        // dependency on these scripts, so loading them just inflates the dashboard payload.
+        // Each branch is gated on its own appearance flag because the dashboard layout and
+        // the product editor toggle independently.
+        $is_new_vendor_layout  = 'latest' === dokan_get_option( 'vendor_layout_style', 'dokan_appearance', 'legacy' );
+        $is_new_product_editor = 'latest' === dokan_get_option( 'vendor_product_editor', 'dokan_appearance', 'legacy' );
+
+        $load_for_dashboard = dokan_is_seller_dashboard() && ! $is_new_vendor_layout;
+        $load_for_edit      = ( get_query_var( 'edit' ) && is_singular( 'product' ) ) && ! $is_new_product_editor;
+
+        if ( $load_for_dashboard || $load_for_edit || apply_filters( 'dokan_forced_load_scripts', false ) ) {
             $this->dokan_dashboard_scripts();
         }
 
@@ -894,12 +904,21 @@ class Assets {
         }
 
         // store and my account page
+        // The seller dashboard endpoint is registered as a WC My Account endpoint, so
+        // is_account_page() matches on SPA dashboard URLs too. Skip this block in that
+        // case — the SPA does not use Select2, jQuery UI, the legacy tooltip, or the
+        // legacy form-validate script.
+        $skip_for_spa_dashboard = $is_new_vendor_layout && dokan_is_seller_dashboard();
+
         if (
-            dokan_is_store_page()
-            || dokan_is_store_review_page()
-            || is_account_page()
-            || is_product()
-            || dokan_is_store_listing()
+            ! $skip_for_spa_dashboard
+            && (
+                dokan_is_store_page()
+                || dokan_is_store_review_page()
+                || is_account_page()
+                || is_product()
+                || dokan_is_store_listing()
+            )
         ) {
             if ( DOKAN_LOAD_STYLE ) {
                 wp_enqueue_style( 'dokan-select2-css' );


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

After the 5.0.x line shipped the new React-based vendor dashboard SPA (`vendor_layout_style = 'latest'`), every dashboard URL was still loading the **entire** legacy template asset chain alongside the new bundle. The SPA does not consume any of these scripts — its webpack-generated asset manifest declares only modern dependencies (`react`, `wp-components`, `wc-components`, `lodash`, etc.).

Two enqueue paths in `includes/Assets.php` were responsible:

1. **`Assets::enqueue_front_scripts()` → `dokan_dashboard_scripts()`** — called on every `dokan_is_seller_dashboard()` page, regardless of layout. Loaded `jquery`, `jquery-ui` (+ autocomplete + datepicker), `underscore`, `post`, `dokan-date-range-picker`, `dokan-tooltip`, `dokan-form-validate`, `dokan-select2-js`, `dokan-accounting`, `serializejson`, `wc-password-strength-meter`, `dokan-script`, plus the entire `wp_enqueue_media()` payload, and styles `jquery-ui`, `woocommerce-general`, `dokan-select2-css`, `dokan-modal`, `dokan-timepicker`, `dokan-date-range-picker`.
2. **The `is_account_page()` block** — re-enqueued `dokan-select2-css`, `jquery-ui-sortable`, `jquery-ui-datepicker`, `dokan-tooltip`, `dokan-form-validate`, `speaking-url`, `dokan-script`, `dokan-select2-js`. This fired on SPA dashboard URLs too because the seller dashboard endpoint is a WC My Account endpoint, so `is_account_page()` matches.

This PR adds appearance-flag guards to both code paths. The legacy bundle is still loaded when `vendor_layout_style = 'legacy'` (the default) or when the `dokan_forced_load_scripts` filter forces it on. The product-edit branch is gated independently on `vendor_product_editor` because that toggle is separate from the dashboard layout toggle.

### Verification that the SPA does not consume the gated scripts

1. **Auto-generated dependency manifest** (`assets/js/vendor-dashboard/layout/index.asset.php`):
   ```
   dokan-hooks, dokan-utilities, lodash, react, react-dom, react-jsx-runtime,
   wc-components, wc-csv, wc-date, wp-api-fetch, wp-components, wp-compose,
   wp-date, wp-dom-ready, wp-element, wp-hooks, wp-html-entities, wp-i18n, wp-url
   ```
   No `jquery`, no `underscore`, no `dokan-script`, no `dokan-select2-js`, no `dokan-vue-bootstrap`, no `moment`. The `DependencyExtractionWebpackPlugin` would add them automatically if the source imported them.

2. **SPA source scan** (`src/vendor-dashboard/**`) — zero hits for `jQuery`, `window.jQuery`, `window.$`, `underscore`, `window._`, `Select2`, `window.moment`, `dokanHelper`, `dokan_helper`.

3. **Compiled bundle scan** (`assets/js/vendor-dashboard/layout/index.js`) — zero substring hits for `jQuery`, `Select2`, `datepicker(`, `underscore`.

4. **Sole legacy global read**: `window.dokan?.urls?.storeUrl` in `src/vendor-dashboard/layout/components/Header.tsx:43`. This comes from `wp_localize_script( 'dokan-util-helper', 'dokan', ... )` at `Assets.php:871-872`, which runs **outside** the gated block. `dokan-util-helper` is enqueued unconditionally via `load_dokan_global_scripts()` (priority 5 on `wp_enqueue_scripts`). The localized `var dokan = {…}` therefore still emits on SPA pages — verified untouched by this change.

### How to test the changes in this Pull Request:

**Test matrix — verify nothing regressed for legacy users:**
1. Go to **Dokan → Settings → Appearance**. Set **Vendor Dashboard Layout** to `Legacy`. Save.
2. Log in as a vendor. Visit `/dashboard`, `/dashboard/products`, `/dashboard/orders`, `/dashboard/settings/store`, `/dashboard/reports`, `/dashboard/withdraw`. For each: open DevTools → Network → JS/CSS and confirm `dokan-script`, `dokan-select2-js`, `dokan-date-range-picker`, `dokan-tooltip`, `jquery-ui-*`, and `dokan-select2-css` are all loaded (identical to behaviour before this PR).
3. Edit a product on the legacy editor. Confirm the legacy chain still loads on the single product edit page.
4. Visit a store page (`/store/<slug>/`) and a single product page. Confirm Select2/tooltip/jquery-ui-sortable/etc. still load (this PR did not change the non-dashboard paths).

**Verify the regression is fixed on the new SPA layout:**
5. Switch **Vendor Dashboard Layout** to `Latest`. Save.
6. Visit `/dashboard`. In DevTools → Network → filter by JS: confirm `dokan-script`, `dokan-select2-js`, `dokan-tooltip`, `dokan-form-validate`, `dokan-accounting`, `serializejson`, `dokan-date-range-picker`, `dokan-chart`, `dokan-flot`, `wc-password-strength-meter`, `jquery-ui` (the CSS one), `woocommerce-general`, `dokan-select2-css` are **no longer requested**.
7. Confirm `dokan-vendor-dashboard` (the SPA bundle) and `dokan-util-helper` (which carries `var dokan = {…}`) **are** still requested.
8. Click through SPA pages: Dashboard, Products, Orders, Withdraw, Settings, Reports. Confirm the SPA still renders, the header avatar / store link still works (proves `window.dokan.urls.storeUrl` is populated), and there are no JavaScript errors in the console.
9. With layout set to `Latest`, visit a store page and a single product page (non-dashboard). Confirm Select2 etc. still load there — the gate only skips when on the dashboard itself.
10. Apply the `dokan_forced_load_scripts` filter and confirm the legacy bundle returns on SPA pages (escape hatch preserved).

### Changelog entry

**Title:** Stop loading legacy dashboard scripts on the new vendor dashboard SPA

**Previous behaviour:** With the new vendor dashboard (`Appearance → Vendor Dashboard Layout = Latest`), every dashboard URL also loaded the full legacy template script chain — jQuery, jQuery UI, underscore, Select2, the legacy `dokan-script`, Flot, Chart.js, `wp_enqueue_media()`, plus a duplicate Select2/tooltip block from the My Account branch — none of which the SPA uses.

**New behaviour:** Those legacy scripts/styles are skipped on SPA dashboard URLs, shaving several hundred KB of unused JS plus the legacy CSS off every dashboard page load. Legacy-layout sites, store/single-product/account pages, and the `dokan_forced_load_scripts` filter are unaffected.

### Follow-up candidates (intentionally not in this PR)

These also fire on every SPA dashboard URL but need behavioural verification before gating, so they are out of scope:

* `includes/Analytics/Assets.php:146-152` — `vendor_analytics_script` + `vendor_analytics_style` fire on **every** dashboard tab, not just the analytics tab.
* `includes/Intelligence/Assets.php:43-49` — `dokan-ai-script` fires on every dashboard tab when AI is configured.

### PR Self Review Checklist:

* [x] Code style matches surrounding code
* [x] Naming is descriptive (`$is_new_vendor_layout`, `$is_new_product_editor`, `$skip_for_spa_dashboard`)
* [x] KISS — guards are additive, no removals
* [x] DRY — both flags read once, reused for both guards
* [x] Behaviour for the default (legacy) install is bit-identical to before
* [x] `dokan_forced_load_scripts` escape hatch preserved