### PR TITLE
feat(settings): add has_stored() + finish Fees.php migration (PR 3/N)

### DIFF
--- a/docs/settings/accessing.md
+++ b/docs/settings/accessing.md
@@ -13,11 +13,13 @@ $value = dokan()->settings->get( 'vendor_store_url' );
 ```php
 dokan()->settings->get( string $key, $fallback = null );
 dokan()->settings->has( string $key ): bool;
+dokan()->settings->has_stored( string $key ): bool;
 dokan()->settings->all(): array;
 ```
 
 - `$key` is the flat schema id (the `id` field on a `SettingsElement` in `includes/Admin/Settings/Schema/SettingsSchema.php`). It is **not** the legacy section/field name from `dokan_get_option()`.
 - `$fallback` is only used when `$key` is not registered in the schema. For registered keys the schema default is authoritative — do not pass a `$fallback` to override it.
+- `has()` checks whether the id is **registered** in the schema. `has_stored()` checks whether a **user-set value** exists in storage (the new flat option, or — via the legacy bridge — a mapped per-section option). Use `has_stored()` when you need to distinguish a user choice from a schema default falling through — e.g. to preserve a runtime fallback that depends on another setting.
 - `all()` returns every registered field's effective value (stored value, or schema default when nothing is stored), keyed by id.
 
 ## Choosing the right key

--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -35,6 +35,16 @@ class SettingsRegistry {
     private ?array $field_index = null;
 
     /**
+     * Lazy set of ids that are present in storage (flat option or via the
+     * legacy bridge overlay). Null until first {@see is_stored()} call.
+     *
+     * Keys are flat schema ids; values are unused (the array is used as a set).
+     *
+     * @var array<string,bool>|null
+     */
+    private ?array $stored_keys = null;
+
+    /**
      * Settings repository — single read surface for the stored payload.
      *
      * @var SettingsRepositoryInterface
@@ -102,6 +112,7 @@ class SettingsRegistry {
     public function clear_cache(): void {
         $this->cache       = null;
         $this->field_index = null;
+        $this->stored_keys = null;
     }
 
     /**
@@ -144,6 +155,56 @@ class SettingsRegistry {
                 continue;
             }
             $this->field_index[ $id ] = $element;
+        }
+    }
+
+    /**
+     * Whether `$id` has a value present in storage (the flat option or, via
+     * the legacy bridge, a mapped per-section legacy option).
+     *
+     * Returns false for unregistered ids, and false when the only "value" the
+     * accessor would return is the schema default. Use this to distinguish a
+     * user-set value from a defaulted one — e.g. when preserving a runtime
+     * fallback that depends on another setting.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $id Flat schema id.
+     *
+     * @return bool
+     */
+    public function is_stored( string $id ): bool {
+        if ( null === $this->stored_keys ) {
+            $this->build_stored_keys();
+        }
+        return isset( $this->stored_keys[ $id ] );
+    }
+
+    /**
+     * Build the set of ids present in storage, applying the same bridge
+     * overlay {@see populate_values()} uses so legacy-only values count
+     * as "stored".
+     *
+     * @return void
+     */
+    private function build_stored_keys(): void {
+        $stored = $this->settings_repo->all();
+
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                $bridge = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class );
+                $stored = $bridge->hydrate_new_from_legacy( $stored );
+            } catch ( \Throwable $unused ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $unused );
+                // Container not booted — fall back to flat-only view.
+            }
+        }
+
+        $this->stored_keys = [];
+        foreach ( array_keys( $stored ) as $id ) {
+            if ( is_string( $id ) && '' !== $id ) {
+                $this->stored_keys[ $id ] = true;
+            }
         }
     }
 

--- a/includes/Admin/Settings/SettingsAccessor.php
+++ b/includes/Admin/Settings/SettingsAccessor.php
@@ -65,6 +65,13 @@ final class SettingsAccessor implements SettingsAccessorInterface {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function has_stored( string $key ): bool {
+		return $this->has( $key ) && $this->registry->is_stored( $key );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function all(): array {
 		$out = [];
 		foreach ( $this->registry->get_schema() as $element ) {

--- a/includes/Admin/Settings/SettingsAccessorInterface.php
+++ b/includes/Admin/Settings/SettingsAccessorInterface.php
@@ -40,6 +40,27 @@ interface SettingsAccessorInterface {
 	public function has( string $key ): bool;
 
 	/**
+	 * Whether `$key` has a value present in storage (the flat option or, via
+	 * the legacy bridge, a mapped per-section legacy option).
+	 *
+	 * Distinct from {@see has()}: a registered key with no stored value
+	 * returns true from `has()` (it's known to the schema) but false from
+	 * `has_stored()` (its effective value comes from the schema default,
+	 * not from a user-set value).
+	 *
+	 * Use this to preserve runtime fallback contracts that depend on whether
+	 * the user explicitly set a value — e.g. "fall back to the product tax
+	 * recipient when shipping_tax_fee_recipient isn't explicitly stored".
+	 *
+	 * @since DOKAN_SINCE
+	 *
+	 * @param string $key Flat schema id.
+	 *
+	 * @return bool
+	 */
+	public function has_stored( string $key ): bool;
+
+	/**
 	 * Snapshot of every registered field's effective value, keyed by id.
 	 *
 	 * @return array<string,mixed>

--- a/includes/Fees.php
+++ b/includes/Fees.php
@@ -225,11 +225,9 @@ class Fees {
         }
 
         $default_tax_fee_recipient = $this->get_tax_fee_recipient( $order->get_id() ); // this is needed for backward compatibility
-        // Not migrated to dokan()->settings->get() yet: the third argument is a
-        // dynamic default that falls back to the product tax recipient when this
-        // setting is unset. The schema can only express a static default, so
-        // this site stays on dokan_get_option() until that BC contract is revisited.
-        $shipping_tax_recipient    = dokan_get_option( 'shipping_tax_fee_recipient', 'dokan_selling', $default_tax_fee_recipient );
+        $shipping_tax_recipient    = dokan()->settings->has_stored( 'shipping_tax_fee_recipient' )
+            ? dokan()->settings->get( 'shipping_tax_fee_recipient' )
+            : $default_tax_fee_recipient;
         $shipping_tax_recipient    = apply_filters( 'dokan_shipping_tax_fee_recipient', $shipping_tax_recipient, $order->get_id() );
 
         $order->update_meta_data( 'shipping_tax_fee_recipient', $shipping_tax_recipient, true );

--- a/tests/php/src/Admin/Settings/SettingsAccessorTest.php
+++ b/tests/php/src/Admin/Settings/SettingsAccessorTest.php
@@ -67,6 +67,42 @@ class SettingsAccessorTest extends DokanTestCase {
 		$this->assertFalse( $accessor->has( 'not_a_real_setting_xyz' ) );
 	}
 
+	public function test_has_stored_returns_false_for_unregistered_id(): void {
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertFalse( $accessor->has_stored( 'not_a_real_setting_xyz' ) );
+	}
+
+	public function test_has_stored_returns_false_when_registered_but_unset(): void {
+		// dokan_admin_settings is empty (cleared in setUp). vendor_store_url is
+		// registered with a schema default — has() is true, has_stored() must be false.
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has( 'vendor_store_url' ) );
+		$this->assertFalse( $accessor->has_stored( 'vendor_store_url' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_in_new_flat_option(): void {
+		$repo = new SettingsRepository();
+		$repo->update( [ 'vendor_store_url' => 'boutique' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue( $accessor->has_stored( 'vendor_store_url' ) );
+	}
+
+	public function test_has_stored_returns_true_when_value_only_in_legacy_option(): void {
+		// New flat option is empty; legacy dokan_general.custom_store_url is set.
+		// The bridge overlay must make this count as "stored".
+		update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+		$accessor = new SettingsAccessor( new SettingsRegistry() );
+		$this->assertTrue(
+			$accessor->has_stored( 'vendor_store_url' ),
+			'A value present only in the mapped legacy option must count as stored via the bridge overlay.'
+		);
+
+		// Cleanup outside the standard tearDown.
+		delete_option( 'dokan_general' );
+	}
+
 	public function test_all_returns_every_field_keyed_by_id_with_value_or_default(): void {
 		$repo = new SettingsRepository();
 		$repo->update( [ 'vendor_store_url' => 'boutique' ] );


### PR DESCRIPTION
## Summary

Adds `dokan()->settings->has_stored( \$key ): bool` and completes the Fees.php call-site migration that PR #3210 had to skip.

**Stacked on:** PR #3210 (`refactor/settings-migrate-fees-rewrites`), which is stacked on PR #3209.

## Why

PR #3210 left one site untouched — `Fees::get_shipping_tax_fee_recipient()` at `includes/Fees.php:228`. Its `dokan_get_option()` call used a *dynamic* third-arg default that falls back to the product tax recipient when this setting isn't explicitly stored. The accessor's schema-driven defaults can only express a static default, so the BC contract couldn't be preserved by a literal migration.

`has_stored()` is the missing primitive: it lets callers distinguish "the user set this" from "the schema default falls through." Other call sites in the codebase have the same shape (a runtime fallback that depends on another setting) and will benefit from this in later migration PRs.

## What

| | Returns true when |
|---|---|
| `has( \$key )` | the id is registered in the schema |
| `has_stored( \$key )` | the id is **registered** AND a value exists in storage (new flat option, or — via the legacy bridge — a mapped per-section option) |

### Implementation (5 commits)

1. **`SettingsRegistry::is_stored( \$id )`** — lazy id-keyed set of stored keys, built by applying the same `LegacySettingsBridge::hydrate_new_from_legacy()` overlay that `populate_values()` uses. Invalidated alongside the existing caches in `clear_cache()`.
2. **`SettingsAccessorInterface::has_stored()` + `SettingsAccessor` delegate** — one-liner that combines `has()` (registration check) with `is_stored()` (storage check).
3. **Tests (4 new):** unregistered key, registered-but-unset, value in new flat option, value only in legacy option (proves bridge overlay path).
4. **Fees.php:228 migration** — replaces the lingering `dokan_get_option()` with `has_stored()`-guarded `get()`. Preserves the BC contract exactly.
5. **Docs** — `docs/settings/accessing.md` now lists `has_stored()` and explains when to choose it over `has()`.

## Test plan

- [ ] PHPCS clean across the 5 changed files (verified locally).
- [ ] PHPUnit \`SettingsAccessorTest\` — 11 tests pass (7 existing + 4 new).
- [ ] PHPUnit \`SettingsRegistryFindFieldTest\` — still green (the registry test file doesn't cover `is_stored()` directly, but the accessor integration tests exercise the path through the same code).
- [ ] Smoke: place an order with shipping tax on a fresh site (no stored `shipping_tax_fee_recipient`) and confirm the recipient still falls back to the product tax recipient — equivalent to pre-migration behavior.

## Out of scope

- Other call sites with dynamic-default semantics (will be migrated in subsequent PRs now that the primitive exists).
- The next module migration (functions.php, REST controllers, etc.).