### PR TITLE
fix(settings): invalidate SettingsRegistry cache on option change

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -2,6 +2,7 @@
 
 namespace WeDevs\Dokan\Admin\Settings\Schema;
 
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepositoryInterface;
 
@@ -58,6 +59,62 @@ class SettingsRegistry {
      */
     public function __construct( ?SettingsRepositoryInterface $settings_repo = null ) {
         $this->settings_repo = $settings_repo ?? new SettingsRepository();
+        $this->register_cache_invalidation_hooks();
+    }
+
+    /**
+     * Invalidate the processed schema cache whenever its underlying storage
+     * changes. Without this, consumers like {@see SettingsAccessor::get()}
+     * return stale values after any in-request option write.
+     *
+     * Listens to:
+     *   - The new flat option ({@see SettingsRepository::OPTION_KEY}) where
+     *     all admin writes land.
+     *   - Every legacy `dokan_*` section that the bridge knows about — Pro
+     *     and third-party `update_option()` writes against those sections
+     *     would otherwise leave the registry overlay stale.
+     *
+     * @return void
+     */
+    private function register_cache_invalidation_hooks(): void {
+        $new_option = SettingsRepository::OPTION_KEY;
+        add_action( "update_option_{$new_option}", [ $this, 'clear_cache' ] );
+        add_action( "add_option_{$new_option}", [ $this, 'clear_cache' ] );
+
+        if ( ! function_exists( 'dokan_get_container' ) ) {
+            return;
+        }
+        try {
+            $bridge = dokan_get_container()->get( LegacySettingsBridge::class );
+            if ( ! $bridge instanceof LegacySettingsBridge ) {
+                return;
+            }
+        } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            // Bridge not booted yet — fall back to new-flat-option-only invalidation.
+            return;
+        }
+
+        foreach ( $this->known_legacy_sections( $bridge ) as $section ) {
+            add_action( "update_option_{$section}", [ $this, 'clear_cache' ] );
+            add_action( "add_option_{$section}", [ $this, 'clear_cache' ] );
+        }
+    }
+
+    /**
+     * Unique legacy section option names mentioned in the bridge mapping.
+     *
+     * @param LegacySettingsBridge $bridge
+     *
+     * @return array<int,string>
+     */
+    private function known_legacy_sections( LegacySettingsBridge $bridge ): array {
+        $sections = [];
+        foreach ( $bridge->get_mapping() as $entry ) {
+            if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+                $sections[ $entry['option'] ] = true;
+            }
+        }
+        return array_keys( $sections );
     }
 
     /**

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryCacheInvalidationTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryCacheInvalidationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Schema;
+
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\Admin\Settings\SettingsAccessor;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Regression: SettingsRegistry must invalidate its processed-schema cache
+ * when the underlying storage changes within a single request, so
+ * dokan()->settings->get() never returns stale values after a write.
+ *
+ * @group admin-settings
+ * @group settings-schema
+ * @group settings-cache
+ */
+class SettingsRegistryCacheInvalidationTest extends DokanTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        delete_option( 'dokan_admin_settings' );
+        delete_option( 'dokan_general' );
+    }
+
+    protected function tearDown(): void {
+        delete_option( 'dokan_admin_settings' );
+        delete_option( 'dokan_general' );
+        parent::tearDown();
+    }
+
+    public function test_cache_invalidates_when_new_flat_option_is_updated(): void {
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        // Prime the cache with the schema default.
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        // Write through the canonical repository.
+        ( new SettingsRepository() )->update( [ 'vendor_store_url_slug' => 'boutique' ] );
+
+        // Without invalidation hooks, this would still return the cached 'store'.
+        $this->assertSame( 'boutique', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+
+    public function test_cache_invalidates_when_legacy_section_is_updated(): void {
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        // Prime the cache.
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        // Write the legacy field that maps to vendor_store_url_slug
+        // (legacy_key: dokan_general.custom_store_url).
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shoppe' ] );
+
+        // The bridge overlay should pick up the legacy write on the next read.
+        $this->assertSame( 'shoppe', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+
+    public function test_cache_invalidates_when_new_flat_option_is_added(): void {
+        // Ensure the option doesn't exist so add_option fires (not update_option).
+        delete_option( SettingsRepository::OPTION_KEY );
+
+        $registry = new SettingsRegistry();
+        $accessor = new SettingsAccessor( $registry );
+
+        $this->assertSame( 'store', $accessor->get( 'vendor_store_url_slug' ) );
+
+        add_option( SettingsRepository::OPTION_KEY, [ 'vendor_store_url_slug' => 'emporium' ] );
+
+        $this->assertSame( 'emporium', $accessor->get( 'vendor_store_url_slug' ) );
+    }
+}


### PR DESCRIPTION
## Summary

`SettingsRegistry` caches its processed schema (with overlay-applied values) on first read. Without invalidation listeners, the cache goes stale the moment anything writes to `dokan_admin_settings` or any of the legacy `dokan_*` sections within the same request — `dokan()->settings->get()` silently returns pre-write values.

## Why this surfaces now

Previously masked because `dokan_get_option()` reads through `LegacySettingsRepository`, which DOES wire its own per-section flush listeners. Once call sites migrate to `dokan()->settings->get()` (the ongoing PR series targeting this branch), the overlay-aware registry becomes the read path and the missing invalidation surfaces as stale values.

Symptom that surfaced this: characterization tests in the upcoming reverse-withdrawal migration PR (PR 3/N) that write to `dokan_reverse_withdrawal` and then read via `SettingsHelper` were returning schema defaults instead of the just-written values. Pre-migration the same tests would have passed.

## Fix

Wire option-change listeners in `SettingsRegistry`'s constructor:
- `update_option_{dokan_admin_settings}` / `add_option_{dokan_admin_settings}` for the canonical write surface.
- `update_option_{section}` / `add_option_{section}` for every legacy section name the bridge knows about (`LegacySettingsBridge::get_mapping()`), so Pro and raw third-party `update_option()` writes also invalidate the overlay.

Bridge enumeration is wrapped in a `dokan_get_container()` availability check so the registry stays instantiable pre-bootstrap (e.g. in unit tests with no container).

## Test plan

- [x] New regression file `SettingsRegistryCacheInvalidationTest` (3 tests / 6 assertions, all green): new-flat-option update, legacy section update via bridge overlay, new-flat-option add.
- [x] No regression in existing settings test suite (same 4 pre-existing failures as before; none introduced by this patch).
- [x] `wp plugin activate woocommerce dokan-lite` succeeds.