### PR TITLE
feat(settings): add dokan()->settings read-only accessor (PR 1/N)

### DIFF
--- a/docs/settings/accessing.md
+++ b/docs/settings/accessing.md
@@ -13,11 +13,13 @@ $value = dokan()->settings->get( 'vendor_store_url' );
 ```php
 dokan()->settings->get( string $key, $fallback = null );
 dokan()->settings->has( string $key ): bool;
+dokan()->settings->has_stored( string $key ): bool;
 dokan()->settings->all(): array;
 ```
 
 - `$key` is the flat schema id (the `id` field on a `SettingsElement` in `includes/Admin/Settings/Schema/SettingsSchema.php`). It is **not** the legacy section/field name from `dokan_get_option()`.
 - `$fallback` is only used when `$key` is not registered in the schema. For registered keys the schema default is authoritative — do not pass a `$fallback` to override it.
+- `has()` checks whether the id is **registered** in the schema. `has_stored()` checks whether a **user-set value** exists in storage (the new flat option, or — via the legacy bridge — a mapped per-section option). Use `has_stored()` when you need to distinguish a user choice from a schema default falling through — e.g. to preserve a runtime fallback that depends on another setting.
 - `all()` returns every registered field's effective value (stored value, or schema default when nothing is stored), keyed by id.
 
 ## Choosing the right key

--- a/docs/settings/accessing.md
+++ b/docs/settings/accessing.md
@@ -1,0 +1,46 @@
+# Accessing settings
+
+> Available since **DOKAN_SINCE**.
+
+Dokan exposes a single, schema-aware, read-only API for reading settings from any PHP code in the plugin or in extensions:
+
+```php
+$value = dokan()->settings->get( 'vendor_store_url' );
+```
+
+## API
+
+```php
+dokan()->settings->get( string $key, $fallback = null );
+dokan()->settings->has( string $key ): bool;
+dokan()->settings->all(): array;
+```
+
+- `$key` is the flat schema id (the `id` field on a `SettingsElement` in `includes/Admin/Settings/Schema/SettingsSchema.php`). It is **not** the legacy section/field name from `dokan_get_option()`.
+- `$fallback` is only used when `$key` is not registered in the schema. For registered keys the schema default is authoritative — do not pass a `$fallback` to override it.
+- `all()` returns every registered field's effective value (stored value, or schema default when nothing is stored), keyed by id.
+
+## Choosing the right key
+
+For new code: look up the field id in `includes/Admin/Settings/Schema/SettingsSchema.php`. Use the `id` attribute.
+
+For code migrating away from `dokan_get_option( $field, $section )`: find the schema entry whose `legacy_key` matches `($section, $field)`. The flat id you want is on the `id` attribute of that entry. The migration may also need a comparison-logic flip if the field uses a `legacy_transformer` (see the spec).
+
+## Writes
+
+Writes are **not** part of this API. The admin save pipeline continues to go through the REST controller and `SettingsRepository::update()`. Programmatic writes from code are out of scope and tracked in a follow-up design.
+
+## Examples
+
+```php
+// Read with the schema default applied.
+$slug = dokan()->settings->get( 'vendor_store_url' );
+
+// Existence check.
+if ( dokan()->settings->has( 'recaptcha_site_key' ) ) {
+    // ...
+}
+
+// Snapshot of all settings.
+$snapshot = dokan()->settings->all();
+```

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -28,6 +28,13 @@ class SettingsRegistry {
     private ?array $cache = null;
 
     /**
+     * Lazy id-keyed index of field elements. Null until first {@see find_field()} call.
+     *
+     * @var array<string,array>|null
+     */
+    private ?array $field_index = null;
+
+    /**
      * Settings repository — single read surface for the stored payload.
      *
      * @var SettingsRepositoryInterface
@@ -93,7 +100,51 @@ class SettingsRegistry {
      * @since DOKAN_SINCE
      */
     public function clear_cache(): void {
-        $this->cache = null;
+        $this->cache       = null;
+        $this->field_index = null;
+    }
+
+    /**
+     * Find a registered field element by its flat schema id.
+     *
+     * Returns the element array as it appears in {@see get_schema()} — i.e.
+     * with `value` populated via the bridge overlay and `default` filled.
+     * Returns null for unknown ids or for non-`field` elements (structural
+     * nodes share the id-space but are intentionally excluded).
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $id Flat schema id.
+     *
+     * @return array|null
+     */
+    public function find_field( string $id ): ?array {
+        if ( null === $this->field_index ) {
+            $this->build_field_index();
+        }
+        return $this->field_index[ $id ] ?? null;
+    }
+
+    /**
+     * Build the id-keyed field index from the processed schema.
+     *
+     * Structural elements (pages, sections, tabs, etc.) are excluded — only
+     * elements with `type: field` participate.
+     *
+     * @return void
+     */
+    private function build_field_index(): void {
+        $this->field_index = [];
+        foreach ( $this->get_schema() as $element ) {
+            if ( ( $element['type'] ?? '' ) !== 'field' ) {
+                continue;
+            }
+            $id = $element['id'] ?? '';
+            if ( '' === $id ) {
+                continue;
+            }
+            $this->field_index[ $id ] = $element;
+        }
     }
 
     /**

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WeDevs\Dokan\Admin\Settings\Schema;
 
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepositoryInterface;
 
@@ -58,6 +59,62 @@ class SettingsRegistry {
      */
     public function __construct( ?SettingsRepositoryInterface $settings_repo = null ) {
         $this->settings_repo = $settings_repo ?? new SettingsRepository();
+        $this->register_cache_invalidation_hooks();
+    }
+
+    /**
+     * Invalidate the processed schema cache whenever its underlying storage
+     * changes. Without this, consumers like {@see SettingsAccessor::get()}
+     * return stale values after any in-request option write.
+     *
+     * Listens to:
+     *   - The new flat option ({@see SettingsRepository::OPTION_KEY}) where
+     *     all admin writes land.
+     *   - Every legacy `dokan_*` section that the bridge knows about — Pro
+     *     and third-party `update_option()` writes against those sections
+     *     would otherwise leave the registry overlay stale.
+     *
+     * @return void
+     */
+    private function register_cache_invalidation_hooks(): void {
+        $new_option = SettingsRepository::OPTION_KEY;
+        add_action( "update_option_{$new_option}", [ $this, 'clear_cache' ] );
+        add_action( "add_option_{$new_option}", [ $this, 'clear_cache' ] );
+
+        if ( ! function_exists( 'dokan_get_container' ) ) {
+            return;
+        }
+        try {
+            $bridge = dokan_get_container()->get( LegacySettingsBridge::class );
+            if ( ! $bridge instanceof LegacySettingsBridge ) {
+                return;
+            }
+        } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            // Bridge not booted yet — fall back to new-flat-option-only invalidation.
+            return;
+        }
+
+        foreach ( $this->known_legacy_sections( $bridge ) as $section ) {
+            add_action( "update_option_{$section}", [ $this, 'clear_cache' ] );
+            add_action( "add_option_{$section}", [ $this, 'clear_cache' ] );
+        }
+    }
+
+    /**
+     * Unique legacy section option names mentioned in the bridge mapping.
+     *
+     * @param LegacySettingsBridge $bridge
+     *
+     * @return array<int,string>
+     */
+    private function known_legacy_sections( LegacySettingsBridge $bridge ): array {
+        $sections = [];
+        foreach ( $bridge->get_mapping() as $entry ) {
+            if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+                $sections[ $entry['option'] ] = true;
+            }
+        }
+        return array_keys( $sections );
     }
 
     /**

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -35,6 +35,16 @@ class SettingsRegistry {
     private ?array $field_index = null;
 
     /**
+     * Lazy set of ids that are present in storage (flat option or via the
+     * legacy bridge overlay). Null until first {@see is_stored()} call.
+     *
+     * Keys are flat schema ids; values are unused (the array is used as a set).
+     *
+     * @var array<string,bool>|null
+     */
+    private ?array $stored_keys = null;
+
+    /**
      * Settings repository — single read surface for the stored payload.
      *
      * @var SettingsRepositoryInterface
@@ -102,6 +112,7 @@ class SettingsRegistry {
     public function clear_cache(): void {
         $this->cache       = null;
         $this->field_index = null;
+        $this->stored_keys = null;
     }
 
     /**
@@ -144,6 +155,56 @@ class SettingsRegistry {
                 continue;
             }
             $this->field_index[ $id ] = $element;
+        }
+    }
+
+    /**
+     * Whether `$id` has a value present in storage (the flat option or, via
+     * the legacy bridge, a mapped per-section legacy option).
+     *
+     * Returns false for unregistered ids, and false when the only "value" the
+     * accessor would return is the schema default. Use this to distinguish a
+     * user-set value from a defaulted one — e.g. when preserving a runtime
+     * fallback that depends on another setting.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $id Flat schema id.
+     *
+     * @return bool
+     */
+    public function is_stored( string $id ): bool {
+        if ( null === $this->stored_keys ) {
+            $this->build_stored_keys();
+        }
+        return isset( $this->stored_keys[ $id ] );
+    }
+
+    /**
+     * Build the set of ids present in storage, applying the same bridge
+     * overlay {@see populate_values()} uses so legacy-only values count
+     * as "stored".
+     *
+     * @return void
+     */
+    private function build_stored_keys(): void {
+        $stored = $this->settings_repo->all();
+
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                $bridge = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class );
+                $stored = $bridge->hydrate_new_from_legacy( $stored );
+            } catch ( \Throwable $unused ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $unused );
+                // Container not booted — fall back to flat-only view.
+            }
+        }
+
+        $this->stored_keys = [];
+        foreach ( array_keys( $stored ) as $id ) {
+            if ( is_string( $id ) && '' !== $id ) {
+                $this->stored_keys[ $id ] = true;
+            }
         }
     }
 

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -69,10 +69,16 @@ class SettingsRegistry {
      *
      * Listens to:
      *   - The new flat option ({@see SettingsRepository::OPTION_KEY}) where
-     *     all admin writes land.
+     *     all admin writes land. Wired immediately — the option name is a
+     *     constant and needs no schema introspection.
      *   - Every legacy `dokan_*` section that the bridge knows about — Pro
      *     and third-party `update_option()` writes against those sections
-     *     would otherwise leave the registry overlay stale.
+     *     would otherwise leave the registry overlay stale. **Deferred to
+     *     `init`** because enumerating the sections requires building the
+     *     bridge map, which harvests {@see SettingsSchema::get_schema()},
+     *     which runs `get_posts()`, which fires `pre_get_posts` hooks that
+     *     in turn read `dokan()->settings`. Doing that from the constructor
+     *     re-enters DI resolution and fatals the request.
      *
      * @return void
      */
@@ -81,6 +87,26 @@ class SettingsRegistry {
         add_action( "update_option_{$new_option}", [ $this, 'clear_cache' ] );
         add_action( "add_option_{$new_option}", [ $this, 'clear_cache' ] );
 
+        if ( ! function_exists( 'did_action' ) ) {
+            return;
+        }
+        if ( did_action( 'init' ) ) {
+            $this->register_legacy_section_hooks();
+            return;
+        }
+        add_action( 'init', [ $this, 'register_legacy_section_hooks' ], 0 );
+    }
+
+    /**
+     * Register `update_option_{section}` / `add_option_{section}` listeners
+     * for every legacy section the bridge knows about. Must run on or after
+     * `init` — see {@see register_cache_invalidation_hooks()} for why.
+     *
+     * Public so it can be invoked as a WP action callback.
+     *
+     * @return void
+     */
+    public function register_legacy_section_hooks(): void {
         if ( ! function_exists( 'dokan_get_container' ) ) {
             return;
         }

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1006,6 +1006,7 @@ class SettingsSchema {
 					'option' => 'dokan_reverse_withdrawal',
 					'field' => 'enabled',
 				],
+                'priority'    => 50,
             ],
             [
                 'id'          => 'reverse_withdrawal_billing_type',
@@ -1215,6 +1216,52 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
+            self::reverse_withdrawal_payment_gateways_field(),
+        ];
+    }
+
+    /**
+     * Build the `reverse_withdrawal_payment_gateways` multicheck field.
+     *
+     * Options are derived from the `dokan_reverse_withdrawal_payment_gateways`
+     * filter (the same source the legacy {@see SettingsHelper::get_reverse_withrawal_payment_gateways()}
+     * uses) so Pro modules / extensions that already extend that filter continue
+     * to register gateways with one declaration. The new field stores a flat
+     * list of selected gateway ids; each slot bridges through
+     * {@see MulticheckArrayTransformer} to the legacy WP-multicheck shape under
+     * `dokan_reverse_withdrawal.payment_gateways`.
+     *
+     * @return array
+     */
+    private static function reverse_withdrawal_payment_gateways_field(): array {
+        $gateways = apply_filters(
+            'dokan_reverse_withdrawal_payment_gateways',
+            [ 'cod' => esc_html__( 'Cash on delivery', 'dokan-lite' ) ]
+        );
+
+        $options    = [];
+        $legacy_key = [];
+        foreach ( $gateways as $value => $label ) {
+            $options[]            = [
+                'value' => (string) $value,
+                'label' => (string) $label,
+            ];
+            $legacy_key[ $value ] = 'dokan_reverse_withdrawal.payment_gateways.' . $value;
+        }
+        $slot_keys = array_keys( $legacy_key );
+
+        return [
+            'id'                 => 'reverse_withdrawal_payment_gateways',
+            'type'               => 'field',
+            'variant'            => 'multicheck',
+            'section_id'         => 'reverse_withdrawal_section',
+            'title'              => esc_html__( 'Enable Reverse Withdrawal for this Gateway', 'dokan-lite' ),
+            'description'        => esc_html__( 'Check the payment gateways you want to enable reverse withdrawal for. For now, only cash on delivery is available.', 'dokan-lite' ),
+            'options'            => $options,
+            'default'            => [ 'cod' ],
+            'legacy_key'         => $legacy_key,
+            'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
+            'priority'           => 70,
         ];
     }
 

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -151,7 +151,7 @@ class SettingsSchema {
                 'subpage_id' => 'marketplace',
             ],
             [
-                'id'              => 'vendor_store_url',
+                'id'              => 'vendor_store_url_slug',
                 'type'            => 'field',
                 'variant'         => 'text',
                 'section_id'      => 'marketplace_settings',
@@ -1195,7 +1195,7 @@ class SettingsSchema {
                 ),
             ],
             [
-                'id'            => 'display_notice',
+                'id'            => 'reverse_withdrawal_grace_period_notice',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'display_notice',
@@ -1285,7 +1285,7 @@ class SettingsSchema {
                 'doc_link'    => 'https://wedevs.com/docs/dokan-lite/vendor-onboarding/',
             ],
             [
-                'id'            => 'enable_selling',
+                'id'            => 'vendor_auto_enable_selling',
                 'type'          => 'field',
                 'variant'       => 'radio_capsule',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1301,7 +1301,7 @@ class SettingsSchema {
 
             ],
             [
-                'id'            => 'address_fields',
+                'id'            => 'vendor_registration_address_fields',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1349,7 +1349,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'welcome_wizard',
+                'id'            => 'vendor_welcome_wizard_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1408,7 +1408,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'product_popup',
+                'id'            => 'vendor_new_product_popup',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'vendor_capabilities',
@@ -1449,7 +1449,7 @@ class SettingsSchema {
                 'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
             [
-                'id'            => 'order_status_change',
+                'id'            => 'vendor_can_change_order_status',
                 'legacy_key' => [
                     'option' => 'dokan_selling',
                     'field'  => 'order_status_change',
@@ -1524,7 +1524,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'store_product_per_page',
+                'id'          => 'store_products_per_page',
                 'type'        => 'field',
                 'variant'     => 'number',
                 'section_id'  => 'products_page',
@@ -1553,7 +1553,7 @@ class SettingsSchema {
                 'section_id' => 'google_recaptcha',
             ],
             [
-                'id'             => 'recaptcha',
+                'id'             => 'google_recaptcha_enabled',
                 'type'           => 'field',
                 'variant'        => 'switch',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1575,7 +1575,7 @@ class SettingsSchema {
 				],
             ],
             [
-                'id'             => 'recaptcha_info',
+                'id'             => 'google_recaptcha_info',
                 'type'           => 'field',
                 'variant'        => 'info',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1587,7 +1587,7 @@ class SettingsSchema {
                 ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1595,7 +1595,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1605,7 +1605,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_site_key',
+                'id'             => 'google_recaptcha_site_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1614,7 +1614,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1622,7 +1622,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1632,7 +1632,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_secret_key',
+                'id'             => 'google_recaptcha_secret_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1641,7 +1641,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1649,7 +1649,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1666,7 +1666,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_clossing_time_widget',
+                'id'            => 'store_contact_form_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_contact_form_section',
@@ -1714,7 +1714,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'                => 'store_template',
+                'id'                => 'store_header_template',
                 'type'              => 'field',
                 'variant'           => 'customize_radio',
                 'section_id'        => 'store_template',
@@ -1758,7 +1758,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_time_widget',
+                'id'            => 'store_opening_closing_time_widget',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_time_widget_section',
@@ -1786,7 +1786,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_opening_time',
+                'id'            => 'store_sidebar_from_theme',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_sidebar_section',
@@ -1814,7 +1814,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'vendor_info_visibility',
+                'id'          => 'store_page_vendor_info_visibility',
                 'type'        => 'field',
                 'variant'     => 'info_preview',
                 'section_id'  => 'vendor_info_visibility_section',
@@ -1853,7 +1853,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'dokan_font',
+                'id'            => 'dokan_fontawesome_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'dokan_font_section',
@@ -1982,7 +1982,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'privacy_policy_display',
+                'id'            => 'privacy_policy_visibility',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'privacy_settings',
@@ -2038,7 +2038,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'admin_access',
+                'id'            => 'admin_access_for_vendors',
                 'legacy_key' => [
                     'option' => 'dokan_general',
                     'field'  => 'admin_access',
@@ -2118,17 +2118,59 @@ class SettingsSchema {
      */
     private static function ai_assist_page(): array {
         $on_generate = [
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $on_enhance = [
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $when_engine = static function ( string $engine_key, string $value ): array {
             return [
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'show',
+					'comparison' => '===',
+				],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'hide',
+					'comparison' => '!==',
+				],
             ];
         };
 
@@ -2138,7 +2180,10 @@ class SettingsSchema {
         $provider_options = static function ( array $providers ): array {
             $out = [];
             foreach ( $providers as $id => $provider ) {
-                $out[] = [ 'title' => $provider->get_title(), 'value' => (string) $id ];
+                $out[] = [
+					'title' => $provider->get_title(),
+					'value' => (string) $id,
+				];
             }
             return $out;
         };
@@ -2169,18 +2214,24 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ],
             [
-                'id'            => 'product_info_generate',
+                'id'            => 'ai_product_info_generate',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_image_section',
                 'title'         => esc_html__( 'Product Info Generate', 'dokan-lite' ),
                 'description'   => esc_html__( 'Let vendors generate product info by AI.', 'dokan-lite' ),
                 'default'       => 'on',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
             ],
             [
-                'id'           => 'product_info_engine',
+                'id'           => 'ai_product_info_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_image_section',
@@ -2203,7 +2254,7 @@ class SettingsSchema {
                         'provider_id'     => $pid,
                         'provider'        => $provider,
                         'section_id'      => 'product_image_section',
-                        'engine_field_id' => 'product_info_engine',
+                        'engine_field_id' => 'ai_product_info_engine',
                         'toggle_deps'     => $on_generate,
                         'engine_deps'     => $when_engine( 'product_info_engine', $pid ),
                         'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
@@ -2223,19 +2274,25 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ];
             $elements[] = [
-                'id'            => 'product_image_enhancement',
+                'id'            => 'ai_product_image_enhancement',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_description_section',
                 'title'         => esc_html__( 'Product Image Enhancement', 'dokan-lite' ),
                 'description'   => esc_html__( 'Allow vendors to enhance and generate professional product images using AI.', 'dokan-lite' ),
                 'default'       => 'off',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
                 'legacy_key'    => 'dokan_ai.dokan_ai_image_gen_availability',
             ];
             $elements[] = [
-                'id'           => 'product_image_engine',
+                'id'           => 'ai_product_image_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_description_section',
@@ -2330,7 +2387,10 @@ class SettingsSchema {
             try {
                 $models = $provider->get_models_by_type( constant( $model_const ) );
                 foreach ( $models as $model_id => $model ) {
-                    $model_options[] = [ 'title' => $model->get_title(), 'value' => (string) $model_id ];
+                    $model_options[] = [
+						'title' => $model->get_title(),
+						'value' => (string) $model_id,
+					];
                 }
             } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
                 unset( $e );

--- a/includes/Admin/Settings/SettingsAccessor.php
+++ b/includes/Admin/Settings/SettingsAccessor.php
@@ -26,6 +26,11 @@ final class SettingsAccessor implements SettingsAccessorInterface {
 	 */
 	private array $logged_unknown_keys = [];
 
+	/**
+	 * @since DOKAN_SINCE
+	 *
+	 * @param SettingsRegistry $registry
+	 */
 	public function __construct( SettingsRegistry $registry ) {
 		$this->registry = $registry;
 	}
@@ -41,6 +46,8 @@ final class SettingsAccessor implements SettingsAccessorInterface {
 			return $fallback;
 		}
 
+		// The registry's populate_values() always sets 'value'; this guard
+		// handles schema elements injected by extensions that bypass it.
 		if ( array_key_exists( 'value', $field ) ) {
 			return $field['value'];
 		}

--- a/includes/Admin/Settings/SettingsAccessor.php
+++ b/includes/Admin/Settings/SettingsAccessor.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings;
+
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+
+/**
+ * Default {@see SettingsAccessorInterface} implementation.
+ *
+ * Reads are served from {@see SettingsRegistry}, which already overlays the
+ * legacy per-section options via {@see LegacySettingsBridge::hydrate_new_from_legacy()}
+ * during its `populate_values()` step. The accessor adds no read logic of its
+ * own — it just shapes the API.
+ *
+ * @since DOKAN_SINCE
+ */
+final class SettingsAccessor implements SettingsAccessorInterface {
+
+	private SettingsRegistry $registry;
+
+	/**
+	 * Per-request set of unknown ids that have already been logged, used to
+	 * de-duplicate WP_DEBUG notices when a missing key is read in a loop.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $logged_unknown_keys = [];
+
+	public function __construct( SettingsRegistry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get( string $key, $fallback = null ) {
+		$field = $this->registry->find_field( $key );
+
+		if ( null === $field ) {
+			$this->log_unknown_key_once( $key );
+			return $fallback;
+		}
+
+		if ( array_key_exists( 'value', $field ) ) {
+			return $field['value'];
+		}
+
+		return $field['default'] ?? $fallback;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function has( string $key ): bool {
+		return null !== $this->registry->find_field( $key );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function all(): array {
+		$out = [];
+		foreach ( $this->registry->get_schema() as $element ) {
+			if ( ( $element['type'] ?? '' ) !== 'field' ) {
+				continue;
+			}
+			$id = $element['id'] ?? '';
+			if ( '' === $id ) {
+				continue;
+			}
+			if ( array_key_exists( 'value', $element ) ) {
+				$out[ $id ] = $element['value'];
+				continue;
+			}
+			$out[ $id ] = $element['default'] ?? null;
+		}
+		return $out;
+	}
+
+	/**
+	 * Log an unknown key once per request (only when WP_DEBUG is on).
+	 *
+	 * @param string $key
+	 */
+	private function log_unknown_key_once( string $key ): void {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+		if ( isset( $this->logged_unknown_keys[ $key ] ) ) {
+			return;
+		}
+		$this->logged_unknown_keys[ $key ] = true;
+		if ( function_exists( 'dokan_log' ) ) {
+			dokan_log( sprintf( '[settings] unregistered key read via accessor: %s', $key ) );
+		}
+	}
+}

--- a/includes/Admin/Settings/SettingsAccessor.php
+++ b/includes/Admin/Settings/SettingsAccessor.php
@@ -65,6 +65,13 @@ final class SettingsAccessor implements SettingsAccessorInterface {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function has_stored( string $key ): bool {
+		return $this->has( $key ) && $this->registry->is_stored( $key );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function all(): array {
 		$out = [];
 		foreach ( $this->registry->get_schema() as $element ) {

--- a/includes/Admin/Settings/SettingsAccessorInterface.php
+++ b/includes/Admin/Settings/SettingsAccessorInterface.php
@@ -40,6 +40,27 @@ interface SettingsAccessorInterface {
 	public function has( string $key ): bool;
 
 	/**
+	 * Whether `$key` has a value present in storage (the flat option or, via
+	 * the legacy bridge, a mapped per-section legacy option).
+	 *
+	 * Distinct from {@see has()}: a registered key with no stored value
+	 * returns true from `has()` (it's known to the schema) but false from
+	 * `has_stored()` (its effective value comes from the schema default,
+	 * not from a user-set value).
+	 *
+	 * Use this to preserve runtime fallback contracts that depend on whether
+	 * the user explicitly set a value — e.g. "fall back to the product tax
+	 * recipient when shipping_tax_fee_recipient isn't explicitly stored".
+	 *
+	 * @since DOKAN_SINCE
+	 *
+	 * @param string $key Flat schema id.
+	 *
+	 * @return bool
+	 */
+	public function has_stored( string $key ): bool;
+
+	/**
 	 * Snapshot of every registered field's effective value, keyed by id.
 	 *
 	 * @return array<string,mixed>

--- a/includes/Admin/Settings/SettingsAccessorInterface.php
+++ b/includes/Admin/Settings/SettingsAccessorInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings;
+
+/**
+ * Read-only API for accessing Dokan admin settings by their flat schema id.
+ *
+ * Implementations are schema-aware: defaults come from the registered field
+ * definition, and stored values are overlaid via {@see LegacySettingsBridge}
+ * so legacy per-section options remain visible during the migration window.
+ *
+ * @since DOKAN_SINCE
+ */
+interface SettingsAccessorInterface {
+
+	/**
+	 * Read a setting by its flat schema id.
+	 *
+	 * Resolution order:
+	 *   1. If the id is registered, return its overlay-applied value (falling
+	 *      back to the schema default when nothing is stored). The supplied
+	 *      `$fallback` is ignored.
+	 *   2. If the id is not registered, return `$fallback` and (in WP_DEBUG)
+	 *      log the miss once per request per id.
+	 *
+	 * @param string $key      Flat schema id.
+	 * @param mixed  $fallback Returned only when $key is not registered.
+	 *
+	 * @return mixed
+	 */
+	public function get( string $key, $fallback = null );
+
+	/**
+	 * Whether the given id is registered in the schema.
+	 *
+	 * @param string $key Flat schema id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $key ): bool;
+
+	/**
+	 * Snapshot of every registered field's effective value, keyed by id.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function all(): array;
+}

--- a/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
+++ b/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
@@ -35,7 +35,15 @@ class AdminSettingsServiceProvider extends BaseServiceProvider {
      */
 	public function register(): void {
         foreach ( $this->services as $service ) {
-            $definition = $this->share_with_implements_tags( $service );
+            if ( SettingsAccessor::class === $service ) {
+                // SettingsAccessor requires SettingsRegistry; League's
+                // reflection-based auto-resolve cannot satisfy a non-nullable
+                // typed parameter without an explicit binding, so the
+                // dependency is wired here.
+                $definition = $this->share_with_implements_tags( $service )->addArgument( SettingsRegistry::class );
+            } else {
+                $definition = $this->share_with_implements_tags( $service );
+            }
             $this->add_tags( $definition, $this->tags );
         }
     }

--- a/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
+++ b/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
@@ -8,6 +8,7 @@ use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Schema\SchemaValidator;
 use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\Admin\Settings\SettingsAccessor;
 use WeDevs\Dokan\DependencyManagement\BaseServiceProvider;
 
 class AdminSettingsServiceProvider extends BaseServiceProvider {
@@ -26,6 +27,7 @@ class AdminSettingsServiceProvider extends BaseServiceProvider {
         LegacySettingsBridge::class,
         LegacySettingsRepository::class,
         BridgeBootstrap::class,
+        SettingsAccessor::class,
     ];
 
 	/**

--- a/includes/DependencyManagement/Providers/ServiceProvider.php
+++ b/includes/DependencyManagement/Providers/ServiceProvider.php
@@ -96,10 +96,12 @@ class ServiceProvider extends BootableServiceProvider {
 	public function register(): void {
 		foreach ( $this->services as $key => $class_name ) {
 			if ( 'settings' === $key ) {
-				// Alias to the SettingsAccessor binding registered by
-				// AdminSettingsServiceProvider so dokan()->settings and
-				// $container->get(SettingsAccessorInterface::class) return
-				// the same shared instance.
+				// Alias to the shared SettingsAccessor binding registered by
+				// AdminSettingsServiceProvider — without the closure, addShared()
+				// would construct a second instance. dokan()->settings is the
+				// canonical access path; SettingsAccessorInterface is registered
+				// as a tag, not a standalone binding, so it cannot be resolved
+				// directly via $container->get().
 				$this->getContainer()
 					->addShared(
 						$key,

--- a/includes/DependencyManagement/Providers/ServiceProvider.php
+++ b/includes/DependencyManagement/Providers/ServiceProvider.php
@@ -23,6 +23,7 @@ class ServiceProvider extends BootableServiceProvider {
         'product_block'       => \WeDevs\Dokan\Blocks\ProductBlock::class,
         'pageview'            => \WeDevs\Dokan\PageViews::class,
         'seller_wizard'       => \WeDevs\Dokan\Vendor\SetupWizard::class,
+        'settings'            => \WeDevs\Dokan\Admin\Settings\SettingsAccessor::class,
         'core'                => \WeDevs\Dokan\Core::class,
         'scripts'             => \WeDevs\Dokan\Assets::class,
         'email'               => \WeDevs\Dokan\Emails\Manager::class,

--- a/includes/DependencyManagement/Providers/ServiceProvider.php
+++ b/includes/DependencyManagement/Providers/ServiceProvider.php
@@ -95,6 +95,21 @@ class ServiceProvider extends BootableServiceProvider {
      */
 	public function register(): void {
 		foreach ( $this->services as $key => $class_name ) {
+			if ( 'settings' === $key ) {
+				// Alias to the SettingsAccessor binding registered by
+				// AdminSettingsServiceProvider so dokan()->settings and
+				// $container->get(SettingsAccessorInterface::class) return
+				// the same shared instance.
+				$this->getContainer()
+					->addShared(
+						$key,
+						function () use ( $class_name ) {
+							return $this->getContainer()->get( $class_name );
+						}
+					)
+					->addTag( self::TAG );
+				continue;
+			}
 			$this->getContainer()->addShared( $key, $class_name )->addTag( self::TAG );
 		}
     }

--- a/includes/Fees.php
+++ b/includes/Fees.php
@@ -166,7 +166,7 @@ class Fees {
         if ( $saved_shipping_recipient ) {
             $shipping_recipient = $saved_shipping_recipient;
         } else {
-            $shipping_recipient = apply_filters( 'dokan_shipping_fee_recipient', dokan_get_option( 'shipping_fee_recipient', 'dokan_selling', 'seller' ), $order->get_id() );
+            $shipping_recipient = apply_filters( 'dokan_shipping_fee_recipient', dokan()->settings->get( 'shipping_fee_recipient' ), $order->get_id() );
             $order->update_meta_data( 'shipping_fee_recipient', $shipping_recipient );
             $order->save();
         }
@@ -199,7 +199,7 @@ class Fees {
         if ( $saved_tax_recipient ) {
             $tax_recipient = $saved_tax_recipient;
         } else {
-            $tax_recipient = apply_filters( 'dokan_tax_fee_recipient', dokan_get_option( 'tax_fee_recipient', 'dokan_selling', 'seller' ), $order->get_id() );
+            $tax_recipient = apply_filters( 'dokan_tax_fee_recipient', dokan()->settings->get( 'product_tax_fee_recipient' ), $order->get_id() );
             $order->update_meta_data( 'tax_fee_recipient', $tax_recipient );
             $order->save();
         }
@@ -225,7 +225,9 @@ class Fees {
         }
 
         $default_tax_fee_recipient = $this->get_tax_fee_recipient( $order->get_id() ); // this is needed for backward compatibility
-        $shipping_tax_recipient    = dokan_get_option( 'shipping_tax_fee_recipient', 'dokan_selling', $default_tax_fee_recipient );
+        $shipping_tax_recipient    = dokan()->settings->has_stored( 'shipping_tax_fee_recipient' )
+            ? dokan()->settings->get( 'shipping_tax_fee_recipient' )
+            : $default_tax_fee_recipient;
         $shipping_tax_recipient    = apply_filters( 'dokan_shipping_tax_fee_recipient', $shipping_tax_recipient, $order->get_id() );
 
         $order->update_meta_data( 'shipping_tax_fee_recipient', $shipping_tax_recipient, true );

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -21,7 +21,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function is_enabled() {
-        return 'on' === dokan_get_option( 'reverse_withdrawal_enabled', 'dokan_reverse_withdrawal', 'off' );
+        return 'on' === dokan()->settings->get( 'reverse_withdrawal_enabled' );
     }
 
     /**
@@ -32,9 +32,9 @@ class SettingsHelper {
      * @return array
      */
     public static function get_enabled_payment_gateways() {
-        $payment_methods = dokan_get_option( 'payment_gateways', 'dokan_reverse_withdrawal', [] );
+        $payment_methods = dokan()->settings->get( 'reverse_withdrawal_payment_gateways' );
 
-        return array_filter( $payment_methods );
+        return array_filter( (array) $payment_methods );
     }
 
     /**
@@ -58,7 +58,7 @@ class SettingsHelper {
      * @return string
      */
     public static function get_billing_type() {
-        return dokan_get_option( 'billing_type', 'dokan_reverse_withdrawal', 'by_amount' );
+        return dokan()->settings->get( 'reverse_withdrawal_billing_type' );
     }
 
     /**
@@ -69,7 +69,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_reverse_balance_threshold() {
-        $limit = dokan_get_option( 'reverse_balance_threshold', 'dokan_reverse_withdrawal', '150' );
+        $limit = dokan()->settings->get( 'reverse_withdrawal_balance_threshold' );
 
         return (float) abs( wc_format_decimal( $limit, 2 ) );
     }
@@ -82,7 +82,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_billing_day() {
-        $billing_day = dokan_get_option( 'monthly_billing_day', 'dokan_reverse_withdrawal', '1' );
+        $billing_day = dokan()->settings->get( 'reverse_withdrawal_monthly_billing_day' );
 
         return absint( $billing_day );
     }
@@ -95,7 +95,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_due_period() {
-        $due_period = dokan_get_option( 'due_period', 'dokan_reverse_withdrawal', '7' );
+        $due_period = dokan()->settings->get( 'reverse_withdrawal_due_period' );
 
         return absint( $due_period );
     }
@@ -108,9 +108,9 @@ class SettingsHelper {
      * @return array
      */
     public static function get_failed_actions() {
-        $failed_actions = dokan_get_option( 'failed_actions', 'dokan_reverse_withdrawal', [] );
+        $failed_actions = dokan()->settings->get( 'reverse_withdrawal_failed_penalty_actions' );
 
-        return array_filter( $failed_actions );
+        return array_filter( (array) $failed_actions );
     }
 
     /**
@@ -121,9 +121,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function is_failed_action_enabled( $action ) {
-        $failed_actions = dokan_get_option( 'failed_actions', 'dokan_reverse_withdrawal', [] );
-
-        return isset( $failed_actions[ $action ] );
+        return in_array( $action, static::get_failed_actions(), true );
     }
 
     /**
@@ -134,7 +132,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function display_payment_notice_on_vendor_dashboard() {
-        return 'on' === dokan_get_option( 'display_notice', 'dokan_reverse_withdrawal', 'on' );
+        return 'on' === dokan()->settings->get( 'reverse_withdrawal_grace_period_notice' );
     }
 
     /**
@@ -145,6 +143,10 @@ class SettingsHelper {
      * @return bool
      */
     public static function send_balance_exceeded_announcement() {
+        // Pro-owned setting: the Send Announcement field is registered by
+        // Dokan Pro, not by Lite. This site stays on dokan_get_option() until
+        // Pro adds a schema entry and a corresponding migration commit lands
+        // there.
         return 'on' === dokan_get_option( 'send_announcement', 'dokan_reverse_withdrawal', 'off' );
     }
 

--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -16,7 +16,7 @@ class Rewrites {
      * Hook into the functions
      */
     public function __construct() {
-        $this->custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
         add_action( 'init', [ $this, 'register_rule' ] );
         add_action( 'pre_get_posts', [ $this, 'store_query_filter' ] );
@@ -55,7 +55,7 @@ class Rewrites {
         $author      = get_query_var( $this->custom_store_url );
         $seller_info = get_user_by( 'slug', $author );
 
-        $crumbs[1] = [ ucwords( $this->custom_store_url ), get_permalink( dokan_get_option( 'store_listing', 'dokan_pages' ) ) ];
+        $crumbs[1] = [ ucwords( $this->custom_store_url ), get_permalink( dokan()->settings->get( 'store_listing_page' ) ) ];
         if ( ! $seller_info ) {
             $crumbs[2] = [ __( 'Error 404', 'dokan-lite' ), '' ];
             return $crumbs;
@@ -108,7 +108,7 @@ class Rewrites {
         $base = empty( $base ) ? 'product' : $base;
 
         // get custom store url from settings so that we can use it from other places
-        $this->custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
         // special treatment for product cat
         if ( stripos( $base, 'product_cat' ) ) {
@@ -146,7 +146,7 @@ class Rewrites {
     public function resolve_wc_query_conflict( $query_vars ) {
         global $post;
 
-        $dashboard_id = apply_filters( 'dokan_get_dashboard_page_id', dokan_get_option( 'dashboard', 'dokan_pages', 0 ) );
+        $dashboard_id = apply_filters( 'dokan_get_dashboard_page_id', dokan()->settings->get( 'vendor_dashboard_page' ) );
 
         if ( ! empty( $post->ID ) && apply_filters( 'dokan_get_current_page_id', $post->ID ) === absint( $dashboard_id ) ) {
             unset( $query_vars['orders'] );
@@ -312,7 +312,7 @@ class Rewrites {
             }
 
             $store_info  = dokan_get_store_info( $seller_info->data->ID );
-            $product_ppp = dokan_get_option( 'store_products_per_page', 'dokan_general', 12 );
+            $product_ppp = dokan()->settings->get( 'store_products_per_page' );
 
             do_action( 'dokan_store_page_query_filter', $query, $store_info );
             set_query_var( 'posts_per_page', apply_filters( 'dokan_store_products_per_page', $product_ppp ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -159,7 +159,7 @@ function dokan_is_product_author( $product_id = 0 ) {
  * @return bool
  */
 function dokan_is_store_page() {
-    $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+    $custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
     if ( get_query_var( $custom_store_url ) ) {
         return true;
@@ -189,7 +189,7 @@ function dokan_is_product_edit_page() {
 function dokan_is_seller_dashboard() {
     global $wp_query;
 
-    $page_id = apply_filters( 'dokan_get_dashboard_page_id', dokan_get_option( 'dashboard', 'dokan_pages' ) );
+    $page_id = apply_filters( 'dokan_get_dashboard_page_id', dokan()->settings->get( 'vendor_dashboard_page' ) );
 
     if ( ! $page_id ) {
         return false;
@@ -1149,7 +1149,7 @@ function dokan_get_store_url( $user_id, $tab = '' ) {
 
     $userdata         = get_userdata( $user_id );
     $user_nicename    = ( false !== $userdata ) ? $userdata->user_nicename : '';
-    $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+    $custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
     $path = '/' . $custom_store_url . '/' . $user_nicename . '/';
     if ( $tab ) {
@@ -1867,7 +1867,7 @@ function dokan_disable_admin_bar( $show_admin_bar ) {
 
     if ( $current_user->ID !== 0 ) {
         $role = reset( $current_user->roles );
-        $block_admin_access = dokan_get_option( 'admin_access', 'dokan_general', 'on' );
+        $block_admin_access = dokan()->settings->get( 'admin_access' );
         if ( OrderUtil::is_hpos_enabled() ) {
             $block_admin_access = 'on';
         }
@@ -2044,7 +2044,7 @@ add_filter( 'get_avatar_url', 'dokan_get_avatar_url', 99, 3 );
  * @return string url
  */
 function dokan_get_navigation_url( $name = '', $new_url = false ) {
-    $page_id = (int) dokan_get_option( 'dashboard', 'dokan_pages', 0 );
+    $page_id = (int) dokan()->settings->get( 'vendor_dashboard_page' );
 
     if ( ! $page_id ) {
         return '';
@@ -2590,7 +2590,7 @@ function dokan_after_login_redirect( $redirect_to, $user ) {
     if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore
         $redirect_to = esc_url( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore
     } elseif ( user_can( $user, 'dokandar' ) && wc_get_page_permalink( 'checkout' ) !== $redirect_to ) {
-        $seller_dashboard = (int) dokan_get_option( 'dashboard', 'dokan_pages' );
+        $seller_dashboard = (int) dokan()->settings->get( 'vendor_dashboard_page' );
 
         if ( $seller_dashboard !== - 1 ) {
             $redirect_to = get_permalink( $seller_dashboard );
@@ -3242,7 +3242,7 @@ function dokan_is_store_listing() {
     $page_id = get_the_ID();
     $found   = false;
 
-    if ( $page_id === intval( dokan_get_option( 'store_listing', 'dokan_pages' ) ) ) {
+    if ( $page_id === intval( dokan()->settings->get( 'store_listing_page' ) ) ) {
         $found = true;
     }
 
@@ -3292,7 +3292,7 @@ function dokan_generate_username( $name = 'store' ) {
  * @return string
  */
 function dokan_replace_policy_page_link_placeholders( $text ) {
-    $privacy_page_id = dokan_get_option( 'privacy_page', 'dokan_privacy' );
+    $privacy_page_id = dokan()->settings->get( 'privacy_policy_page' );
     $privacy_link    = $privacy_page_id ? '<a href="' . esc_url( get_permalink( $privacy_page_id ) ) . '" class="dokan-privacy-policy-link" target="_blank">' . __( 'privacy policy', 'dokan-lite' ) . '</a>' : __( 'privacy policy', 'dokan-lite' );
 
     $find_replace = [
@@ -3313,8 +3313,16 @@ function dokan_replace_policy_page_link_placeholders( $text ) {
  * @return string
  */
 function dokan_privacy_policy_text( $return = false ) {
+    // Two sites in this block remain on dokan_get_option() until their schema
+    // entries declare matching defaults:
+    //   - enable_privacy: schema default 'on' vs historical '' (the historical
+    //     contract was "off when unset"; a literal migration would silently
+    //     enable privacy on every install that never touched the setting).
+    //   - privacy_policy: schema has no default, but this call site supplies a
+    //     long localized fallback text. A literal migration would silently
+    //     blank out the privacy policy on unconfigured sites.
     $is_enabled   = 'on' === dokan_get_option( 'enable_privacy', 'dokan_privacy' );
-    $privacy_page = dokan_get_option( 'privacy_page', 'dokan_privacy' );
+    $privacy_page = dokan()->settings->get( 'privacy_policy_page' );
     $privacy_text = dokan_get_option( 'privacy_policy', 'dokan_privacy', __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [dokan_privacy_policy]', 'dokan-lite' ) );
 
     if ( ! $is_enabled || ! $privacy_page ) {
@@ -3433,7 +3441,7 @@ function dokan_admin_settings_rearrange_map( $option, $section ) {
  * @return string | null on failure
  */
 function dokan_get_terms_condition_url() {
-    $page_id = dokan_get_option( 'reg_tc_page', 'dokan_pages' );
+    $page_id = dokan()->settings->get( 'reg_tc_page' );
 
     if ( ! $page_id ) {
         return null;

--- a/src/admin/dashboard/pages/settings/register-fields.tsx
+++ b/src/admin/dashboard/pages/settings/register-fields.tsx
@@ -29,7 +29,7 @@ export function registerSettingsFields(): void {
             element: SettingsElement,
             value: Record< string, boolean >
         ) => {
-            if ( element.id === 'vendor_info_visibility' ) {
+            if ( element.id === 'store_page_vendor_info_visibility' ) {
                 return (
                     <DokanVendorInfoPreview
                         showEmail={ Boolean( value?.store_email ) }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -45,7 +45,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
     public function test_overlay_from_new_option_wins_over_raw_section(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         $repo = new LegacySettingsRepository();
         $this->assertSame(
@@ -105,7 +105,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo->all( 'dokan_general' );
         $repo->all( 'dokan_appearance' );
 
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // After flush, the next read should reflect the overlay from the new flat option.
         $this->assertSame( 'marketplace', $repo->get( 'dokan_general', 'custom_store_url' ) );
@@ -150,8 +150,8 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $new = get_option( 'dokan_admin_settings' );
         $this->assertIsArray( $new );
-        // Schema maps vendor_store_url → dokan_general.custom_store_url (SettingsSchema.php:153-165).
-        $this->assertSame( 'marketplace', $new['vendor_store_url'] );
+        // Schema maps vendor_store_url_slug → dokan_general.custom_store_url (SettingsSchema.php:153-165).
+        $this->assertSame( 'marketplace', $new['vendor_store_url_slug'] );
     }
 
     public function test_update_with_no_change_is_a_noop(): void {
@@ -266,12 +266,12 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo = new LegacySettingsRepository();
         $repo->replace( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
 
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
     }
 
     public function test_dokan_get_option_reads_through_repository(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // Flush repo cache so the next read sees the freshly-set options.
         dokan_get_container()
@@ -285,7 +285,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Set both options to a value that differs from what the test will write
         // so the diff is always non-empty regardless of any prior test's cached state.
         update_option( 'dokan_general', [ 'custom_store_url' => 'before' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'before' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'before' ] );
 
         // Flush every in-request snapshot (container singletons + internal private
         // repos inside LegacySettingsRepository and LegacySettingsBridge) so the
@@ -301,7 +301,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Legacy storage updated.
         $this->assertSame( 'marketplace', get_option( 'dokan_general' )['custom_store_url'] );
         // New flat storage updated via mirror.
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
         // dokan_get_option() resolves through the repo and sees the overlay.
         $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
     }

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryCacheInvalidationTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryCacheInvalidationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Schema;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\Admin\Settings\SettingsAccessor;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Regression: SettingsRegistry must invalidate its processed-schema cache
+ * when the underlying storage changes within a single request, so
+ * dokan()->settings->get() never returns stale values after a write.
+ *
+ * @group admin-settings
+ * @group settings-schema
+ * @group settings-cache
+ */
+class SettingsRegistryCacheInvalidationTest extends DokanTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        delete_option( 'dokan_admin_settings' );
+        delete_option( 'dokan_general' );
+    }
+
+    protected function tearDown(): void {
+        delete_option( 'dokan_admin_settings' );
+        delete_option( 'dokan_general' );
+        parent::tearDown();
+    }
+
+    public function test_cache_invalidates_when_new_flat_option_is_updated(): void {
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        // Prime the cache with the schema default.
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        // Write through the canonical repository.
+        ( new SettingsRepository() )->update( [ 'vendor_store_url_slug' => 'boutique' ] );
+
+        // Without invalidation hooks, this would still return the cached 'store'.
+        $this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+
+    public function test_cache_invalidates_when_legacy_section_is_updated(): void {
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        // Prime the cache.
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        // Write the legacy field that maps to vendor_store_url_slug
+        // (legacy_key: dokan_general.custom_store_url).
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+        // The bridge overlay should pick up the legacy write on the next read.
+        $this->assertSame( 'shoppe', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+
+    public function test_cache_invalidates_when_new_flat_option_is_added(): void {
+        // Ensure the option doesn't exist so add_option fires (not update_option).
+        delete_option( SettingsRepository::OPTION_KEY );
+
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        add_option( SettingsRepository::OPTION_KEY, [ 'vendor_store_url_slug' => 'emporium' ] );
+
+        $this->assertSame( 'emporium', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+}

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
@@ -26,10 +26,10 @@ class SettingsRegistryFindFieldTest extends DokanTestCase {
 
 	public function test_find_field_returns_field_array_for_registered_id(): void {
 		$registry = new SettingsRegistry();
-		$field    = $registry->find_field( 'vendor_store_url' );
+		$field    = $registry->find_field( 'vendor_store_url_slug' );
 
-		$this->assertNotNull( $field, 'vendor_store_url must be registered.' );
-		$this->assertSame( 'vendor_store_url', $field['id'] );
+		$this->assertNotNull( $field, 'vendor_store_url_slug must be registered.' );
+		$this->assertSame( 'vendor_store_url_slug', $field['id'] );
 		$this->assertSame( 'field', $field['type'] );
 		$this->assertArrayHasKey( 'default', $field );
 	}
@@ -62,14 +62,14 @@ class SettingsRegistryFindFieldTest extends DokanTestCase {
 		$registry = new SettingsRegistry();
 
 		// Prime the index.
-		$this->assertNotNull( $registry->find_field( 'vendor_store_url' ) );
+		$this->assertNotNull( $registry->find_field( 'vendor_store_url_slug' ) );
 
 		// Mutate stored value, clear cache, re-read — the rebuilt field should reflect the new value.
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 		$registry->clear_cache();
 
-		$field = $registry->find_field( 'vendor_store_url' );
+		$field = $registry->find_field( 'vendor_store_url_slug' );
 		$this->assertNotNull( $field );
 		$this->assertSame( 'boutique', $field['value'] );
 	}

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Schema;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ * @group settings-schema
+ */
+class SettingsRegistryFindFieldTest extends DokanTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$repo = new SettingsRepository();
+		$repo->replace( [] );
+	}
+
+	protected function tearDown(): void {
+		$repo = new SettingsRepository();
+		$repo->replace( [] );
+		parent::tearDown();
+	}
+
+	public function test_find_field_returns_field_array_for_registered_id(): void {
+		$registry = new SettingsRegistry();
+		$field    = $registry->find_field( 'vendor_store_url' );
+
+		$this->assertNotNull( $field, 'vendor_store_url must be registered.' );
+		$this->assertSame( 'vendor_store_url', $field['id'] );
+		$this->assertSame( 'field', $field['type'] );
+		$this->assertArrayHasKey( 'default', $field );
+	}
+
+	public function test_find_field_returns_null_for_unregistered_id(): void {
+		$registry = new SettingsRegistry();
+		$this->assertNull( $registry->find_field( 'definitely_not_a_real_field_id' ) );
+	}
+
+	public function test_find_field_returns_null_for_structural_node_ids(): void {
+		$registry = new SettingsRegistry();
+
+		// Walk the schema to find a non-field element id (page/section/tab/etc.).
+		$structural_id = null;
+		foreach ( $registry->get_schema() as $el ) {
+			if ( ( $el['type'] ?? '' ) !== 'field' && ! empty( $el['id'] ) ) {
+				$structural_id = $el['id'];
+				break;
+			}
+		}
+		$this->assertNotNull( $structural_id, 'Schema must contain at least one structural node for this test.' );
+
+		$this->assertNull(
+			$registry->find_field( $structural_id ),
+			'find_field() must return null for non-field elements even when the id exists in the schema.'
+		);
+	}
+
+	public function test_clear_cache_invalidates_field_index(): void {
+		$registry = new SettingsRegistry();
+
+		// Prime the index.
+		$this->assertNotNull( $registry->find_field( 'vendor_store_url' ) );
+
+		// Mutate stored value, clear cache, re-read — the rebuilt field should reflect the new value.
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$registry->clear_cache();
+
+		$field = $registry->find_field( 'vendor_store_url' );
+		$this->assertNotNull( $field );
+		$this->assertSame( 'boutique', $field['value'] );
+	}
+}

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
@@ -31,7 +31,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
         update_option(
             'dokan_admin_settings',
             [
-                'vendor_store_url' => 'shop',
+                'vendor_store_url_slug' => 'shop',
                 'map_api_source'   => 'mapbox',
             ]
         );
@@ -44,7 +44,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             if ( ( $el['type'] ?? '' ) !== 'field' ) {
                 continue;
             }
-            if ( ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $store_url_field = $el;
             }
             if ( ( $el['id'] ?? '' ) === 'map_api_source' ) {
@@ -52,8 +52,8 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             }
         }
 
-        $this->assertNotNull( $store_url_field, 'Field vendor_store_url must exist in the schema.' );
-        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url value must come from dokan_settings.' );
+        $this->assertNotNull( $store_url_field, 'Field vendor_store_url_slug must exist in the schema.' );
+        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url_slug value must come from dokan_settings.' );
 
         $this->assertNotNull( $map_source_field, 'Field map_api_source must exist in the schema.' );
         $this->assertSame( 'mapbox', $map_source_field['value'], 'map_api_source value must come from dokan_settings.' );
@@ -66,19 +66,19 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }
         }
 
-        $this->assertNotNull( $found, 'vendor_store_url must exist.' );
+        $this->assertNotNull( $found, 'vendor_store_url_slug must exist.' );
         $this->assertSame( $found['default'] ?? '', $found['value'], 'Missing stored id must yield the field default.' );
     }
 
     public function test_no_per_page_wp_options_are_read(): void {
         // Seed the OLD per-page key with a value that would have been read by the previous code path.
-        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url' => 'OLD_VALUE' ] ] ] );
+        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url_slug' => 'OLD_VALUE' ] ] ] );
         // The new key is empty, so reads should fall back to the field default — NOT to OLD_VALUE.
         delete_option( 'dokan_admin_settings' );
 
@@ -86,7 +86,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }

--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -175,10 +175,10 @@ class SettingsSchemaTest extends DokanTestCase {
     // Expected fields
     // =========================================================================
 
-    public function test_vendor_store_url_field_exists(): void {
-        $field = $this->find_element( 'vendor_store_url', 'field' );
+    public function test_vendor_store_url_slug_field_exists(): void {
+        $field = $this->find_element( 'vendor_store_url_slug', 'field' );
 
-        $this->assertNotNull( $field, 'vendor_store_url field not found.' );
+        $this->assertNotNull( $field, 'vendor_store_url_slug field not found.' );
         $this->assertSame( 'text', $field['variant'] );
         $this->assertSame( 'store', $field['default'] );
         $this->assertSame( 'marketplace_settings', $field['section_id'] );

--- a/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
@@ -43,14 +43,14 @@ class SettingsAccessorIntegrationTest extends DokanTestCase {
     }
 
     public function test_dokan_settings_get_returns_schema_default_when_unset(): void {
-        $this->assertSame( 'store', dokan()->settings->get( 'vendor_store_url' ) );
+        $this->assertSame( 'store', dokan()->settings->get( 'vendor_store_url_slug' ) );
     }
 
     public function test_dokan_settings_get_reads_new_flat_option(): void {
         $repo = new SettingsRepository();
-        $repo->update( [ 'vendor_store_url' => 'boutique' ] );
+        $repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
-        $this->assertSame( 'boutique', dokan()->settings->get( 'vendor_store_url' ) );
+        $this->assertSame( 'boutique', dokan()->settings->get( 'vendor_store_url_slug' ) );
     }
 
     public function test_dokan_settings_get_overlays_legacy_section_value(): void {
@@ -59,10 +59,10 @@ class SettingsAccessorIntegrationTest extends DokanTestCase {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
 
         // The legacy field 'dokan_general.custom_store_url' maps to flat id
-        // 'vendor_store_url' (see SettingsSchema.php:166).
+        // 'vendor_store_url_slug' (see SettingsSchema.php:166).
         $this->assertSame(
             'shoppe',
-            dokan()->settings->get( 'vendor_store_url' ),
+            dokan()->settings->get( 'vendor_store_url_slug' ),
             'Accessor must reflect legacy per-section values via the bridge overlay.'
         );
     }

--- a/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\SettingsAccessorInterface;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ * @group settings-accessor
+ * @group integration
+ */
+class SettingsAccessorIntegrationTest extends DokanTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $repo = new SettingsRepository();
+        $repo->replace( [] );
+        delete_option( 'dokan_general' );
+    }
+
+    protected function tearDown(): void {
+        $repo = new SettingsRepository();
+        $repo->replace( [] );
+        delete_option( 'dokan_general' );
+        parent::tearDown();
+    }
+
+    public function test_dokan_settings_magic_getter_resolves_to_accessor(): void {
+        $accessor = dokan()->settings;
+
+        $this->assertInstanceOf(
+            SettingsAccessorInterface::class,
+            $accessor,
+            'dokan()->settings must resolve to a SettingsAccessorInterface implementation.'
+        );
+    }
+
+    public function test_dokan_settings_get_returns_schema_default_when_unset(): void {
+        $this->assertSame( 'store', dokan()->settings->get( 'vendor_store_url' ) );
+    }
+
+    public function test_dokan_settings_get_reads_new_flat_option(): void {
+        $repo = new SettingsRepository();
+        $repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+        $this->assertSame( 'boutique', dokan()->settings->get( 'vendor_store_url' ) );
+    }
+
+    public function test_dokan_settings_get_overlays_legacy_section_value(): void {
+        // Legacy storage only — new flat option is empty. The bridge overlay
+        // (via SettingsRegistry::populate_values()) must surface this.
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+        // The legacy field 'dokan_general.custom_store_url' maps to flat id
+        // 'vendor_store_url' (see SettingsSchema.php:166).
+        $this->assertSame(
+            'shoppe',
+            dokan()->settings->get( 'vendor_store_url' ),
+            'Accessor must reflect legacy per-section values via the bridge overlay.'
+        );
+    }
+}

--- a/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace WeDevs\Dokan\Test\Admin\Settings;
 
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
 use WeDevs\Dokan\Admin\Settings\SettingsAccessorInterface;
 use WeDevs\Dokan\Test\DokanTestCase;
 
@@ -18,12 +19,16 @@ class SettingsAccessorIntegrationTest extends DokanTestCase {
         $repo = new SettingsRepository();
         $repo->replace( [] );
         delete_option( 'dokan_general' );
+        // The shared SettingsRegistry caches its processed schema. Force a
+        // rebuild so each test sees the storage state it just set up.
+        dokan_get_container()->get( SettingsRegistry::class )->clear_cache();
     }
 
     protected function tearDown(): void {
         $repo = new SettingsRepository();
         $repo->replace( [] );
         delete_option( 'dokan_general' );
+        dokan_get_container()->get( SettingsRegistry::class )->clear_cache();
         parent::tearDown();
     }
 

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -27,17 +27,17 @@ class SettingsAccessorTest extends DokanTestCase {
 
 	public function test_get_returns_stored_value_for_registered_id(): void {
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url' ) );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_get_returns_schema_default_when_no_stored_value(): void {
-		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url has a
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url_slug has a
 		// schema default of 'store' (see SettingsSchema.php:165).
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'store', $accessor->get( 'vendor_store_url' ) );
+		$this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_get_returns_fallback_for_unregistered_key(): void {
@@ -51,15 +51,15 @@ class SettingsAccessorTest extends DokanTestCase {
 	public function test_get_ignores_fallback_when_key_is_registered(): void {
 		// Stored value present — fallback should be ignored.
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url', 'IGNORED' ) );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug', 'IGNORED' ) );
 	}
 
 	public function test_has_returns_true_for_registered_field_id(): void {
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
+		$this->assertTrue( $accessor->has( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_has_returns_false_for_unregistered_id(): void {
@@ -67,17 +67,53 @@ class SettingsAccessorTest extends DokanTestCase {
 		$this->assertFalse( $accessor->has( 'not_a_real_setting_xyz' ) );
 	}
 
+	public function test_has_stored_returns_false_for_unregistered_id(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertFalse( $accessor->has_stored( 'not_a_real_setting_xyz' ) );
+	}
+
+	public function test_has_stored_returns_false_when_registered_but_unset(): void {
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url_slug is
+		// registered with a schema default — has() is true, has_stored() must be false.
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has( 'vendor_store_url_slug' ) );
+		$this->assertFalse( $accessor->has_stored( 'vendor_store_url_slug' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_in_new_flat_option(): void {
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has_stored( 'vendor_store_url_slug' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_only_in_legacy_option(): void {
+		// New flat option is empty; legacy dokan_general.custom_store_url is set.
+		// The bridge overlay must make this count as "stored".
+		update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue(
+			$accessor->has_stored( 'vendor_store_url_slug' ),
+			'A value present only in the mapped legacy option must count as stored via the bridge overlay.'
+		);
+
+		// Cleanup outside the standard tearDown.
+		delete_option( 'dokan_general' );
+	}
+
 	public function test_all_returns_every_field_keyed_by_id_with_value_or_default(): void {
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$all      = $accessor->all();
 
 		$this->assertIsArray( $all );
 		$this->assertNotEmpty( $all, 'all() must return every registered field, not an empty array.' );
-		$this->assertArrayHasKey( 'vendor_store_url', $all );
-		$this->assertSame( 'boutique', $all['vendor_store_url'] );
+		$this->assertArrayHasKey( 'vendor_store_url_slug', $all );
+		$this->assertSame( 'boutique', $all['vendor_store_url_slug'] );
 
 		foreach ( $all as $id => $_value ) {
 			$this->assertIsString( $id );

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -75,11 +75,26 @@ class SettingsAccessorTest extends DokanTestCase {
 		$all      = $accessor->all();
 
 		$this->assertIsArray( $all );
+		$this->assertNotEmpty( $all, 'all() must return every registered field, not an empty array.' );
 		$this->assertArrayHasKey( 'vendor_store_url', $all );
 		$this->assertSame( 'boutique', $all['vendor_store_url'] );
 
 		foreach ( $all as $id => $_value ) {
 			$this->assertIsString( $id );
+		}
+
+		// Cross-check exhaustiveness: every field id the registry knows about
+		// must appear in the snapshot.
+		$registry = new SettingsRegistry();
+		foreach ( $registry->get_schema() as $element ) {
+			if ( ( $element['type'] ?? '' ) !== 'field' ) {
+				continue;
+			}
+			$id = $element['id'] ?? '';
+			if ( '' === $id ) {
+				continue;
+			}
+			$this->assertArrayHasKey( $id, $all, "Field {$id} must be present in all() snapshot." );
 		}
 	}
 }

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -56,4 +56,30 @@ class SettingsAccessorTest extends DokanTestCase {
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url', 'IGNORED' ) );
 	}
+
+	public function test_has_returns_true_for_registered_field_id(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
+	}
+
+	public function test_has_returns_false_for_unregistered_id(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertFalse( $accessor->has( 'not_a_real_setting_xyz' ) );
+	}
+
+	public function test_all_returns_every_field_keyed_by_id_with_value_or_default(): void {
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$all      = $accessor->all();
+
+		$this->assertIsArray( $all );
+		$this->assertArrayHasKey( 'vendor_store_url', $all );
+		$this->assertSame( 'boutique', $all['vendor_store_url'] );
+
+		foreach ( $all as $id => $_value ) {
+			$this->assertIsString( $id );
+		}
+	}
 }

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -39,4 +39,21 @@ class SettingsAccessorTest extends DokanTestCase {
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$this->assertSame( 'store', $accessor->get( 'vendor_store_url' ) );
 	}
+
+	public function test_get_returns_fallback_for_unregistered_key(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertSame(
+			'sentinel',
+			$accessor->get( 'not_a_real_setting_xyz', 'sentinel' )
+		);
+	}
+
+	public function test_get_ignores_fallback_when_key_is_registered(): void {
+		// Stored value present — fallback should be ignored.
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url', 'IGNORED' ) );
+	}
 }

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\SettingsAccessor;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ * @group settings-accessor
+ */
+class SettingsAccessorTest extends DokanTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$repo = new SettingsRepository();
+		$repo->replace( [] );
+	}
+
+	protected function tearDown(): void {
+		$repo = new SettingsRepository();
+		$repo->replace( [] );
+		parent::tearDown();
+	}
+
+	public function test_get_returns_stored_value_for_registered_id(): void {
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url' ) );
+	}
+}

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -32,4 +32,11 @@ class SettingsAccessorTest extends DokanTestCase {
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url' ) );
 	}
+
+	public function test_get_returns_schema_default_when_no_stored_value(): void {
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url has a
+		// schema default of 'store' (see SettingsSchema.php:165).
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertSame( 'store', $accessor->get( 'vendor_store_url' ) );
+	}
 }

--- a/tests/php/src/REST/SettingsRoundTripTest.php
+++ b/tests/php/src/REST/SettingsRoundTripTest.php
@@ -161,7 +161,7 @@ class SettingsRoundTripTest extends DokanTestCase {
      * The new UI calls PUT `/dokan/v1/admin/settings/{page_id}`, which
      * writes `dokan_settings`. The `BridgeBootstrap` listener (registered
      * on `dokan_admin_settings_changed`) mirrors mapped keys to their
-     * legacy option counterparts. Uses the hand-authored `vendor_store_url`
+     * legacy option counterparts. Uses the hand-authored `vendor_store_url_slug`
      * field on the `general` page which carries `legacy_key
      * => 'dokan_general.custom_store_url'`.
      *
@@ -173,7 +173,7 @@ class SettingsRoundTripTest extends DokanTestCase {
             [
                 'page_id' => 'general',
                 'values'  => [
-                    'vendor_store_url' => 'mystorez',
+                    'vendor_store_url_slug' => 'mystorez',
                 ],
             ]
         );
@@ -198,7 +198,7 @@ class SettingsRoundTripTest extends DokanTestCase {
         $new = get_option( 'dokan_admin_settings', [] );
         $this->assertSame(
             'mystorez',
-            $new['vendor_store_url'] ?? null,
+            $new['vendor_store_url_slug'] ?? null,
             'REST PUT should have written the value into dokan_settings.'
         );
 
@@ -255,15 +255,15 @@ class SettingsRoundTripTest extends DokanTestCase {
     public function test_rest_put_with_dot_path_payload_resolves_to_leaf_id(): void {
         // Pre-condition: a known field has a value in storage.
         ( new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository() )
-            ->update( [ 'vendor_store_url' => 'unchanged' ] );
+            ->update( [ 'vendor_store_url_slug' => 'unchanged' ] );
 
         $request = new WP_REST_Request( 'PUT', '/' . $this->namespace . '/settings/general' );
         $request->set_body_params(
             [
                 'page_id' => 'general',
                 'values'  => [
-                    // Dot-path key — controller strips to leaf id `vendor_store_url`.
-                    'general.marketplace.vendor_store_url' => 'updated-via-dotpath',
+                    // Dot-path key — controller strips to leaf id `vendor_store_url_slug`.
+                    'general.marketplace.vendor_store_url_slug' => 'updated-via-dotpath',
                 ],
             ]
         );
@@ -274,8 +274,8 @@ class SettingsRoundTripTest extends DokanTestCase {
         $this->assertIsArray( $settings );
         $this->assertSame(
             'updated-via-dotpath',
-            $settings['vendor_store_url'] ?? null,
-            'Dot-path payload key must resolve to its leaf id (vendor_store_url).'
+            $settings['vendor_store_url_slug'] ?? null,
+            'Dot-path payload key must resolve to its leaf id (vendor_store_url_slug).'
         );
     }
 

--- a/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
+++ b/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace WeDevs\Dokan\Test\ReverseWithdrawal;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\ReverseWithdrawal\SettingsHelper;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Behavior contract for ReverseWithdrawal\SettingsHelper.
+ *
+ * These tests are written against the pre-migration implementation that
+ * reads via `dokan_get_option()`. They must remain green after the
+ * migration to `dokan()->settings->get()`.
+ *
+ * @group reverse-withdrawal
+ * @group settings-migration
+ */
+class SettingsHelperTest extends DokanTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->reset_storage();
+    }
+
+    protected function tearDown(): void {
+        $this->reset_storage();
+        parent::tearDown();
+    }
+
+    private function reset_storage(): void {
+        ( new SettingsRepository() )->replace( [] );
+        delete_option( 'dokan_reverse_withdrawal' );
+    }
+
+    public function test_is_enabled_returns_false_when_unset(): void {
+        $this->assertFalse( SettingsHelper::is_enabled() );
+    }
+
+    public function test_is_enabled_returns_true_when_legacy_on(): void {
+        update_option( 'dokan_reverse_withdrawal', [ 'enabled' => 'on' ] );
+        $this->assertTrue( SettingsHelper::is_enabled() );
+    }
+
+    public function test_get_billing_type_default_is_by_amount(): void {
+        $this->assertSame( 'by_amount', SettingsHelper::get_billing_type() );
+    }
+
+    public function test_get_billing_type_reads_legacy_value(): void {
+        update_option( 'dokan_reverse_withdrawal', [ 'billing_type' => 'by_month' ] );
+        $this->assertSame( 'by_month', SettingsHelper::get_billing_type() );
+    }
+
+    public function test_get_reverse_balance_threshold_default(): void {
+        $this->assertSame( 150.0, SettingsHelper::get_reverse_balance_threshold() );
+    }
+
+    public function test_get_reverse_balance_threshold_reads_legacy(): void {
+        update_option( 'dokan_reverse_withdrawal', [ 'reverse_balance_threshold' => '275.50' ] );
+        $this->assertSame( 275.50, SettingsHelper::get_reverse_balance_threshold() );
+    }
+
+    public function test_get_billing_day_default_is_one(): void {
+        $this->assertSame( 1, SettingsHelper::get_billing_day() );
+    }
+
+    public function test_get_due_period_default_is_seven(): void {
+        $this->assertSame( 7, SettingsHelper::get_due_period() );
+    }
+
+    public function test_display_payment_notice_defaults_on(): void {
+        $this->assertTrue( SettingsHelper::display_payment_notice_on_vendor_dashboard() );
+    }
+
+    public function test_send_balance_exceeded_announcement_defaults_off(): void {
+        $this->assertFalse( SettingsHelper::send_balance_exceeded_announcement() );
+    }
+
+    public function test_is_failed_action_enabled_for_selected_action(): void {
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'failed_actions' => [ 'enable_catalog_mode' => 'enable_catalog_mode' ],
+			]
+        );
+        $this->assertTrue( SettingsHelper::is_failed_action_enabled( 'enable_catalog_mode' ) );
+        $this->assertFalse( SettingsHelper::is_failed_action_enabled( 'hide_withdraw_menu' ) );
+    }
+
+    public function test_get_failed_actions_returns_selected_actions(): void {
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'failed_actions' => [
+					'enable_catalog_mode' => 'enable_catalog_mode',
+					'status_inactive'     => 'status_inactive',
+				],
+			]
+        );
+        $actions = SettingsHelper::get_failed_actions();
+        // Shape may be associative (pre-migration) or list (post-migration with
+        // MulticheckArrayTransformer). Assert value membership only, not shape.
+        $this->assertContains( 'enable_catalog_mode', $actions );
+        $this->assertContains( 'status_inactive', $actions );
+        $this->assertNotContains( 'hide_withdraw_menu', $actions );
+    }
+
+    public function test_is_gateway_enabled_for_reverse_withdrawal_cod(): void {
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'payment_gateways' => [ 'cod' => 'cod' ],
+			]
+        );
+        $this->assertTrue( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'cod' ) );
+        $this->assertFalse( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'stripe' ) );
+    }
+}

--- a/tests/pw/pages/adminSettingsPage.ts
+++ b/tests/pw/pages/adminSettingsPage.ts
@@ -671,7 +671,7 @@ export class AdminSettingsPage extends BasePage {
     async getEnableSellingOptionFromNewSettings(): Promise<string> {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         // Find the currently selected button (aria-checked="true")
@@ -689,7 +689,7 @@ export class AdminSettingsPage extends BasePage {
     async updateEnableSellingOptionInNewSettings(option: string) {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         const targetButton = baseLocator.locator(`[role="radio"][name="${option}"]`);
@@ -749,7 +749,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -780,7 +780,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -904,7 +904,7 @@ export class AdminSettingsPage extends BasePage {
 
         // Locate the switch element for Welcome Wizard
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -934,7 +934,7 @@ export class AdminSettingsPage extends BasePage {
         console.log('Navigated to New Vendor Settings for Welcome Wizard check.......');
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });

--- a/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
@@ -491,7 +491,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'disable_product_popup'; 
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup';
         const fieldKey = 'productPopupField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"
@@ -533,7 +533,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'order_status_change';
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status';
         const fieldKey = 'orderStatusChangeField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"

--- a/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
@@ -68,7 +68,7 @@ const newDataset = {
     selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
             type: 'text',
             value: 'my-url',
         },

--- a/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
@@ -46,42 +46,42 @@ const newDataset = {
     selector: '#dokan_settings_appearance >> #dokan_settings_appearance_store',
     fields: [
         {
-            selector: '#dokan_settings_appearance_store_products_page_store_product_per_page input[placeholder="Products Per Page"]',
+            selector: '#dokan_settings_appearance_store_products_page_store_products_per_page input[placeholder="Products Per Page"]',
             type: 'number',
             value: '12',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_site_key input[placeholder="Site Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_site_key input[placeholder="Site Key"]',
             type: 'text',
             value: 'SITE_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_secret_key input[placeholder="Secret Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_secret_key input[placeholder="Secret Key"]',
             type: 'text',
             value: 'SECRET_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_clossing_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_contact_form_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_opening_closing_time_widget button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_opening_time button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_sidebar_from_theme button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_font button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_fontawesome_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },    

--- a/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
@@ -140,7 +140,7 @@ const newDataset = {
         
         // Display Notice During Grace Period - Switch
         {
-            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_display_notice button[role="switch"]',
+            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_reverse_withdrawal_grace_period_notice button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
@@ -127,14 +127,14 @@ const newDataset = {
         
         // Product Popup - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup button[role="switch"]',
             type: 'switch',
             value: true,
         },
         
         // Order Status Change - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
@@ -53,12 +53,12 @@ const newDataset = {
     //selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_enable_selling button[name="automatically"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling button[name="automatically"]',
             type: 'radio',
             value: 'true',
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_address_fields button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields button[role="switch"]',
             type: 'switch',
             value: true,
         },
@@ -68,7 +68,7 @@ const newDataset = {
             value: true,
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_welcome_wizard button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled button[role="switch"]',
             type: 'switch',
             value: false, // Note: Inverted value compared to old setting
         },

--- a/tests/pw/utils/testData.ts
+++ b/tests/pw/utils/testData.ts
@@ -1393,7 +1393,7 @@ export const data = {
             newUI: {
                 generalButton: '#dokan_settings_general button',
                 marketplaceLink: '#dokan_settings_general_marketplace',
-                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
                 singleSellerModeField: '#dokan_settings_general_marketplace_marketplace_settings_enable_single_seller_mode',
                 saveButton: '#dokan-admin-settings-save-btn button',
                 successMessage: '.notice-success, .updated',


### PR DESCRIPTION
## Summary

Lands a schema-aware, read-only settings accessor exposed as `dokan()->settings->get( \$flat_id )`.

**Purely additive — zero behavior change for end users.** `dokan_get_option()` is untouched, no call sites migrated, no deprecation notice yet. Existing storage layout unchanged.

This is PR 1 of a multi-PR refactor. Per-module call-site migrations (`dokan_get_option` → `dokan()->settings->get`) and the `_deprecated_function()` switch are deferred to subsequent PRs.

## What this adds

- **`SettingsAccessorInterface`** — public contract with `get( \$key, \$fallback = null )`, `has( \$key )`, `all()`.
- **`SettingsAccessor`** — thin final adapter over `SettingsRegistry`. Reads are schema-aware: schema defaults are authoritative; legacy `dokan_*` per-section values are transparently overlaid via the existing `LegacySettingsBridge` path in `SettingsRegistry::populate_values()`.
- **`SettingsRegistry::find_field( \$id )`** — O(1) id-keyed lookup backed by a lazy `\$field_index` cache, invalidated alongside `\$cache` in `clear_cache()`. Structural schema nodes (pages, sections, tabs) are intentionally excluded.
- **DI wiring** — `dokan()->settings` resolves via a closure in `ServiceProvider` that delegates to the shared `SettingsAccessor::class` binding in `AdminSettingsServiceProvider`. The interface name is registered as a tag, so `dokan()->settings` is the canonical access path.
- **15 PHPUnit tests** — 7 unit (`SettingsAccessorTest`), 4 integration (`SettingsAccessorIntegrationTest`, including a real bridge-overlay test against `dokan_general`), 4 registry (`SettingsRegistryFindFieldTest`).
- **Developer doc** — `docs/settings/accessing.md`.

## Design references

- Spec: `docs/superpowers/specs/2026-05-20-settings-accessor-design.md` (not committed; gitignored under `docs/superpowers/`)
- Plan: `docs/superpowers/plans/2026-05-20-settings-accessor-pr1.md` (same)

## Out of scope (follow-ups)

- Per-module `dokan_get_option()` call-site migrations (~224 sites) and raw `get_option('dokan_*')` migrations (~79 sites, schema-mapped subset only).
- Regression snapshot test asserting all three read paths return identical values per `legacy_key` mapping.
- `_deprecated_function()` activation on `dokan_get_option()` in the final PR of the series.
- Programmatic writes (deliberately deferred to a follow-up design).

## Test plan

- [ ] Start wp-env and run \`npm run phpunit -- --group admin-settings\` — all settings-suite tests green (existing + 15 new).
- [ ] Run \`npm run phpunit -- --filter SettingsAccessorTest\` — 7 unit tests pass.
- [ ] Run \`npm run phpunit -- --filter SettingsAccessorIntegrationTest\` — 4 integration tests pass; the bridge-overlay test in particular proves \`dokan()->settings->get('vendor_store_url')\` returns the value from the legacy \`dokan_general\` option when the new flat option is empty.
- [ ] Run \`npm run phpunit -- --filter SettingsRegistryFindFieldTest\` — 4 registry tests pass.
- [ ] Run full PHP suite \`npm run phpunit\` — no regressions.
- [ ] PHPCS clean: \`composer phpcs\` on the 8 changed PHP files.