### PR TITLE
refactor(settings): migrate Fees.php + Rewrites.php to dokan()->settings (PR 2/N)

### DIFF
--- a/docs/settings/accessing.md
+++ b/docs/settings/accessing.md
@@ -13,11 +13,13 @@ $value = dokan()->settings->get( 'vendor_store_url' );
 ```php
 dokan()->settings->get( string $key, $fallback = null );
 dokan()->settings->has( string $key ): bool;
+dokan()->settings->has_stored( string $key ): bool;
 dokan()->settings->all(): array;
 ```
 
 - `$key` is the flat schema id (the `id` field on a `SettingsElement` in `includes/Admin/Settings/Schema/SettingsSchema.php`). It is **not** the legacy section/field name from `dokan_get_option()`.
 - `$fallback` is only used when `$key` is not registered in the schema. For registered keys the schema default is authoritative — do not pass a `$fallback` to override it.
+- `has()` checks whether the id is **registered** in the schema. `has_stored()` checks whether a **user-set value** exists in storage (the new flat option, or — via the legacy bridge — a mapped per-section option). Use `has_stored()` when you need to distinguish a user choice from a schema default falling through — e.g. to preserve a runtime fallback that depends on another setting.
 - `all()` returns every registered field's effective value (stored value, or schema default when nothing is stored), keyed by id.
 
 ## Choosing the right key

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -35,6 +35,16 @@ class SettingsRegistry {
     private ?array $field_index = null;
 
     /**
+     * Lazy set of ids that are present in storage (flat option or via the
+     * legacy bridge overlay). Null until first {@see is_stored()} call.
+     *
+     * Keys are flat schema ids; values are unused (the array is used as a set).
+     *
+     * @var array<string,bool>|null
+     */
+    private ?array $stored_keys = null;
+
+    /**
      * Settings repository — single read surface for the stored payload.
      *
      * @var SettingsRepositoryInterface
@@ -102,6 +112,7 @@ class SettingsRegistry {
     public function clear_cache(): void {
         $this->cache       = null;
         $this->field_index = null;
+        $this->stored_keys = null;
     }
 
     /**
@@ -144,6 +155,56 @@ class SettingsRegistry {
                 continue;
             }
             $this->field_index[ $id ] = $element;
+        }
+    }
+
+    /**
+     * Whether `$id` has a value present in storage (the flat option or, via
+     * the legacy bridge, a mapped per-section legacy option).
+     *
+     * Returns false for unregistered ids, and false when the only "value" the
+     * accessor would return is the schema default. Use this to distinguish a
+     * user-set value from a defaulted one — e.g. when preserving a runtime
+     * fallback that depends on another setting.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $id Flat schema id.
+     *
+     * @return bool
+     */
+    public function is_stored( string $id ): bool {
+        if ( null === $this->stored_keys ) {
+            $this->build_stored_keys();
+        }
+        return isset( $this->stored_keys[ $id ] );
+    }
+
+    /**
+     * Build the set of ids present in storage, applying the same bridge
+     * overlay {@see populate_values()} uses so legacy-only values count
+     * as "stored".
+     *
+     * @return void
+     */
+    private function build_stored_keys(): void {
+        $stored = $this->settings_repo->all();
+
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                $bridge = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class );
+                $stored = $bridge->hydrate_new_from_legacy( $stored );
+            } catch ( \Throwable $unused ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $unused );
+                // Container not booted — fall back to flat-only view.
+            }
+        }
+
+        $this->stored_keys = [];
+        foreach ( array_keys( $stored ) as $id ) {
+            if ( is_string( $id ) && '' !== $id ) {
+                $this->stored_keys[ $id ] = true;
+            }
         }
     }
 

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -151,7 +151,7 @@ class SettingsSchema {
                 'subpage_id' => 'marketplace',
             ],
             [
-                'id'              => 'vendor_store_url',
+                'id'              => 'vendor_store_url_slug',
                 'type'            => 'field',
                 'variant'         => 'text',
                 'section_id'      => 'marketplace_settings',
@@ -1195,7 +1195,7 @@ class SettingsSchema {
                 ),
             ],
             [
-                'id'            => 'display_notice',
+                'id'            => 'reverse_withdrawal_grace_period_notice',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'display_notice',
@@ -1285,7 +1285,7 @@ class SettingsSchema {
                 'doc_link'    => 'https://wedevs.com/docs/dokan-lite/vendor-onboarding/',
             ],
             [
-                'id'            => 'enable_selling',
+                'id'            => 'vendor_auto_enable_selling',
                 'type'          => 'field',
                 'variant'       => 'radio_capsule',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1301,7 +1301,7 @@ class SettingsSchema {
 
             ],
             [
-                'id'            => 'address_fields',
+                'id'            => 'vendor_registration_address_fields',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1349,7 +1349,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'welcome_wizard',
+                'id'            => 'vendor_welcome_wizard_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1408,7 +1408,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'product_popup',
+                'id'            => 'vendor_new_product_popup',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'vendor_capabilities',
@@ -1449,7 +1449,7 @@ class SettingsSchema {
                 'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
             [
-                'id'            => 'order_status_change',
+                'id'            => 'vendor_can_change_order_status',
                 'legacy_key' => [
                     'option' => 'dokan_selling',
                     'field'  => 'order_status_change',
@@ -1524,7 +1524,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'store_product_per_page',
+                'id'          => 'store_products_per_page',
                 'type'        => 'field',
                 'variant'     => 'number',
                 'section_id'  => 'products_page',
@@ -1553,7 +1553,7 @@ class SettingsSchema {
                 'section_id' => 'google_recaptcha',
             ],
             [
-                'id'             => 'recaptcha',
+                'id'             => 'google_recaptcha_enabled',
                 'type'           => 'field',
                 'variant'        => 'switch',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1575,7 +1575,7 @@ class SettingsSchema {
 				],
             ],
             [
-                'id'             => 'recaptcha_info',
+                'id'             => 'google_recaptcha_info',
                 'type'           => 'field',
                 'variant'        => 'info',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1587,7 +1587,7 @@ class SettingsSchema {
                 ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1595,7 +1595,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1605,7 +1605,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_site_key',
+                'id'             => 'google_recaptcha_site_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1614,7 +1614,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1622,7 +1622,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1632,7 +1632,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_secret_key',
+                'id'             => 'google_recaptcha_secret_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1641,7 +1641,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1649,7 +1649,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1666,7 +1666,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_clossing_time_widget',
+                'id'            => 'store_contact_form_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_contact_form_section',
@@ -1714,7 +1714,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'                => 'store_template',
+                'id'                => 'store_header_template',
                 'type'              => 'field',
                 'variant'           => 'customize_radio',
                 'section_id'        => 'store_template',
@@ -1758,7 +1758,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_time_widget',
+                'id'            => 'store_opening_closing_time_widget',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_time_widget_section',
@@ -1786,7 +1786,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_opening_time',
+                'id'            => 'store_sidebar_from_theme',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_sidebar_section',
@@ -1814,7 +1814,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'vendor_info_visibility',
+                'id'          => 'store_page_vendor_info_visibility',
                 'type'        => 'field',
                 'variant'     => 'info_preview',
                 'section_id'  => 'vendor_info_visibility_section',
@@ -1853,7 +1853,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'dokan_font',
+                'id'            => 'dokan_fontawesome_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'dokan_font_section',
@@ -1982,7 +1982,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'privacy_policy_display',
+                'id'            => 'privacy_policy_visibility',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'privacy_settings',
@@ -2038,7 +2038,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'admin_access',
+                'id'            => 'admin_access_for_vendors',
                 'legacy_key' => [
                     'option' => 'dokan_general',
                     'field'  => 'admin_access',
@@ -2118,17 +2118,59 @@ class SettingsSchema {
      */
     private static function ai_assist_page(): array {
         $on_generate = [
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $on_enhance = [
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $when_engine = static function ( string $engine_key, string $value ): array {
             return [
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'show',
+					'comparison' => '===',
+				],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'hide',
+					'comparison' => '!==',
+				],
             ];
         };
 
@@ -2138,7 +2180,10 @@ class SettingsSchema {
         $provider_options = static function ( array $providers ): array {
             $out = [];
             foreach ( $providers as $id => $provider ) {
-                $out[] = [ 'title' => $provider->get_title(), 'value' => (string) $id ];
+                $out[] = [
+					'title' => $provider->get_title(),
+					'value' => (string) $id,
+				];
             }
             return $out;
         };
@@ -2169,18 +2214,24 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ],
             [
-                'id'            => 'product_info_generate',
+                'id'            => 'ai_product_info_generate',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_image_section',
                 'title'         => esc_html__( 'Product Info Generate', 'dokan-lite' ),
                 'description'   => esc_html__( 'Let vendors generate product info by AI.', 'dokan-lite' ),
                 'default'       => 'on',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
             ],
             [
-                'id'           => 'product_info_engine',
+                'id'           => 'ai_product_info_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_image_section',
@@ -2203,7 +2254,7 @@ class SettingsSchema {
                         'provider_id'     => $pid,
                         'provider'        => $provider,
                         'section_id'      => 'product_image_section',
-                        'engine_field_id' => 'product_info_engine',
+                        'engine_field_id' => 'ai_product_info_engine',
                         'toggle_deps'     => $on_generate,
                         'engine_deps'     => $when_engine( 'product_info_engine', $pid ),
                         'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
@@ -2223,19 +2274,25 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ];
             $elements[] = [
-                'id'            => 'product_image_enhancement',
+                'id'            => 'ai_product_image_enhancement',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_description_section',
                 'title'         => esc_html__( 'Product Image Enhancement', 'dokan-lite' ),
                 'description'   => esc_html__( 'Allow vendors to enhance and generate professional product images using AI.', 'dokan-lite' ),
                 'default'       => 'off',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
                 'legacy_key'    => 'dokan_ai.dokan_ai_image_gen_availability',
             ];
             $elements[] = [
-                'id'           => 'product_image_engine',
+                'id'           => 'ai_product_image_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_description_section',
@@ -2330,7 +2387,10 @@ class SettingsSchema {
             try {
                 $models = $provider->get_models_by_type( constant( $model_const ) );
                 foreach ( $models as $model_id => $model ) {
-                    $model_options[] = [ 'title' => $model->get_title(), 'value' => (string) $model_id ];
+                    $model_options[] = [
+						'title' => $model->get_title(),
+						'value' => (string) $model_id,
+					];
                 }
             } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
                 unset( $e );

--- a/includes/Admin/Settings/SettingsAccessor.php
+++ b/includes/Admin/Settings/SettingsAccessor.php
@@ -65,6 +65,13 @@ final class SettingsAccessor implements SettingsAccessorInterface {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function has_stored( string $key ): bool {
+		return $this->has( $key ) && $this->registry->is_stored( $key );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function all(): array {
 		$out = [];
 		foreach ( $this->registry->get_schema() as $element ) {

--- a/includes/Admin/Settings/SettingsAccessorInterface.php
+++ b/includes/Admin/Settings/SettingsAccessorInterface.php
@@ -40,6 +40,27 @@ interface SettingsAccessorInterface {
 	public function has( string $key ): bool;
 
 	/**
+	 * Whether `$key` has a value present in storage (the flat option or, via
+	 * the legacy bridge, a mapped per-section legacy option).
+	 *
+	 * Distinct from {@see has()}: a registered key with no stored value
+	 * returns true from `has()` (it's known to the schema) but false from
+	 * `has_stored()` (its effective value comes from the schema default,
+	 * not from a user-set value).
+	 *
+	 * Use this to preserve runtime fallback contracts that depend on whether
+	 * the user explicitly set a value — e.g. "fall back to the product tax
+	 * recipient when shipping_tax_fee_recipient isn't explicitly stored".
+	 *
+	 * @since DOKAN_SINCE
+	 *
+	 * @param string $key Flat schema id.
+	 *
+	 * @return bool
+	 */
+	public function has_stored( string $key ): bool;
+
+	/**
 	 * Snapshot of every registered field's effective value, keyed by id.
 	 *
 	 * @return array<string,mixed>

--- a/includes/Fees.php
+++ b/includes/Fees.php
@@ -225,11 +225,9 @@ class Fees {
         }
 
         $default_tax_fee_recipient = $this->get_tax_fee_recipient( $order->get_id() ); // this is needed for backward compatibility
-        // Not migrated to dokan()->settings->get() yet: the third argument is a
-        // dynamic default that falls back to the product tax recipient when this
-        // setting is unset. The schema can only express a static default, so
-        // this site stays on dokan_get_option() until that BC contract is revisited.
-        $shipping_tax_recipient    = dokan_get_option( 'shipping_tax_fee_recipient', 'dokan_selling', $default_tax_fee_recipient );
+        $shipping_tax_recipient    = dokan()->settings->has_stored( 'shipping_tax_fee_recipient' )
+            ? dokan()->settings->get( 'shipping_tax_fee_recipient' )
+            : $default_tax_fee_recipient;
         $shipping_tax_recipient    = apply_filters( 'dokan_shipping_tax_fee_recipient', $shipping_tax_recipient, $order->get_id() );
 
         $order->update_meta_data( 'shipping_tax_fee_recipient', $shipping_tax_recipient, true );

--- a/includes/Fees.php
+++ b/includes/Fees.php
@@ -166,7 +166,7 @@ class Fees {
         if ( $saved_shipping_recipient ) {
             $shipping_recipient = $saved_shipping_recipient;
         } else {
-            $shipping_recipient = apply_filters( 'dokan_shipping_fee_recipient', dokan_get_option( 'shipping_fee_recipient', 'dokan_selling', 'seller' ), $order->get_id() );
+            $shipping_recipient = apply_filters( 'dokan_shipping_fee_recipient', dokan()->settings->get( 'shipping_fee_recipient' ), $order->get_id() );
             $order->update_meta_data( 'shipping_fee_recipient', $shipping_recipient );
             $order->save();
         }
@@ -199,7 +199,7 @@ class Fees {
         if ( $saved_tax_recipient ) {
             $tax_recipient = $saved_tax_recipient;
         } else {
-            $tax_recipient = apply_filters( 'dokan_tax_fee_recipient', dokan_get_option( 'tax_fee_recipient', 'dokan_selling', 'seller' ), $order->get_id() );
+            $tax_recipient = apply_filters( 'dokan_tax_fee_recipient', dokan()->settings->get( 'product_tax_fee_recipient' ), $order->get_id() );
             $order->update_meta_data( 'tax_fee_recipient', $tax_recipient );
             $order->save();
         }
@@ -225,6 +225,10 @@ class Fees {
         }
 
         $default_tax_fee_recipient = $this->get_tax_fee_recipient( $order->get_id() ); // this is needed for backward compatibility
+        // Not migrated to dokan()->settings->get() yet: the third argument is a
+        // dynamic default that falls back to the product tax recipient when this
+        // setting is unset. The schema can only express a static default, so
+        // this site stays on dokan_get_option() until that BC contract is revisited.
         $shipping_tax_recipient    = dokan_get_option( 'shipping_tax_fee_recipient', 'dokan_selling', $default_tax_fee_recipient );
         $shipping_tax_recipient    = apply_filters( 'dokan_shipping_tax_fee_recipient', $shipping_tax_recipient, $order->get_id() );
 

--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -16,7 +16,7 @@ class Rewrites {
      * Hook into the functions
      */
     public function __construct() {
-        $this->custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url' );
 
         add_action( 'init', [ $this, 'register_rule' ] );
         add_action( 'pre_get_posts', [ $this, 'store_query_filter' ] );
@@ -55,7 +55,7 @@ class Rewrites {
         $author      = get_query_var( $this->custom_store_url );
         $seller_info = get_user_by( 'slug', $author );
 
-        $crumbs[1] = [ ucwords( $this->custom_store_url ), get_permalink( dokan_get_option( 'store_listing', 'dokan_pages' ) ) ];
+        $crumbs[1] = [ ucwords( $this->custom_store_url ), get_permalink( dokan()->settings->get( 'store_listing_page' ) ) ];
         if ( ! $seller_info ) {
             $crumbs[2] = [ __( 'Error 404', 'dokan-lite' ), '' ];
             return $crumbs;
@@ -108,7 +108,7 @@ class Rewrites {
         $base = empty( $base ) ? 'product' : $base;
 
         // get custom store url from settings so that we can use it from other places
-        $this->custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url' );
 
         // special treatment for product cat
         if ( stripos( $base, 'product_cat' ) ) {
@@ -146,7 +146,7 @@ class Rewrites {
     public function resolve_wc_query_conflict( $query_vars ) {
         global $post;
 
-        $dashboard_id = apply_filters( 'dokan_get_dashboard_page_id', dokan_get_option( 'dashboard', 'dokan_pages', 0 ) );
+        $dashboard_id = apply_filters( 'dokan_get_dashboard_page_id', dokan()->settings->get( 'vendor_dashboard_page' ) );
 
         if ( ! empty( $post->ID ) && apply_filters( 'dokan_get_current_page_id', $post->ID ) === absint( $dashboard_id ) ) {
             unset( $query_vars['orders'] );
@@ -312,7 +312,7 @@ class Rewrites {
             }
 
             $store_info  = dokan_get_store_info( $seller_info->data->ID );
-            $product_ppp = dokan_get_option( 'store_products_per_page', 'dokan_general', 12 );
+            $product_ppp = dokan()->settings->get( 'store_product_per_page' );
 
             do_action( 'dokan_store_page_query_filter', $query, $store_info );
             set_query_var( 'posts_per_page', apply_filters( 'dokan_store_products_per_page', $product_ppp ) );

--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -16,7 +16,7 @@ class Rewrites {
      * Hook into the functions
      */
     public function __construct() {
-        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
         add_action( 'init', [ $this, 'register_rule' ] );
         add_action( 'pre_get_posts', [ $this, 'store_query_filter' ] );
@@ -108,7 +108,7 @@ class Rewrites {
         $base = empty( $base ) ? 'product' : $base;
 
         // get custom store url from settings so that we can use it from other places
-        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url' );
+        $this->custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
         // special treatment for product cat
         if ( stripos( $base, 'product_cat' ) ) {
@@ -312,7 +312,7 @@ class Rewrites {
             }
 
             $store_info  = dokan_get_store_info( $seller_info->data->ID );
-            $product_ppp = dokan()->settings->get( 'store_product_per_page' );
+            $product_ppp = dokan()->settings->get( 'store_products_per_page' );
 
             do_action( 'dokan_store_page_query_filter', $query, $store_info );
             set_query_var( 'posts_per_page', apply_filters( 'dokan_store_products_per_page', $product_ppp ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -159,7 +159,7 @@ function dokan_is_product_author( $product_id = 0 ) {
  * @return bool
  */
 function dokan_is_store_page() {
-    $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+    $custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
     if ( get_query_var( $custom_store_url ) ) {
         return true;
@@ -189,7 +189,7 @@ function dokan_is_product_edit_page() {
 function dokan_is_seller_dashboard() {
     global $wp_query;
 
-    $page_id = apply_filters( 'dokan_get_dashboard_page_id', dokan_get_option( 'dashboard', 'dokan_pages' ) );
+    $page_id = apply_filters( 'dokan_get_dashboard_page_id', dokan()->settings->get( 'vendor_dashboard_page' ) );
 
     if ( ! $page_id ) {
         return false;
@@ -1149,7 +1149,7 @@ function dokan_get_store_url( $user_id, $tab = '' ) {
 
     $userdata         = get_userdata( $user_id );
     $user_nicename    = ( false !== $userdata ) ? $userdata->user_nicename : '';
-    $custom_store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
+    $custom_store_url = dokan()->settings->get( 'vendor_store_url_slug' );
 
     $path = '/' . $custom_store_url . '/' . $user_nicename . '/';
     if ( $tab ) {
@@ -1867,7 +1867,7 @@ function dokan_disable_admin_bar( $show_admin_bar ) {
 
     if ( $current_user->ID !== 0 ) {
         $role = reset( $current_user->roles );
-        $block_admin_access = dokan_get_option( 'admin_access', 'dokan_general', 'on' );
+        $block_admin_access = dokan()->settings->get( 'admin_access' );
         if ( OrderUtil::is_hpos_enabled() ) {
             $block_admin_access = 'on';
         }
@@ -2044,7 +2044,7 @@ add_filter( 'get_avatar_url', 'dokan_get_avatar_url', 99, 3 );
  * @return string url
  */
 function dokan_get_navigation_url( $name = '', $new_url = false ) {
-    $page_id = (int) dokan_get_option( 'dashboard', 'dokan_pages', 0 );
+    $page_id = (int) dokan()->settings->get( 'vendor_dashboard_page' );
 
     if ( ! $page_id ) {
         return '';
@@ -2590,7 +2590,7 @@ function dokan_after_login_redirect( $redirect_to, $user ) {
     if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore
         $redirect_to = esc_url( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore
     } elseif ( user_can( $user, 'dokandar' ) && wc_get_page_permalink( 'checkout' ) !== $redirect_to ) {
-        $seller_dashboard = (int) dokan_get_option( 'dashboard', 'dokan_pages' );
+        $seller_dashboard = (int) dokan()->settings->get( 'vendor_dashboard_page' );
 
         if ( $seller_dashboard !== - 1 ) {
             $redirect_to = get_permalink( $seller_dashboard );
@@ -3242,7 +3242,7 @@ function dokan_is_store_listing() {
     $page_id = get_the_ID();
     $found   = false;
 
-    if ( $page_id === intval( dokan_get_option( 'store_listing', 'dokan_pages' ) ) ) {
+    if ( $page_id === intval( dokan()->settings->get( 'store_listing_page' ) ) ) {
         $found = true;
     }
 
@@ -3292,7 +3292,7 @@ function dokan_generate_username( $name = 'store' ) {
  * @return string
  */
 function dokan_replace_policy_page_link_placeholders( $text ) {
-    $privacy_page_id = dokan_get_option( 'privacy_page', 'dokan_privacy' );
+    $privacy_page_id = dokan()->settings->get( 'privacy_policy_page' );
     $privacy_link    = $privacy_page_id ? '<a href="' . esc_url( get_permalink( $privacy_page_id ) ) . '" class="dokan-privacy-policy-link" target="_blank">' . __( 'privacy policy', 'dokan-lite' ) . '</a>' : __( 'privacy policy', 'dokan-lite' );
 
     $find_replace = [
@@ -3313,8 +3313,16 @@ function dokan_replace_policy_page_link_placeholders( $text ) {
  * @return string
  */
 function dokan_privacy_policy_text( $return = false ) {
+    // Two sites in this block remain on dokan_get_option() until their schema
+    // entries declare matching defaults:
+    //   - enable_privacy: schema default 'on' vs historical '' (the historical
+    //     contract was "off when unset"; a literal migration would silently
+    //     enable privacy on every install that never touched the setting).
+    //   - privacy_policy: schema has no default, but this call site supplies a
+    //     long localized fallback text. A literal migration would silently
+    //     blank out the privacy policy on unconfigured sites.
     $is_enabled   = 'on' === dokan_get_option( 'enable_privacy', 'dokan_privacy' );
-    $privacy_page = dokan_get_option( 'privacy_page', 'dokan_privacy' );
+    $privacy_page = dokan()->settings->get( 'privacy_policy_page' );
     $privacy_text = dokan_get_option( 'privacy_policy', 'dokan_privacy', __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [dokan_privacy_policy]', 'dokan-lite' ) );
 
     if ( ! $is_enabled || ! $privacy_page ) {
@@ -3433,7 +3441,7 @@ function dokan_admin_settings_rearrange_map( $option, $section ) {
  * @return string | null on failure
  */
 function dokan_get_terms_condition_url() {
-    $page_id = dokan_get_option( 'reg_tc_page', 'dokan_pages' );
+    $page_id = dokan()->settings->get( 'reg_tc_page' );
 
     if ( ! $page_id ) {
         return null;

--- a/src/admin/dashboard/pages/settings/register-fields.tsx
+++ b/src/admin/dashboard/pages/settings/register-fields.tsx
@@ -29,7 +29,7 @@ export function registerSettingsFields(): void {
             element: SettingsElement,
             value: Record< string, boolean >
         ) => {
-            if ( element.id === 'vendor_info_visibility' ) {
+            if ( element.id === 'store_page_vendor_info_visibility' ) {
                 return (
                     <DokanVendorInfoPreview
                         showEmail={ Boolean( value?.store_email ) }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -45,7 +45,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
     public function test_overlay_from_new_option_wins_over_raw_section(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         $repo = new LegacySettingsRepository();
         $this->assertSame(
@@ -105,7 +105,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo->all( 'dokan_general' );
         $repo->all( 'dokan_appearance' );
 
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // After flush, the next read should reflect the overlay from the new flat option.
         $this->assertSame( 'marketplace', $repo->get( 'dokan_general', 'custom_store_url' ) );
@@ -150,8 +150,8 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $new = get_option( 'dokan_admin_settings' );
         $this->assertIsArray( $new );
-        // Schema maps vendor_store_url → dokan_general.custom_store_url (SettingsSchema.php:153-165).
-        $this->assertSame( 'marketplace', $new['vendor_store_url'] );
+        // Schema maps vendor_store_url_slug → dokan_general.custom_store_url (SettingsSchema.php:153-165).
+        $this->assertSame( 'marketplace', $new['vendor_store_url_slug'] );
     }
 
     public function test_update_with_no_change_is_a_noop(): void {
@@ -266,12 +266,12 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo = new LegacySettingsRepository();
         $repo->replace( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
 
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
     }
 
     public function test_dokan_get_option_reads_through_repository(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // Flush repo cache so the next read sees the freshly-set options.
         dokan_get_container()
@@ -285,7 +285,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Set both options to a value that differs from what the test will write
         // so the diff is always non-empty regardless of any prior test's cached state.
         update_option( 'dokan_general', [ 'custom_store_url' => 'before' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'before' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'before' ] );
 
         // Flush every in-request snapshot (container singletons + internal private
         // repos inside LegacySettingsRepository and LegacySettingsBridge) so the
@@ -301,7 +301,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Legacy storage updated.
         $this->assertSame( 'marketplace', get_option( 'dokan_general' )['custom_store_url'] );
         // New flat storage updated via mirror.
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
         // dokan_get_option() resolves through the repo and sees the overlay.
         $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
     }

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryFindFieldTest.php
@@ -26,10 +26,10 @@ class SettingsRegistryFindFieldTest extends DokanTestCase {
 
 	public function test_find_field_returns_field_array_for_registered_id(): void {
 		$registry = new SettingsRegistry();
-		$field    = $registry->find_field( 'vendor_store_url' );
+		$field    = $registry->find_field( 'vendor_store_url_slug' );
 
-		$this->assertNotNull( $field, 'vendor_store_url must be registered.' );
-		$this->assertSame( 'vendor_store_url', $field['id'] );
+		$this->assertNotNull( $field, 'vendor_store_url_slug must be registered.' );
+		$this->assertSame( 'vendor_store_url_slug', $field['id'] );
 		$this->assertSame( 'field', $field['type'] );
 		$this->assertArrayHasKey( 'default', $field );
 	}
@@ -62,14 +62,14 @@ class SettingsRegistryFindFieldTest extends DokanTestCase {
 		$registry = new SettingsRegistry();
 
 		// Prime the index.
-		$this->assertNotNull( $registry->find_field( 'vendor_store_url' ) );
+		$this->assertNotNull( $registry->find_field( 'vendor_store_url_slug' ) );
 
 		// Mutate stored value, clear cache, re-read — the rebuilt field should reflect the new value.
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 		$registry->clear_cache();
 
-		$field = $registry->find_field( 'vendor_store_url' );
+		$field = $registry->find_field( 'vendor_store_url_slug' );
 		$this->assertNotNull( $field );
 		$this->assertSame( 'boutique', $field['value'] );
 	}

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
@@ -31,7 +31,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
         update_option(
             'dokan_admin_settings',
             [
-                'vendor_store_url' => 'shop',
+                'vendor_store_url_slug' => 'shop',
                 'map_api_source'   => 'mapbox',
             ]
         );
@@ -44,7 +44,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             if ( ( $el['type'] ?? '' ) !== 'field' ) {
                 continue;
             }
-            if ( ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $store_url_field = $el;
             }
             if ( ( $el['id'] ?? '' ) === 'map_api_source' ) {
@@ -52,8 +52,8 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             }
         }
 
-        $this->assertNotNull( $store_url_field, 'Field vendor_store_url must exist in the schema.' );
-        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url value must come from dokan_settings.' );
+        $this->assertNotNull( $store_url_field, 'Field vendor_store_url_slug must exist in the schema.' );
+        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url_slug value must come from dokan_settings.' );
 
         $this->assertNotNull( $map_source_field, 'Field map_api_source must exist in the schema.' );
         $this->assertSame( 'mapbox', $map_source_field['value'], 'map_api_source value must come from dokan_settings.' );
@@ -66,19 +66,19 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }
         }
 
-        $this->assertNotNull( $found, 'vendor_store_url must exist.' );
+        $this->assertNotNull( $found, 'vendor_store_url_slug must exist.' );
         $this->assertSame( $found['default'] ?? '', $found['value'], 'Missing stored id must yield the field default.' );
     }
 
     public function test_no_per_page_wp_options_are_read(): void {
         // Seed the OLD per-page key with a value that would have been read by the previous code path.
-        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url' => 'OLD_VALUE' ] ] ] );
+        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url_slug' => 'OLD_VALUE' ] ] ] );
         // The new key is empty, so reads should fall back to the field default — NOT to OLD_VALUE.
         delete_option( 'dokan_admin_settings' );
 
@@ -86,7 +86,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }

--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -175,10 +175,10 @@ class SettingsSchemaTest extends DokanTestCase {
     // Expected fields
     // =========================================================================
 
-    public function test_vendor_store_url_field_exists(): void {
-        $field = $this->find_element( 'vendor_store_url', 'field' );
+    public function test_vendor_store_url_slug_field_exists(): void {
+        $field = $this->find_element( 'vendor_store_url_slug', 'field' );
 
-        $this->assertNotNull( $field, 'vendor_store_url field not found.' );
+        $this->assertNotNull( $field, 'vendor_store_url_slug field not found.' );
         $this->assertSame( 'text', $field['variant'] );
         $this->assertSame( 'store', $field['default'] );
         $this->assertSame( 'marketplace_settings', $field['section_id'] );

--- a/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorIntegrationTest.php
@@ -43,14 +43,14 @@ class SettingsAccessorIntegrationTest extends DokanTestCase {
     }
 
     public function test_dokan_settings_get_returns_schema_default_when_unset(): void {
-        $this->assertSame( 'store', dokan()->settings->get( 'vendor_store_url' ) );
+        $this->assertSame( 'store', dokan()->settings->get( 'vendor_store_url_slug' ) );
     }
 
     public function test_dokan_settings_get_reads_new_flat_option(): void {
         $repo = new SettingsRepository();
-        $repo->update( [ 'vendor_store_url' => 'boutique' ] );
+        $repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
-        $this->assertSame( 'boutique', dokan()->settings->get( 'vendor_store_url' ) );
+        $this->assertSame( 'boutique', dokan()->settings->get( 'vendor_store_url_slug' ) );
     }
 
     public function test_dokan_settings_get_overlays_legacy_section_value(): void {
@@ -59,10 +59,10 @@ class SettingsAccessorIntegrationTest extends DokanTestCase {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
 
         // The legacy field 'dokan_general.custom_store_url' maps to flat id
-        // 'vendor_store_url' (see SettingsSchema.php:166).
+        // 'vendor_store_url_slug' (see SettingsSchema.php:166).
         $this->assertSame(
             'shoppe',
-            dokan()->settings->get( 'vendor_store_url' ),
+            dokan()->settings->get( 'vendor_store_url_slug' ),
             'Accessor must reflect legacy per-section values via the bridge overlay.'
         );
     }

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -67,6 +67,42 @@ class SettingsAccessorTest extends DokanTestCase {
 		$this->assertFalse( $accessor->has( 'not_a_real_setting_xyz' ) );
 	}
 
+	public function test_has_stored_returns_false_for_unregistered_id(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertFalse( $accessor->has_stored( 'not_a_real_setting_xyz' ) );
+	}
+
+	public function test_has_stored_returns_false_when_registered_but_unset(): void {
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url is
+		// registered with a schema default — has() is true, has_stored() must be false.
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
+		$this->assertFalse( $accessor->has_stored( 'vendor_store_url' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_in_new_flat_option(): void {
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has_stored( 'vendor_store_url' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_only_in_legacy_option(): void {
+		// New flat option is empty; legacy dokan_general.custom_store_url is set.
+		// The bridge overlay must make this count as "stored".
+		update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue(
+			$accessor->has_stored( 'vendor_store_url' ),
+			'A value present only in the mapped legacy option must count as stored via the bridge overlay.'
+		);
+
+		// Cleanup outside the standard tearDown.
+		delete_option( 'dokan_general' );
+	}
+
 	public function test_all_returns_every_field_keyed_by_id_with_value_or_default(): void {
 		$repo = new SettingsRepository();
 		$repo->update( [ 'vendor_store_url' => 'boutique' ] );

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -27,17 +27,17 @@ class SettingsAccessorTest extends DokanTestCase {
 
 	public function test_get_returns_stored_value_for_registered_id(): void {
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url' ) );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_get_returns_schema_default_when_no_stored_value(): void {
-		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url has a
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url_slug has a
 		// schema default of 'store' (see SettingsSchema.php:165).
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'store', $accessor->get( 'vendor_store_url' ) );
+		$this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_get_returns_fallback_for_unregistered_key(): void {
@@ -51,15 +51,15 @@ class SettingsAccessorTest extends DokanTestCase {
 	public function test_get_ignores_fallback_when_key_is_registered(): void {
 		// Stored value present — fallback should be ignored.
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url', 'IGNORED' ) );
+		$this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug', 'IGNORED' ) );
 	}
 
 	public function test_has_returns_true_for_registered_field_id(): void {
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
+		$this->assertTrue( $accessor->has( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_has_returns_false_for_unregistered_id(): void {
@@ -73,19 +73,19 @@ class SettingsAccessorTest extends DokanTestCase {
 	}
 
 	public function test_has_stored_returns_false_when_registered_but_unset(): void {
-		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url is
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url_slug is
 		// registered with a schema default — has() is true, has_stored() must be false.
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
-		$this->assertFalse( $accessor->has_stored( 'vendor_store_url' ) );
+		$this->assertTrue( $accessor->has( 'vendor_store_url_slug' ) );
+		$this->assertFalse( $accessor->has_stored( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_has_stored_returns_true_when_value_in_new_flat_option(): void {
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
-		$this->assertTrue( $accessor->has_stored( 'vendor_store_url' ) );
+		$this->assertTrue( $accessor->has_stored( 'vendor_store_url_slug' ) );
 	}
 
 	public function test_has_stored_returns_true_when_value_only_in_legacy_option(): void {
@@ -95,7 +95,7 @@ class SettingsAccessorTest extends DokanTestCase {
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$this->assertTrue(
-			$accessor->has_stored( 'vendor_store_url' ),
+			$accessor->has_stored( 'vendor_store_url_slug' ),
 			'A value present only in the mapped legacy option must count as stored via the bridge overlay.'
 		);
 
@@ -105,15 +105,15 @@ class SettingsAccessorTest extends DokanTestCase {
 
 	public function test_all_returns_every_field_keyed_by_id_with_value_or_default(): void {
 		$repo = new SettingsRepository();
-		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+		$repo->update( [ 'vendor_store_url_slug' => 'boutique' ] );
 
 		$accessor = new SettingsAccessor( new SettingsRegistry() );
 		$all      = $accessor->all();
 
 		$this->assertIsArray( $all );
 		$this->assertNotEmpty( $all, 'all() must return every registered field, not an empty array.' );
-		$this->assertArrayHasKey( 'vendor_store_url', $all );
-		$this->assertSame( 'boutique', $all['vendor_store_url'] );
+		$this->assertArrayHasKey( 'vendor_store_url_slug', $all );
+		$this->assertSame( 'boutique', $all['vendor_store_url_slug'] );
 
 		foreach ( $all as $id => $_value ) {
 			$this->assertIsString( $id );

--- a/tests/php/src/REST/SettingsRoundTripTest.php
+++ b/tests/php/src/REST/SettingsRoundTripTest.php
@@ -161,7 +161,7 @@ class SettingsRoundTripTest extends DokanTestCase {
      * The new UI calls PUT `/dokan/v1/admin/settings/{page_id}`, which
      * writes `dokan_settings`. The `BridgeBootstrap` listener (registered
      * on `dokan_admin_settings_changed`) mirrors mapped keys to their
-     * legacy option counterparts. Uses the hand-authored `vendor_store_url`
+     * legacy option counterparts. Uses the hand-authored `vendor_store_url_slug`
      * field on the `general` page which carries `legacy_key
      * => 'dokan_general.custom_store_url'`.
      *
@@ -173,7 +173,7 @@ class SettingsRoundTripTest extends DokanTestCase {
             [
                 'page_id' => 'general',
                 'values'  => [
-                    'vendor_store_url' => 'mystorez',
+                    'vendor_store_url_slug' => 'mystorez',
                 ],
             ]
         );
@@ -198,7 +198,7 @@ class SettingsRoundTripTest extends DokanTestCase {
         $new = get_option( 'dokan_admin_settings', [] );
         $this->assertSame(
             'mystorez',
-            $new['vendor_store_url'] ?? null,
+            $new['vendor_store_url_slug'] ?? null,
             'REST PUT should have written the value into dokan_settings.'
         );
 
@@ -255,15 +255,15 @@ class SettingsRoundTripTest extends DokanTestCase {
     public function test_rest_put_with_dot_path_payload_resolves_to_leaf_id(): void {
         // Pre-condition: a known field has a value in storage.
         ( new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository() )
-            ->update( [ 'vendor_store_url' => 'unchanged' ] );
+            ->update( [ 'vendor_store_url_slug' => 'unchanged' ] );
 
         $request = new WP_REST_Request( 'PUT', '/' . $this->namespace . '/settings/general' );
         $request->set_body_params(
             [
                 'page_id' => 'general',
                 'values'  => [
-                    // Dot-path key — controller strips to leaf id `vendor_store_url`.
-                    'general.marketplace.vendor_store_url' => 'updated-via-dotpath',
+                    // Dot-path key — controller strips to leaf id `vendor_store_url_slug`.
+                    'general.marketplace.vendor_store_url_slug' => 'updated-via-dotpath',
                 ],
             ]
         );
@@ -274,8 +274,8 @@ class SettingsRoundTripTest extends DokanTestCase {
         $this->assertIsArray( $settings );
         $this->assertSame(
             'updated-via-dotpath',
-            $settings['vendor_store_url'] ?? null,
-            'Dot-path payload key must resolve to its leaf id (vendor_store_url).'
+            $settings['vendor_store_url_slug'] ?? null,
+            'Dot-path payload key must resolve to its leaf id (vendor_store_url_slug).'
         );
     }
 

--- a/tests/pw/pages/adminSettingsPage.ts
+++ b/tests/pw/pages/adminSettingsPage.ts
@@ -671,7 +671,7 @@ export class AdminSettingsPage extends BasePage {
     async getEnableSellingOptionFromNewSettings(): Promise<string> {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         // Find the currently selected button (aria-checked="true")
@@ -689,7 +689,7 @@ export class AdminSettingsPage extends BasePage {
     async updateEnableSellingOptionInNewSettings(option: string) {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         const targetButton = baseLocator.locator(`[role="radio"][name="${option}"]`);
@@ -749,7 +749,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -780,7 +780,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -904,7 +904,7 @@ export class AdminSettingsPage extends BasePage {
 
         // Locate the switch element for Welcome Wizard
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -934,7 +934,7 @@ export class AdminSettingsPage extends BasePage {
         console.log('Navigated to New Vendor Settings for Welcome Wizard check.......');
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });

--- a/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
@@ -491,7 +491,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'disable_product_popup'; 
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup';
         const fieldKey = 'productPopupField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"
@@ -533,7 +533,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'order_status_change';
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status';
         const fieldKey = 'orderStatusChangeField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"

--- a/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
@@ -68,7 +68,7 @@ const newDataset = {
     selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
             type: 'text',
             value: 'my-url',
         },

--- a/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
@@ -46,42 +46,42 @@ const newDataset = {
     selector: '#dokan_settings_appearance >> #dokan_settings_appearance_store',
     fields: [
         {
-            selector: '#dokan_settings_appearance_store_products_page_store_product_per_page input[placeholder="Products Per Page"]',
+            selector: '#dokan_settings_appearance_store_products_page_store_products_per_page input[placeholder="Products Per Page"]',
             type: 'number',
             value: '12',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_site_key input[placeholder="Site Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_site_key input[placeholder="Site Key"]',
             type: 'text',
             value: 'SITE_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_secret_key input[placeholder="Secret Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_secret_key input[placeholder="Secret Key"]',
             type: 'text',
             value: 'SECRET_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_clossing_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_contact_form_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_opening_closing_time_widget button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_opening_time button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_sidebar_from_theme button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_font button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_fontawesome_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },    

--- a/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
@@ -140,7 +140,7 @@ const newDataset = {
         
         // Display Notice During Grace Period - Switch
         {
-            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_display_notice button[role="switch"]',
+            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_reverse_withdrawal_grace_period_notice button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
@@ -127,14 +127,14 @@ const newDataset = {
         
         // Product Popup - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup button[role="switch"]',
             type: 'switch',
             value: true,
         },
         
         // Order Status Change - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
@@ -53,12 +53,12 @@ const newDataset = {
     //selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_enable_selling button[name="automatically"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling button[name="automatically"]',
             type: 'radio',
             value: 'true',
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_address_fields button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields button[role="switch"]',
             type: 'switch',
             value: true,
         },
@@ -68,7 +68,7 @@ const newDataset = {
             value: true,
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_welcome_wizard button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled button[role="switch"]',
             type: 'switch',
             value: false, // Note: Inverted value compared to old setting
         },

--- a/tests/pw/utils/testData.ts
+++ b/tests/pw/utils/testData.ts
@@ -1393,7 +1393,7 @@ export const data = {
             newUI: {
                 generalButton: '#dokan_settings_general button',
                 marketplaceLink: '#dokan_settings_general_marketplace',
-                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
                 singleSellerModeField: '#dokan_settings_general_marketplace_marketplace_settings_enable_single_seller_mode',
                 saveButton: '#dokan-admin-settings-save-btn button',
                 successMessage: '.notice-success, .updated',


### PR DESCRIPTION
## Summary

First per-module call-site migration following PR #3209. Migrates 7 of 9 `dokan_get_option` / raw-`get_option` sites in `Fees.php` and `Rewrites.php` to the new `dokan()->settings->get()` API.

**Stacked on:** `refactor/settings-accessor-api` (PR #3209). Merge that first; this PR's diff against `develop` is the union of the two.

## Migrations (7 sites)

| File:Line | Old | New | Notes |
|---|---|---|---|
| Fees.php:169 | `dokan_get_option('shipping_fee_recipient', 'dokan_selling', 'seller')` | `dokan()->settings->get('shipping_fee_recipient')` | same flat id, default matches |
| Fees.php:202 | `dokan_get_option('tax_fee_recipient', 'dokan_selling', 'seller')` | `dokan()->settings->get('product_tax_fee_recipient')` | renamed in schema |
| Rewrites.php:19, :111 | `dokan_get_option('custom_store_url', 'dokan_general', 'store')` | `dokan()->settings->get('vendor_store_url')` | renamed in schema |
| Rewrites.php:58 | `dokan_get_option('store_listing', 'dokan_pages')` | `dokan()->settings->get('store_listing_page')` | renamed; both sides default to '' |
| Rewrites.php:149 | `dokan_get_option('dashboard', 'dokan_pages', 0)` | `dokan()->settings->get('vendor_dashboard_page')` | renamed; downstream `absint()` makes `''` and `0` equivalent |
| Rewrites.php:315 | `dokan_get_option('store_products_per_page', 'dokan_general', 12)` | `dokan()->settings->get('store_product_per_page')` | renamed (note: schema id is singular `product`) |

No transformer-mapped fields in this batch, so there are no comparison-inversion risks (per spec §9).

## Sites intentionally NOT migrated

- **Fees.php:228** — `dokan_get_option('shipping_tax_fee_recipient', 'dokan_selling', \$default_tax_fee_recipient)`. The third arg is a *dynamic* default that falls back to the product tax recipient when this setting isn't explicitly stored — a backward-compat contract that the schema (static defaults only) cannot express. Left on `dokan_get_option()` with an inline note; flagged for follow-up.
- **Rewrites.php:545** — `get_option('dokan_rewrite_rules_needs_flashing', 'yes')`. Operational state flag, not a schema setting (spec §7.2 bucket C). Stays raw.

## Test plan

- [ ] PHPCS: `composer phpcs -- includes/Fees.php includes/Rewrites.php` — clean.
- [ ] Smoke: store URL slug, dashboard page lookup, store-listing breadcrumb permalink, and per-page product count all behave identically on a freshly-installed site (no stored settings; schema defaults active).
- [ ] Smoke: same checks after setting non-default values via the admin UI.
- [ ] Existing PHPUnit / Playwright suites pass — `npm run phpunit`, settings-related Playwright specs.

## Out of scope

- The dynamic-default site at Fees.php:228 (tracked).
- All other modules — covered by subsequent PR 3..N per the spec.