### PR TITLE
test: stabilize e2e waits and fix URL rot

### DIFF
--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
@@ -283,7 +283,8 @@ export class AbuseReportsPage {
     }
 
     async isSettingsHeadingVisible(): Promise<boolean> {
-        return await this.page.getByRole('heading', { name: /Product Report Abuse Settings/i }).isVisible();
+        await this.page.getByRole('heading', { name: /Product Report Abuse Settings/i }).waitFor({ state: 'visible', timeout: 10000 });
+        return true;
     }
 
     async getSettingsDocLinkHref(): Promise<string> {
@@ -292,11 +293,13 @@ export class AbuseReportsPage {
     }
 
     async isReportedByHeadingVisible(): Promise<boolean> {
-        return await this.page.locator(this.admin.reportedByHeading).isVisible();
+        await this.page.locator(this.admin.reportedByHeading).waitFor({ state: 'visible', timeout: 10000 });
+        return true;
     }
 
     async isReasonsHeadingVisible(): Promise<boolean> {
-        return await this.page.locator(this.admin.reasonsHeading).isVisible();
+        await this.page.locator(this.admin.reasonsHeading).waitFor({ state: 'visible', timeout: 10000 });
+        return true;
     }
 
     async enableReportedBySliderIfDisabled() {

--- a/tests/pw/tests/e2e/admin/admin.spec.ts
+++ b/tests/pw/tests/e2e/admin/admin.spec.ts
@@ -136,7 +136,7 @@ test.describe('Admin Tests @lite', () => {
 test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
     test('Test Case 1 - / (root) route mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/page=dokan-dashboard/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -145,7 +145,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 2 - /vendors mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/vendors');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -154,7 +154,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 3 - /vendors/create mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/vendors/create');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors\/create/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -163,7 +163,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 4 - /pro-modules mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/pro-modules');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/pro-modules/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -172,7 +172,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 5 - /setup (setup guide) mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/setup');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/setup/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -181,7 +181,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 6 - /extensions mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/extensions');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/extensions/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -190,7 +190,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 7 - /changelog mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/changelog');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/changelog/);
         // The changelog renders historical fix messages that include the
         // word "error" or even "fatal error" in body copy. We don't apply
@@ -204,7 +204,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 8 - /dummy-data mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/dummy-data');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/dummy-data/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -213,7 +213,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 9 - /reverse-withdrawal mounts', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/reverse-withdrawal');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/reverse-withdrawal/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -222,7 +222,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 10 - /withdraw (admin) mounts', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/withdraw');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/withdraw/);
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         await page.close();
@@ -231,7 +231,7 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 11 - Unknown HashRouter route falls through (NoMatch)', { tag: ['@lite', '@exploratory', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/this-does-not-exist');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(await page.locator(fatalLocator).first().isVisible({ timeout: 1000 }).catch(() => false)).toBe(false);
         // The shell still renders (#wpwrap from WP admin layout)
         await expect(page.locator(adminReactRoot).first()).toBeVisible();
@@ -241,9 +241,9 @@ test.describe('Admin Dokan Dashboard (React) Tests @lite', () => {
 
     test('Test Case 12 - Reload preserves /vendors route', { tag: ['@lite', '@admin'] }, async ({ browser }) => {
         const { ctx, page } = await openAdminRoute(browser, '/vendors');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors/);
         await page.close();
         await ctx.close();

--- a/tests/pw/tests/e2e/announcements/announcements.spec.ts
+++ b/tests/pw/tests/e2e/announcements/announcements.spec.ts
@@ -1,8 +1,11 @@
 import { test, expect } from '@utils/test';
+import { request } from '@playwright/test';
 import { AnnouncementsPage } from './announcementsPage';
 import path from 'path';
 
 import { toPath } from '@utils/helpers';
+import { ApiUtils } from '@utils/apiUtils';
+import { payloads } from '@utils/payloads';
 
 // ============================================
 // SESSION STORAGE VARIABLES
@@ -15,6 +18,18 @@ const v1 = path.join(__dirname, '../../../playwright/.auth/vendorStorageState.js
 // ============================================
 
 test.describe('Announcements Tests @pro', () => {
+    // Wipe accumulated announcements before this file's tests run. The legacy
+    // admin list paginates (10/page) and sorts by date desc — once the table
+    // grows past a few hundred rows (especially with scheduled-in-the-future
+    // rows that pin to the top), freshly-published rows from these tests fall
+    // off page 1 and the `<strong>title</strong>` selectors stop finding them.
+    test.beforeAll(async () => {
+        const apiUtils = new ApiUtils(await request.newContext());
+        await apiUtils.deleteAllAnnouncements(payloads.adminAuth);
+        await apiUtils.dispose();
+    });
+
+
     // ============================================
     // TEST CASES
     // ============================================

--- a/tests/pw/tests/e2e/announcements/announcementsPage.ts
+++ b/tests/pw/tests/e2e/announcements/announcementsPage.ts
@@ -351,15 +351,32 @@ export class AnnouncementsPage {
         ]);
         await this.page.waitForLoadState('load');
 
-        // saveAsDraft stays on the edit form; navigate back to the announcement list
-        await this.goToAnnouncementsPage();
-        // Default tab is "All" which is paginated; a freshly-created draft
-        // can land beyond page 1 depending on existing-data ordering. Switch
-        // to the Draft tab so the new draft is guaranteed on page 1.
-        await Promise.all([
-            this.page.waitForResponse(res => res.url().includes('dokan/v1/announcement') && res.status() === 200).catch(() => null),
-            this.page.locator(this.admin.navTabs.draft).click(),
-        ]);
+        // saveAsDraft stays on the edit form; navigate directly to the Draft
+        // tab via the hash route. Default tab is "All" which is paginated, so
+        // a freshly-created draft can land beyond page 1 in a dirty DB; the
+        // Draft filter sorts the new row to page 1.
+        //
+        // Why goto() and not navTabs.draft.click(): the tab click races the
+        // post-navigate re-render — the table loader overlay appears AFTER
+        // any pre-click wait runs (when the React shell starts fetching) and
+        // intercepts pointer events for 15s. A hash-route navigation triggers
+        // the same Vue/React routing without the actionability race.
+        await this.page.goto(toPath(`wp-admin/admin.php?page=dokan#/announcement?status=draft`));
+        await this.page.waitForLoadState('load');
+        // Mirror goToAnnouncementsPage's table-ready wait. A hash-route nav
+        // resolves before the Vue list re-fetches with the new filter, so a
+        // straight visibility assertion races the fetch.
+        await this.page.waitForFunction(
+            () => {
+                const table = document.querySelector('table.wp-list-table');
+                if (!table) return false;
+                const tbody = table.querySelector('tbody');
+                if (!tbody) return false;
+                return tbody.querySelectorAll('tr').length > 0 || !!tbody.querySelector('.no-items');
+            },
+            null,
+            { timeout: 15000 },
+        );
         // Draft items render as <a> wrapped in <strong>; announcementCell
         // walks up from the inner <a> to the <td>.
         await expect(this.page.locator(this.admin.announcementCell(title))).toBeVisible();
@@ -623,8 +640,11 @@ export class AnnouncementsPage {
         await this.page.goto(this.adminNewDashboard.announcementsUrl);
         await this.page.waitForLoadState('domcontentloaded');
 
+        // The status text can appear in column header + badge cells; use
+        // .first() to avoid strict-mode violations when more than one
+        // matching node is rendered.
         await expect(
-            this.page.getByText('Scheduled', { exact: true }),
+            this.page.getByText('Scheduled', { exact: true }).first(),
             'Text "Scheduled" should be visible on the page',
         ).toBeVisible();
 
@@ -634,8 +654,17 @@ export class AnnouncementsPage {
     async trashAnnouncementByTitle(title: string) {
         await this.page.locator(this.adminNewDashboard.rowActionButton(title)).click();
         await this.page.locator(this.adminNewDashboard.moveToTrash).click();
-        await this.page.locator(this.adminNewDashboard.confirmTrash).click();
+        // The confirm fires a REST mutation; the table then refetches.
+        // Sequential trash calls used to race the loader and the next row's
+        // Actions button became unclickable.
+        await Promise.all([
+            this.page.waitForResponse(res => res.url().includes('dokan/v1/announcement') && res.status() < 400),
+            this.page.locator(this.adminNewDashboard.confirmTrash).click(),
+        ]);
         await this.page.waitForLoadState('domcontentloaded');
+        // Wait for the post-mutation table re-render to settle before any
+        // follow-up Actions-button click on the same view.
+        await expect(this.page.locator('.loading')).toBeHidden({ timeout: 15000 });
     }
 
     async trashAndPermanentlyDeleteAnnouncementsInNewAdminDashboard() {

--- a/tests/pw/tests/e2e/brand-filter/brandFilter.spec.ts
+++ b/tests/pw/tests/e2e/brand-filter/brandFilter.spec.ts
@@ -22,9 +22,12 @@ test.describe('Product Brand Filter (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`shop/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/commission/commissionPage.ts
+++ b/tests/pw/tests/e2e/commission/commissionPage.ts
@@ -87,20 +87,27 @@ export class CommissionPage {
             .locator('div.nav-tab')
             .filter({ has: this.page.locator('div.nav-title', { hasText: /^\s*Selling Options\s*$/ }) });
 
-        // Do NOT force the click. If the tab fails actionability, the Vue
-        // settings shell hasn't fully mounted and a forced click would fire on
-        // inert markup — the click event dispatches but Vue's handler doesn't
-        // react, leaving the commission form unrendered and the dropdown wait
-        // timing out. Retry click + render-check together so a transiently-
-        // inert tab doesn't poison the run.
-        await expect(async () => {
-            await tab.click();
-            // Proof that the click registered AND Vue rendered the panel:
-            // the outer `.nav-tab` gains `.nav-tab-active` and the commission
-            // form mounts.
-            await expect(tabContainer).toHaveClass(/\bnav-tab-active\b/, { timeout: 2000 });
-            await this.page.locator(this.admin.commissionTypeDropdown).waitFor({ state: 'visible', timeout: 5000 });
-        }).toPass({ timeout: 20000 });
+        // The Vue settings shell persists the last active tab across navigations.
+        // If Selling Options is already active on entry, clicking it is a no-op
+        // (no class change → no re-render trigger), which used to leave the
+        // dropdown wait spinning while Vue was still mid-mount.
+        const alreadyActive = await tabContainer.evaluate(el => el.classList.contains('nav-tab-active'));
+        if (!alreadyActive) {
+            // Do NOT force the click. If the tab fails actionability, the Vue
+            // settings shell hasn't fully mounted and a forced click would fire
+            // on inert markup — the click event dispatches but Vue's handler
+            // doesn't react, leaving the commission form unrendered. Retry
+            // click + class-check together so a transiently-inert tab doesn't
+            // poison the run.
+            await expect(async () => {
+                await tab.click();
+                await expect(tabContainer).toHaveClass(/\bnav-tab-active\b/, { timeout: 2000 });
+            }).toPass({ timeout: 20000 });
+        }
+
+        // Whether we clicked or skipped, the dropdown is the real signal that
+        // Vue has finished mounting the Selling Options panel.
+        await this.page.locator(this.admin.commissionTypeDropdown).waitFor({ state: 'visible', timeout: 30000 });
     }
 
     async selectCommissionType(value: string) {

--- a/tests/pw/tests/e2e/export-import/exportImport.spec.ts
+++ b/tests/pw/tests/e2e/export-import/exportImport.spec.ts
@@ -24,9 +24,12 @@ test.describe('Vendor Export/Import (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/tools/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/follow-store/followStore.spec.ts
+++ b/tests/pw/tests/e2e/follow-store/followStore.spec.ts
@@ -167,9 +167,12 @@ test.describe('Follow Store Vendor (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/followers/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/frontend-badges/frontendBadges.spec.ts
+++ b/tests/pw/tests/e2e/frontend-badges/frontendBadges.spec.ts
@@ -22,9 +22,12 @@ test.describe('Frontend Vendor Badges (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`store/vendor1/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/license/license.spec.ts
+++ b/tests/pw/tests/e2e/license/license.spec.ts
@@ -63,7 +63,7 @@ test.describe('Admin License Manager (React) Tests @pro', () => {
     test('Test Case 1 - License manager page renders', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-license`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/license`));
         await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -75,11 +75,14 @@ test.describe('Admin License Manager (React) Tests @pro', () => {
     test('Test Case 2 - License page renders content', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-license`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/license`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/live-chat/liveChat.spec.ts
+++ b/tests/pw/tests/e2e/live-chat/liveChat.spec.ts
@@ -122,9 +122,12 @@ test.describe('Live Chat (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/inbox/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/manual-order-pro/manualOrderPro.spec.ts
+++ b/tests/pw/tests/e2e/manual-order-pro/manualOrderPro.spec.ts
@@ -24,9 +24,12 @@ test.describe('Pro Manual Order (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/orders/?manual_order=1`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/new-coupons/newCoupons.spec.ts
+++ b/tests/pw/tests/e2e/new-coupons/newCoupons.spec.ts
@@ -92,9 +92,12 @@ test.describe('Vendor Coupons (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/coupons/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/onboarding/onboarding.spec.ts
+++ b/tests/pw/tests/e2e/onboarding/onboarding.spec.ts
@@ -4,13 +4,13 @@ import path from 'path';
 const a1 = path.join(__dirname, '../../../playwright/.auth/adminStorageState.json');
 import { toPath } from '@utils/helpers';
 
-// Admin Onboarding Wizard (React) — admin React surface in Dokan 5.0.0+. Mount URL: /wp-admin/admin.php?page=dokan-onboard
+// Admin Onboarding Wizard (React) — admin React surface in Dokan 5.0.0+. Mount URL: /wp-admin/admin.php?page=dokan-setup
 
 test.describe('Admin Onboarding Wizard (React) Tests @pro', () => {
     test('Test Case 1 - Page renders without fatal', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-onboard`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-setup`));
         await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -22,11 +22,14 @@ test.describe('Admin Onboarding Wizard (React) Tests @pro', () => {
     test('Test Case 2 - Page renders content', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-onboard`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-setup`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/payments/payments.spec.ts
+++ b/tests/pw/tests/e2e/payments/payments.spec.ts
@@ -184,9 +184,12 @@ test.describe('Vendor Payments Settings (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/payment/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/printful/printful.spec.ts
+++ b/tests/pw/tests/e2e/printful/printful.spec.ts
@@ -79,9 +79,12 @@ test.describe('Printful (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/printful/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/product-addons/productAddons.spec.ts
+++ b/tests/pw/tests/e2e/product-addons/productAddons.spec.ts
@@ -131,9 +131,12 @@ test.describe('Product Add-ons (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/addon/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/product-bulk-edit/productBulkEdit.spec.ts
+++ b/tests/pw/tests/e2e/product-bulk-edit/productBulkEdit.spec.ts
@@ -24,9 +24,12 @@ test.describe('Product Bulk Edit (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/products/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/product-qa/productQA.spec.ts
+++ b/tests/pw/tests/e2e/product-qa/productQA.spec.ts
@@ -185,9 +185,12 @@ test.describe('Product Q&A (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/product-questions-answers/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/product-reviews/productReviews.spec.ts
+++ b/tests/pw/tests/e2e/product-reviews/productReviews.spec.ts
@@ -78,7 +78,7 @@ test.describe('Vendor Reviews (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/reviews/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         const fatal = await page.locator("text=/Fatal error|Parse error|There has been a critical error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal, 'Reviews page should not show a PHP fatal').toBe(false);
@@ -91,7 +91,7 @@ test.describe('Vendor Reviews (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/reviews/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         const tableVisible = await page.locator('table, [role="table"]').first().isVisible({ timeout: 3000 }).catch(() => false);
         const emptyVisible = await page.locator("text=/no reviews|nothing to show|empty/i").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -106,7 +106,7 @@ test.describe('Vendor Reviews (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/reviews/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         await expect(
             page.locator("h1, h2, h3").filter({ hasText: /reviews?/i }).first(),
@@ -122,9 +122,9 @@ test.describe('Vendor Reviews (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/reviews/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         const fatal = await page.locator("text=/Fatal error|Parse error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);
         await page.close();

--- a/tests/pw/tests/e2e/product-tabs/productTabs.spec.ts
+++ b/tests/pw/tests/e2e/product-tabs/productTabs.spec.ts
@@ -22,9 +22,12 @@ test.describe('Product Tabs (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`product/p1_v1-simple/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/product-variations/productVariations.spec.ts
+++ b/tests/pw/tests/e2e/product-variations/productVariations.spec.ts
@@ -24,9 +24,12 @@ test.describe('Product Variations Editor (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/new/#/products/create`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/refunds/refunds.spec.ts
+++ b/tests/pw/tests/e2e/refunds/refunds.spec.ts
@@ -88,9 +88,12 @@ test.describe('Admin Refunds (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan#/refund`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/request-for-quotes/requestForQuotes.spec.ts
+++ b/tests/pw/tests/e2e/request-for-quotes/requestForQuotes.spec.ts
@@ -188,10 +188,14 @@ test.describe('Request For Quotes (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/requested-quotes/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
         // Page may show a heading-only screen with "you haven't received any quotes" copy.
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length, 'RFQ page should render some content').toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+                message: 'RFQ page should render some content',
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/setup-guide/setupGuide.spec.ts
+++ b/tests/pw/tests/e2e/setup-guide/setupGuide.spec.ts
@@ -78,10 +78,14 @@ test.describe('Admin Setup Guide (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/setup`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
         // Just verify the body has content (not a blank page).
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length, 'Setup guide page should not be blank').toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+                message: 'Setup guide page should not be blank',
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/single-store/singleStore.spec.ts
+++ b/tests/pw/tests/e2e/single-store/singleStore.spec.ts
@@ -51,9 +51,12 @@ test.describe('Single Store Front-end (React-aware) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`store/vendor1/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/social-linking/socialLinking.spec.ts
+++ b/tests/pw/tests/e2e/social-linking/socialLinking.spec.ts
@@ -24,9 +24,12 @@ test.describe('Vendor Social Linking (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/social/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/spmv/spmv.spec.ts
+++ b/tests/pw/tests/e2e/spmv/spmv.spec.ts
@@ -110,9 +110,12 @@ test.describe('SPMV (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan#/spmv`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/store-listing/storeListing.spec.ts
+++ b/tests/pw/tests/e2e/store-listing/storeListing.spec.ts
@@ -56,9 +56,12 @@ test.describe('Store Listing Front-end (React-aware) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`store-listing/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/store-seo/storeSeo.spec.ts
+++ b/tests/pw/tests/e2e/store-seo/storeSeo.spec.ts
@@ -24,9 +24,12 @@ test.describe('Store SEO (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/seo/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/store-supports/storeSupports.spec.ts
+++ b/tests/pw/tests/e2e/store-supports/storeSupports.spec.ts
@@ -176,7 +176,7 @@ test.describe('Store Supports (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/support/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         const fatal = await page.locator("text=/Fatal error|Parse error|There has been a critical error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);
         await page.close();
@@ -188,7 +188,7 @@ test.describe('Store Supports (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/support/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         const tableVisible = await page.locator('table, [role="table"]').first().isVisible({ timeout: 3000 }).catch(() => false);
         const emptyVisible = await page.locator("text=/no tickets|no support|nothing/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(tableVisible || emptyVisible).toBe(true);
@@ -199,9 +199,9 @@ test.describe('Store Supports (React) Tests @pro', () => {
     test('Test Case 3 - Admin support page renders', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/edit.php?post_type=dokan_store_support`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/admin-store-support`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);
         await page.close();
@@ -213,9 +213,9 @@ test.describe('Store Supports (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/support/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         const fatal = await page.locator("text=/Fatal error|Parse error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);
         await page.close();

--- a/tests/pw/tests/e2e/stores/stores.spec.ts
+++ b/tests/pw/tests/e2e/stores/stores.spec.ts
@@ -70,7 +70,7 @@ test.describe('Admin Vendors (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/vendors`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors/);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);
@@ -83,7 +83,7 @@ test.describe('Admin Vendors (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/vendors`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         const tableVisible = await page.locator('table, [role="table"], [class*="dataviews"]').first().isVisible({ timeout: 3000 }).catch(() => false);
         expect(tableVisible, 'Vendors page should show a DataViews table').toBe(true);
         await page.close();
@@ -95,7 +95,7 @@ test.describe('Admin Vendors (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/vendors/create`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors\/create/);
         // Form should have a name / username input
         const formInput = page.locator('input[type="text"], input[type="email"]');
@@ -109,9 +109,9 @@ test.describe('Admin Vendors (React) Tests @lite', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/vendors`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toMatch(/#\/vendors/);
         await page.close();
         await ctx.close();
@@ -123,7 +123,7 @@ test.describe('Admin Vendors (React) Tests @lite', () => {
         const vendorId = process.env.VENDOR_ID || '1';
         await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/vendors/${vendorId}`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-admin-dashboard .pui-root').first()).toBeVisible({ timeout: 30_000 });
         expect(page.url()).toContain('#/vendors/');
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal).toBe(false);

--- a/tests/pw/tests/e2e/table-rate-shipping/tableRateShipping.spec.ts
+++ b/tests/pw/tests/e2e/table-rate-shipping/tableRateShipping.spec.ts
@@ -24,9 +24,12 @@ test.describe('Table Rate Shipping (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/shipping`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-analytics/vendorAnalytics.spec.ts
+++ b/tests/pw/tests/e2e/vendor-analytics/vendorAnalytics.spec.ts
@@ -64,9 +64,12 @@ test.describe('Vendor Analytics (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/analytics/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-auction/vendorAuction.spec.ts
+++ b/tests/pw/tests/e2e/vendor-auction/vendorAuction.spec.ts
@@ -100,9 +100,12 @@ test.describe('Vendor Auction (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/auction/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-booking/vendorBooking.spec.ts
+++ b/tests/pw/tests/e2e/vendor-booking/vendorBooking.spec.ts
@@ -115,9 +115,12 @@ test.describe('Vendor Booking (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/booking/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-delivery-time/vendorDeliveryTime.spec.ts
+++ b/tests/pw/tests/e2e/vendor-delivery-time/vendorDeliveryTime.spec.ts
@@ -84,9 +84,12 @@ test.describe('Vendor Delivery Time (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/delivery-time-dashboard/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });
@@ -117,9 +120,12 @@ test.describe('Delivery Time Front-end (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`product/p1_v1-simple/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(4000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-reports-admin/vendorReportsAdmin.spec.ts
+++ b/tests/pw/tests/e2e/vendor-reports-admin/vendorReportsAdmin.spec.ts
@@ -49,7 +49,7 @@ test.describe('Admin Vendor Reports (React) Tests @pro', () => {
     test('Test Case 1 - Admin reports page renders', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan_reports`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/reports`));
         await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -61,11 +61,14 @@ test.describe('Admin Vendor Reports (React) Tests @pro', () => {
     test('Test Case 2 - Admin reports page renders content', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan_reports`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/reports`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-reports/vendorReports.spec.ts
+++ b/tests/pw/tests/e2e/vendor-reports/vendorReports.spec.ts
@@ -89,9 +89,12 @@ test.describe('Vendor Reports (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/reports/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-return-request/vendorReturnRequest.spec.ts
+++ b/tests/pw/tests/e2e/vendor-return-request/vendorReturnRequest.spec.ts
@@ -96,9 +96,12 @@ test.describe('Vendor Return Request (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/return-request/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-shipping/vendorShipping.spec.ts
+++ b/tests/pw/tests/e2e/vendor-shipping/vendorShipping.spec.ts
@@ -48,7 +48,7 @@ test.describe('Vendor Shipping (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/shipping`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         const fatal = await page.locator("text=/Fatal error|Parse error|There has been a critical error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal, 'Vendor shipping page should not show a PHP fatal').toBe(false);
@@ -61,7 +61,7 @@ test.describe('Vendor Shipping (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/shipping`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         // Either React zone list (e.g. .dokan-shipping-zones) or legacy table (.shipping-method-table)
         const reactZones = await page.locator('[class*="shipping-zone"], [class*="ShippingZone"], .dokan-react-shipping').first().isVisible({ timeout: 3000 }).catch(() => false);
@@ -81,7 +81,7 @@ test.describe('Vendor Shipping (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/shipping`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
 
         // Look for shipping-policy related text
         const policyVisible = await page.locator("text=/shipping policy|policy|refund/i").first().isVisible({ timeout: 3000 }).catch(() => false);
@@ -97,9 +97,9 @@ test.describe('Vendor Shipping (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/shipping`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
+        await expect(page.locator('#dokan-vendor-dashboard-layout-root')).toBeVisible({ timeout: 30_000 });
         const fatal = await page.locator("text=/Fatal error|Parse error/i").first().isVisible({ timeout: 1000 }).catch(() => false);
         expect(fatal, 'Reload should not crash the shipping page').toBe(false);
         await page.close();

--- a/tests/pw/tests/e2e/vendor-staff/vendorStaff.spec.ts
+++ b/tests/pw/tests/e2e/vendor-staff/vendorStaff.spec.ts
@@ -99,9 +99,12 @@ test.describe('Vendor Staff (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/vendor-staff/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-subscriptions/vendorSubscriptions.spec.ts
+++ b/tests/pw/tests/e2e/vendor-subscriptions/vendorSubscriptions.spec.ts
@@ -126,9 +126,12 @@ test.describe('Vendor Subscriptions (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/user-subscription/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-tools/vendorTools.spec.ts
+++ b/tests/pw/tests/e2e/vendor-tools/vendorTools.spec.ts
@@ -68,9 +68,12 @@ test.describe('Vendor Tools (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/tools/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/vendor-verifications/vendorVerifications.spec.ts
+++ b/tests/pw/tests/e2e/vendor-verifications/vendorVerifications.spec.ts
@@ -185,9 +185,12 @@ test.describe('Vendor Verifications (React) Tests @pro', () => {
         const page = await ctx.newPage();
         await page.goto(toPath(`dashboard/settings/verification/`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });
@@ -204,7 +207,7 @@ test.describe('Admin Vendor Verifications (React) Tests @pro', () => {
     test('Test Case 1 - Page renders without fatal', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-vendor-verification`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/verifications`));
         await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -216,11 +219,14 @@ test.describe('Admin Vendor Verifications (React) Tests @pro', () => {
     test('Test Case 2 - Page renders content', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/admin.php?page=dokan-vendor-verification`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/verifications`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });

--- a/tests/pw/tests/e2e/wholesale/wholesale.spec.ts
+++ b/tests/pw/tests/e2e/wholesale/wholesale.spec.ts
@@ -156,7 +156,7 @@ test.describe('Wholesale (React) Tests @pro', () => {
     test('Test Case 1 - Admin wholesale customer page renders', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/users.php?page=wholesale_customer`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/wholesale-customer`));
         await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
         const fatal = await page.locator(".notice-error, body.error-page").first().isVisible({ timeout: 1000 }).catch(() => false);
@@ -168,11 +168,14 @@ test.describe('Wholesale (React) Tests @pro', () => {
     test('Test Case 2 - Wholesale page renders content', { tag: ['@pro', '@admin'] }, async ({ browser }) => {
         const ctx = await browser.newContext({ storageState: a1 });
         const page = await ctx.newPage();
-        await page.goto(toPath(`wp-admin/users.php?page=wholesale_customer`));
+        await page.goto(toPath(`wp-admin/admin.php?page=dokan-dashboard#/wholesale-customer`));
         await page.waitForLoadState('domcontentloaded');
-        await page.waitForTimeout(3000);
-        const bodyText = await page.locator('body').innerText();
-        expect(bodyText.trim().length).toBeGreaterThan(50);
+        await expect
+            .poll(async () => (await page.locator('body').innerText()).trim().length, {
+                timeout: 30_000,
+                intervals: [500, 1000, 2000, 3000],
+            })
+            .toBeGreaterThan(50);
         await page.close();
         await ctx.close();
     });


### PR DESCRIPTION
- Sweep one-shot body-length checks in 37 React Test Case 2s into expect.poll (30s timeout, retry intervals) — same > 50 assertion, elastic wait.
- Replace fixed waitForTimeout(2000) admin-shell sleeps in admin.spec.ts (13) and stores.spec.ts (6) with expect(#dokan-admin-dashboard .pui-root).toBeVisible({timeout:30_000}).
- vendor-shipping.spec.ts (5), store-supports.spec.ts (4 vendor + 1 admin), product-reviews.spec.ts (5): replace sleeps with #dokan-vendor-dashboard-layout-root visibility wait.
- store-supports.spec.ts TC3: dead admin URL wp-admin/edit.php?post_type=dokan_store_support (Sorry, not allowed) → admin.php?page=dokan-dashboard#/admin-store-support.
- Fix Dokan 5.0.0 URL rot in 5 React Test Case 1/2s: license, vendor-reports-admin, wholesale, vendor-verifications, onboarding (slugs consolidated under dokan-dashboard HashRouter routes; onboarding now dokan-setup).
- abuseReportsPage.ts: 3 isSettings/Reported/Reasons isVisible() methods → waitFor({state:'visible'}) (throws on timeout, no swallow). Fixes Old TC4 + TC5 race where searchSettings only waited for h2, not h3.
- announcementsPage.ts trashAnnouncementByTitle: pair confirm click with waitForResponse + wait for .loading overlay to be hidden, so sequential trashes don't race the table refresh.
- announcementsPage.ts addAnnouncementAsDraft: replace flaky nav-tab click (loader overlay intercepts pointer events) with direct hash-route goto to ?status=draft + mirror goToAnnouncementsPage's table-ready wait.
- verifyScheduledStatusVisibleInNewAdminDashboard: add .first() to resolve strict-mode violation when multiple Scheduled badges render.
- announcements.spec.ts beforeAll: apiUtils.deleteAllAnnouncements at start — the legacy paginated list (10/page, sort by next-publish date desc with future-dated scheduled rows pinning page 1) had grown to 183 rows across 19 pages, burying freshly-published rows past page 1.
- commissionPage.ts openSellingOptionsTab: skip tab.click() when Vue has already restored Selling Options as the active tab (clicking active is a no-op so the dropdown wait spins); always wait on the dropdown as the real signal with 30s timeout.

No assertions weakened, no .catch swallows, no try/catch wrappers. All waits throw on timeout so real feature breakage still surfaces.

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes #


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

*Title*

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Improved E2E test reliability by replacing fixed timeouts with dynamic content polling assertions across multiple test suites for more stable test execution
  * Updated test navigation to reference current React-based application routes and dashboard endpoints
  * Enhanced test element visibility checks to wait for React component mounting indicators
  * Added API-level test setup hooks for improved test data cleanup and isolation between test runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->