### PR TITLE
refactor(settings): migrate ReverseWithdrawal/SettingsHelper.php to dokan()->settings (PR 3/N)

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -69,10 +69,16 @@ class SettingsRegistry {
      *
      * Listens to:
      *   - The new flat option ({@see SettingsRepository::OPTION_KEY}) where
-     *     all admin writes land.
+     *     all admin writes land. Wired immediately — the option name is a
+     *     constant and needs no schema introspection.
      *   - Every legacy `dokan_*` section that the bridge knows about — Pro
      *     and third-party `update_option()` writes against those sections
-     *     would otherwise leave the registry overlay stale.
+     *     would otherwise leave the registry overlay stale. **Deferred to
+     *     `init`** because enumerating the sections requires building the
+     *     bridge map, which harvests {@see SettingsSchema::get_schema()},
+     *     which runs `get_posts()`, which fires `pre_get_posts` hooks that
+     *     in turn read `dokan()->settings`. Doing that from the constructor
+     *     re-enters DI resolution and fatals the request.
      *
      * @return void
      */
@@ -81,6 +87,26 @@ class SettingsRegistry {
         add_action( "update_option_{$new_option}", [ $this, 'clear_cache' ] );
         add_action( "add_option_{$new_option}", [ $this, 'clear_cache' ] );
 
+        if ( ! function_exists( 'did_action' ) ) {
+            return;
+        }
+        if ( did_action( 'init' ) ) {
+            $this->register_legacy_section_hooks();
+            return;
+        }
+        add_action( 'init', [ $this, 'register_legacy_section_hooks' ], 0 );
+    }
+
+    /**
+     * Register `update_option_{section}` / `add_option_{section}` listeners
+     * for every legacy section the bridge knows about. Must run on or after
+     * `init` — see {@see register_cache_invalidation_hooks()} for why.
+     *
+     * Public so it can be invoked as a WP action callback.
+     *
+     * @return void
+     */
+    public function register_legacy_section_hooks(): void {
         if ( ! function_exists( 'dokan_get_container' ) ) {
             return;
         }

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1215,27 +1215,6 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
-            [
-                'id'            => 'reverse_withdrawal_send_announcement',
-                'legacy_key'    => [
-                    'option' => 'dokan_reverse_withdrawal',
-                    'field'  => 'send_announcement',
-                ],
-                'type'          => 'field',
-                'variant'       => 'switch',
-                'section_id'    => 'reverse_withdrawal_section',
-                'title'         => esc_html__( 'Send Announcement?', 'dokan-lite' ),
-                'description'   => esc_html__( 'Send platform announcements to vendors during the grace period. Limited to one announcement per billing period.', 'dokan-lite' ),
-                'default'       => 'off',
-                'enable_state'  => [
-					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
-					'value' => 'on',
-				],
-                'disable_state' => [
-					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
-					'value' => 'off',
-				],
-            ],
             self::reverse_withdrawal_payment_gateways_field(),
         ];
     }

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1006,6 +1006,7 @@ class SettingsSchema {
 					'option' => 'dokan_reverse_withdrawal',
 					'field' => 'enabled',
 				],
+                'priority'    => 50,
             ],
             [
                 'id'          => 'reverse_withdrawal_billing_type',
@@ -1260,6 +1261,7 @@ class SettingsSchema {
             'default'            => [ 'cod' ],
             'legacy_key'         => $legacy_key,
             'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
+            'priority'           => 70,
         ];
     }
 

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1215,6 +1215,72 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
+            [
+                'id'            => 'reverse_withdrawal_send_announcement',
+                'legacy_key'    => [
+                    'option' => 'dokan_reverse_withdrawal',
+                    'field'  => 'send_announcement',
+                ],
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'section_id'    => 'reverse_withdrawal_section',
+                'title'         => esc_html__( 'Send Announcement?', 'dokan-lite' ),
+                'description'   => esc_html__( 'Send platform announcements to vendors during the grace period. Limited to one announcement per billing period.', 'dokan-lite' ),
+                'default'       => 'off',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+            ],
+            self::reverse_withdrawal_payment_gateways_field(),
+        ];
+    }
+
+    /**
+     * Build the `reverse_withdrawal_payment_gateways` multicheck field.
+     *
+     * Options are derived from the `dokan_reverse_withdrawal_payment_gateways`
+     * filter (the same source the legacy {@see SettingsHelper::get_reverse_withrawal_payment_gateways()}
+     * uses) so Pro modules / extensions that already extend that filter continue
+     * to register gateways with one declaration. The new field stores a flat
+     * list of selected gateway ids; each slot bridges through
+     * {@see MulticheckArrayTransformer} to the legacy WP-multicheck shape under
+     * `dokan_reverse_withdrawal.payment_gateways`.
+     *
+     * @return array
+     */
+    private static function reverse_withdrawal_payment_gateways_field(): array {
+        $gateways = apply_filters(
+            'dokan_reverse_withdrawal_payment_gateways',
+            [ 'cod' => esc_html__( 'Cash on delivery', 'dokan-lite' ) ]
+        );
+
+        $options    = [];
+        $legacy_key = [];
+        foreach ( $gateways as $value => $label ) {
+            $options[]            = [
+                'value' => (string) $value,
+                'label' => (string) $label,
+            ];
+            $legacy_key[ $value ] = 'dokan_reverse_withdrawal.payment_gateways.' . $value;
+        }
+        $slot_keys = array_keys( $legacy_key );
+
+        return [
+            'id'                 => 'reverse_withdrawal_payment_gateways',
+            'type'               => 'field',
+            'variant'            => 'multicheck',
+            'section_id'         => 'reverse_withdrawal_section',
+            'title'              => esc_html__( 'Enable Reverse Withdrawal for this Gateway', 'dokan-lite' ),
+            'description'        => esc_html__( 'Check the payment gateways you want to enable reverse withdrawal for. For now, only cash on delivery is available.', 'dokan-lite' ),
+            'options'            => $options,
+            'default'            => [ 'cod' ],
+            'legacy_key'         => $legacy_key,
+            'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
         ];
     }
 

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -21,7 +21,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function is_enabled() {
-        return 'on' === dokan_get_option( 'reverse_withdrawal_enabled', 'dokan_reverse_withdrawal', 'off' );
+        return 'on' === dokan()->settings->get( 'reverse_withdrawal_enabled' );
     }
 
     /**
@@ -58,7 +58,7 @@ class SettingsHelper {
      * @return string
      */
     public static function get_billing_type() {
-        return dokan_get_option( 'billing_type', 'dokan_reverse_withdrawal', 'by_amount' );
+        return dokan()->settings->get( 'reverse_withdrawal_billing_type' );
     }
 
     /**
@@ -69,7 +69,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_reverse_balance_threshold() {
-        $limit = dokan_get_option( 'reverse_balance_threshold', 'dokan_reverse_withdrawal', '150' );
+        $limit = dokan()->settings->get( 'reverse_withdrawal_balance_threshold' );
 
         return (float) abs( wc_format_decimal( $limit, 2 ) );
     }
@@ -82,7 +82,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_billing_day() {
-        $billing_day = dokan_get_option( 'monthly_billing_day', 'dokan_reverse_withdrawal', '1' );
+        $billing_day = dokan()->settings->get( 'reverse_withdrawal_monthly_billing_day' );
 
         return absint( $billing_day );
     }
@@ -95,7 +95,7 @@ class SettingsHelper {
      * @return float
      */
     public static function get_due_period() {
-        $due_period = dokan_get_option( 'due_period', 'dokan_reverse_withdrawal', '7' );
+        $due_period = dokan()->settings->get( 'reverse_withdrawal_due_period' );
 
         return absint( $due_period );
     }
@@ -134,7 +134,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function display_payment_notice_on_vendor_dashboard() {
-        return 'on' === dokan_get_option( 'display_notice', 'dokan_reverse_withdrawal', 'on' );
+        return 'on' === dokan()->settings->get( 'reverse_withdrawal_grace_period_notice' );
     }
 
     /**

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -108,9 +108,9 @@ class SettingsHelper {
      * @return array
      */
     public static function get_failed_actions() {
-        $failed_actions = dokan_get_option( 'failed_actions', 'dokan_reverse_withdrawal', [] );
+        $failed_actions = dokan()->settings->get( 'reverse_withdrawal_failed_penalty_actions' );
 
-        return array_filter( $failed_actions );
+        return array_filter( (array) $failed_actions );
     }
 
     /**
@@ -121,9 +121,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function is_failed_action_enabled( $action ) {
-        $failed_actions = dokan_get_option( 'failed_actions', 'dokan_reverse_withdrawal', [] );
-
-        return isset( $failed_actions[ $action ] );
+        return in_array( $action, static::get_failed_actions(), true );
     }
 
     /**

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -143,7 +143,11 @@ class SettingsHelper {
      * @return bool
      */
     public static function send_balance_exceeded_announcement() {
-        return 'on' === dokan()->settings->get( 'reverse_withdrawal_send_announcement' );
+        // Pro-owned setting: the Send Announcement field is registered by
+        // Dokan Pro, not by Lite. This site stays on dokan_get_option() until
+        // Pro adds a schema entry and a corresponding migration commit lands
+        // there.
+        return 'on' === dokan_get_option( 'send_announcement', 'dokan_reverse_withdrawal', 'off' );
     }
 
     /**

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -32,13 +32,9 @@ class SettingsHelper {
      * @return array
      */
     public static function get_enabled_payment_gateways() {
-        // TODO(settings-migration): migrate to dokan()->settings->get( 'transactions_reverse_withdrawal_payment_gateways' )
-        // once SettingsSchema flips the dokan_csv_schema_enabled flag on by
-        // default. The flat id is currently defined only in the CSV-fragment
-        // schema, which is feature-flag-gated off in production.
-        $payment_methods = dokan_get_option( 'payment_gateways', 'dokan_reverse_withdrawal', [] );
+        $payment_methods = dokan()->settings->get( 'reverse_withdrawal_payment_gateways' );
 
-        return array_filter( $payment_methods );
+        return array_filter( (array) $payment_methods );
     }
 
     /**
@@ -147,11 +143,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function send_balance_exceeded_announcement() {
-        // TODO(settings-migration): migrate to dokan()->settings->get( 'transactions_reverse_withdrawal_send_announcement' )
-        // once SettingsSchema flips the dokan_csv_schema_enabled flag on by
-        // default. The flat id is currently defined only in the CSV-fragment
-        // schema, which is feature-flag-gated off in production.
-        return 'on' === dokan_get_option( 'send_announcement', 'dokan_reverse_withdrawal', 'off' );
+        return 'on' === dokan()->settings->get( 'reverse_withdrawal_send_announcement' );
     }
 
     /**

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -32,6 +32,10 @@ class SettingsHelper {
      * @return array
      */
     public static function get_enabled_payment_gateways() {
+        // TODO(settings-migration): migrate to dokan()->settings->get( 'transactions_reverse_withdrawal_payment_gateways' )
+        // once SettingsSchema flips the dokan_csv_schema_enabled flag on by
+        // default. The flat id is currently defined only in the CSV-fragment
+        // schema, which is feature-flag-gated off in production.
         $payment_methods = dokan_get_option( 'payment_gateways', 'dokan_reverse_withdrawal', [] );
 
         return array_filter( $payment_methods );
@@ -143,6 +147,10 @@ class SettingsHelper {
      * @return bool
      */
     public static function send_balance_exceeded_announcement() {
+        // TODO(settings-migration): migrate to dokan()->settings->get( 'transactions_reverse_withdrawal_send_announcement' )
+        // once SettingsSchema flips the dokan_csv_schema_enabled flag on by
+        // default. The flat id is currently defined only in the CSV-fragment
+        // schema, which is feature-flag-gated off in production.
         return 'on' === dokan_get_option( 'send_announcement', 'dokan_reverse_withdrawal', 'off' );
     }
 

--- a/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
+++ b/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace WeDevs\Dokan\Test\ReverseWithdrawal;
 
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\ReverseWithdrawal\SettingsHelper;
 use WeDevs\Dokan\Test\DokanTestCase;
 
@@ -19,14 +20,17 @@ class SettingsHelperTest extends DokanTestCase {
 
     protected function setUp(): void {
         parent::setUp();
-        delete_option( 'dokan_reverse_withdrawal' );
-        delete_option( 'dokan_admin_settings' );
+        $this->reset_storage();
     }
 
     protected function tearDown(): void {
-        delete_option( 'dokan_reverse_withdrawal' );
-        delete_option( 'dokan_admin_settings' );
+        $this->reset_storage();
         parent::tearDown();
+    }
+
+    private function reset_storage(): void {
+        ( new SettingsRepository() )->replace( [] );
+        delete_option( 'dokan_reverse_withdrawal' );
     }
 
     public function test_is_enabled_returns_false_when_unset(): void {
@@ -73,20 +77,24 @@ class SettingsHelperTest extends DokanTestCase {
     }
 
     public function test_is_failed_action_enabled_for_selected_action(): void {
-        update_option( 'dokan_reverse_withdrawal', [
-            'failed_actions' => [ 'enable_catalog_mode' => 'enable_catalog_mode' ],
-        ] );
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'failed_actions' => [ 'enable_catalog_mode' => 'enable_catalog_mode' ],
+			]
+        );
         $this->assertTrue( SettingsHelper::is_failed_action_enabled( 'enable_catalog_mode' ) );
         $this->assertFalse( SettingsHelper::is_failed_action_enabled( 'hide_withdraw_menu' ) );
     }
 
     public function test_get_failed_actions_returns_selected_actions(): void {
-        update_option( 'dokan_reverse_withdrawal', [
-            'failed_actions' => [
-                'enable_catalog_mode' => 'enable_catalog_mode',
-                'status_inactive'     => 'status_inactive',
-            ],
-        ] );
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'failed_actions' => [
+					'enable_catalog_mode' => 'enable_catalog_mode',
+					'status_inactive'     => 'status_inactive',
+				],
+			]
+        );
         $actions = SettingsHelper::get_failed_actions();
         // Shape may be associative (pre-migration) or list (post-migration with
         // MulticheckArrayTransformer). Assert value membership only, not shape.
@@ -96,9 +104,11 @@ class SettingsHelperTest extends DokanTestCase {
     }
 
     public function test_is_gateway_enabled_for_reverse_withdrawal_cod(): void {
-        update_option( 'dokan_reverse_withdrawal', [
-            'payment_gateways' => [ 'cod' => 'cod' ],
-        ] );
+        update_option(
+            'dokan_reverse_withdrawal', [
+				'payment_gateways' => [ 'cod' => 'cod' ],
+			]
+        );
         $this->assertTrue( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'cod' ) );
         $this->assertFalse( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'stripe' ) );
     }

--- a/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
+++ b/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
@@ -34,17 +34,6 @@ class SettingsHelperTest extends DokanTestCase {
     }
 
     public function test_is_enabled_returns_true_when_legacy_on(): void {
-        // SKIPPED PRE-MIGRATION: SettingsHelper::is_enabled() currently calls
-        // dokan_get_option('reverse_withdrawal_enabled', 'dokan_reverse_withdrawal'),
-        // but the legacy admin form (ReverseWithdrawal\Admin\Settings) saves to field
-        // 'enabled'. dokan_get_option() does no flat-id → legacy-field translation,
-        // so this read always misses and returns the default 'off'. The Task 3
-        // migration replaces the call with dokan()->settings->get('reverse_withdrawal_enabled'),
-        // which goes through SettingsRegistry + LegacySettingsBridge and correctly
-        // overlays the legacy 'enabled' field onto the flat id. After that commit,
-        // remove this skip.
-        $this->markTestSkipped( 'Pre-migration: is_enabled() reads the wrong legacy field name (introduced by 66303f35f). Unskip in the Task 3 migration commit that swaps to dokan()->settings->get().' );
-
         update_option( 'dokan_reverse_withdrawal', [ 'enabled' => 'on' ] );
         $this->assertTrue( SettingsHelper::is_enabled() );
     }

--- a/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
+++ b/tests/php/src/ReverseWithdrawal/SettingsHelperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace WeDevs\Dokan\Test\ReverseWithdrawal;
+
+use WeDevs\Dokan\ReverseWithdrawal\SettingsHelper;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Behavior contract for ReverseWithdrawal\SettingsHelper.
+ *
+ * These tests are written against the pre-migration implementation that
+ * reads via `dokan_get_option()`. They must remain green after the
+ * migration to `dokan()->settings->get()`.
+ *
+ * @group reverse-withdrawal
+ * @group settings-migration
+ */
+class SettingsHelperTest extends DokanTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        delete_option( 'dokan_reverse_withdrawal' );
+        delete_option( 'dokan_admin_settings' );
+    }
+
+    protected function tearDown(): void {
+        delete_option( 'dokan_reverse_withdrawal' );
+        delete_option( 'dokan_admin_settings' );
+        parent::tearDown();
+    }
+
+    public function test_is_enabled_returns_false_when_unset(): void {
+        $this->assertFalse( SettingsHelper::is_enabled() );
+    }
+
+    public function test_is_enabled_returns_true_when_legacy_on(): void {
+        // SKIPPED PRE-MIGRATION: SettingsHelper::is_enabled() currently calls
+        // dokan_get_option('reverse_withdrawal_enabled', 'dokan_reverse_withdrawal'),
+        // but the legacy admin form (ReverseWithdrawal\Admin\Settings) saves to field
+        // 'enabled'. dokan_get_option() does no flat-id → legacy-field translation,
+        // so this read always misses and returns the default 'off'. The Task 3
+        // migration replaces the call with dokan()->settings->get('reverse_withdrawal_enabled'),
+        // which goes through SettingsRegistry + LegacySettingsBridge and correctly
+        // overlays the legacy 'enabled' field onto the flat id. After that commit,
+        // remove this skip.
+        $this->markTestSkipped( 'Pre-migration: is_enabled() reads the wrong legacy field name (introduced by 66303f35f). Unskip in the Task 3 migration commit that swaps to dokan()->settings->get().' );
+
+        update_option( 'dokan_reverse_withdrawal', [ 'enabled' => 'on' ] );
+        $this->assertTrue( SettingsHelper::is_enabled() );
+    }
+
+    public function test_get_billing_type_default_is_by_amount(): void {
+        $this->assertSame( 'by_amount', SettingsHelper::get_billing_type() );
+    }
+
+    public function test_get_billing_type_reads_legacy_value(): void {
+        update_option( 'dokan_reverse_withdrawal', [ 'billing_type' => 'by_month' ] );
+        $this->assertSame( 'by_month', SettingsHelper::get_billing_type() );
+    }
+
+    public function test_get_reverse_balance_threshold_default(): void {
+        $this->assertSame( 150.0, SettingsHelper::get_reverse_balance_threshold() );
+    }
+
+    public function test_get_reverse_balance_threshold_reads_legacy(): void {
+        update_option( 'dokan_reverse_withdrawal', [ 'reverse_balance_threshold' => '275.50' ] );
+        $this->assertSame( 275.50, SettingsHelper::get_reverse_balance_threshold() );
+    }
+
+    public function test_get_billing_day_default_is_one(): void {
+        $this->assertSame( 1, SettingsHelper::get_billing_day() );
+    }
+
+    public function test_get_due_period_default_is_seven(): void {
+        $this->assertSame( 7, SettingsHelper::get_due_period() );
+    }
+
+    public function test_display_payment_notice_defaults_on(): void {
+        $this->assertTrue( SettingsHelper::display_payment_notice_on_vendor_dashboard() );
+    }
+
+    public function test_send_balance_exceeded_announcement_defaults_off(): void {
+        $this->assertFalse( SettingsHelper::send_balance_exceeded_announcement() );
+    }
+
+    public function test_is_failed_action_enabled_for_selected_action(): void {
+        update_option( 'dokan_reverse_withdrawal', [
+            'failed_actions' => [ 'enable_catalog_mode' => 'enable_catalog_mode' ],
+        ] );
+        $this->assertTrue( SettingsHelper::is_failed_action_enabled( 'enable_catalog_mode' ) );
+        $this->assertFalse( SettingsHelper::is_failed_action_enabled( 'hide_withdraw_menu' ) );
+    }
+
+    public function test_get_failed_actions_returns_selected_actions(): void {
+        update_option( 'dokan_reverse_withdrawal', [
+            'failed_actions' => [
+                'enable_catalog_mode' => 'enable_catalog_mode',
+                'status_inactive'     => 'status_inactive',
+            ],
+        ] );
+        $actions = SettingsHelper::get_failed_actions();
+        // Shape may be associative (pre-migration) or list (post-migration with
+        // MulticheckArrayTransformer). Assert value membership only, not shape.
+        $this->assertContains( 'enable_catalog_mode', $actions );
+        $this->assertContains( 'status_inactive', $actions );
+        $this->assertNotContains( 'hide_withdraw_menu', $actions );
+    }
+
+    public function test_is_gateway_enabled_for_reverse_withdrawal_cod(): void {
+        update_option( 'dokan_reverse_withdrawal', [
+            'payment_gateways' => [ 'cod' => 'cod' ],
+        ] );
+        $this->assertTrue( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'cod' ) );
+        $this->assertFalse( SettingsHelper::is_gateway_enabled_for_reverse_withdrawal( 'stripe' ) );
+    }
+}


### PR DESCRIPTION
## Summary

PR 3/N in the settings-accessor migration series (#3210 was PR 2). Migrates 9 of 10 `dokan_get_option()` call sites in `includes/ReverseWithdrawal/SettingsHelper.php` to `dokan()->settings->get()`. The one remaining site (`send_announcement`) is Pro-owned and intentionally left on `dokan_get_option()` with an inline comment.

Per-call-site mapping and behavior notes are in each commit message. Highlights:

### Latent bug fixed as part of the migration

`SettingsHelper::is_enabled()` was reading `dokan_get_option('reverse_withdrawal_enabled', 'dokan_reverse_withdrawal', 'off')` — but the legacy admin form (`ReverseWithdrawal\Admin\Settings`) saves the field as `enabled`. The recent field-id rename (66303f35f) updated the read site without a translation shim, so `is_enabled()` was silently returning `false` for every install since that commit. The migration to `dokan()->settings->get('reverse_withdrawal_enabled')` routes through `SettingsRegistry` + `LegacySettingsBridge`, which correctly overlays the legacy `enabled` field onto the new flat id — fixing the latent regression. A characterization test that was skipped pre-migration is unskipped in the same commit and now passes.

### `failed_actions` shape rewrite

`reverse_withdrawal_failed_penalty_actions` carries `MulticheckArrayTransformer`, which converts the legacy associative WP-multicheck shape `['enable_catalog_mode' => 'enable_catalog_mode']` to a flat list `['enable_catalog_mode']`. The old `is_failed_action_enabled()` used `isset($arr[$action])` — which works on the associative shape but silently returns false on the new list. Rewritten to `in_array($action, get_failed_actions(), true)`, which works on both shapes.

### `payment_gateways` schema addition

`reverse_withdrawal_payment_gateways` did not exist in the hand-authored schema. Added in this PR, with options built dynamically from the existing `dokan_reverse_withdrawal_payment_gateways` filter (matching the precedent set by `withdraw_order_status_field()`). Uses `MulticheckArrayTransformer::for_slots()` so the new flat-list shape `['cod']` bridges back to the legacy WP-multicheck shape `['cod' => 'cod']`. Pro modules that extend the filter continue to register gateways with one declaration.

`get_enabled_payment_gateways()` return shape changes (assoc → flat list) but the only Lite consumer is `is_gateway_enabled_for_reverse_withdrawal()` which uses `in_array()` and tolerates both.

### `send_announcement` left to Pro

The `Send Announcement` field is owned by Dokan Pro, even though the Lite helper `SettingsHelper::send_balance_exceeded_announcement()` reads it. The Lite call site stays on `dokan_get_option('send_announcement', 'dokan_reverse_withdrawal', 'off')` with an inline comment. The corresponding schema entry + migration belongs in a Pro commit, not here.

### Documented default drift

`get_failed_actions()` on a fresh install now returns `['enable_catalog_mode']` (schema default) instead of `[]` (historical call default). This matches what admins see in the settings UI on a fresh install and is the documented schema-default contract (spec §7.1).

### New characterization test

`tests/php/src/ReverseWithdrawal/SettingsHelperTest.php` pins the public-method behavior across the swap. 13 tests / 17 assertions, all green post-migration.

## Depends on

- #3213 (DI binding) — merged
- #3214 (cache invalidation) — merged

Both already on the integration branch.

## Test plan

- [x] All 13 SettingsHelperTest tests green
- [x] Broader settings suite (123 tests) — same 4 pre-existing failures as before, none introduced by this PR
- [x] PHPCS clean on changed files
- [x] One `dokan_get_option()` call remains (send_announcement) — documented in place as Pro-owned
- [x] `wp plugin activate woocommerce dokan-lite` succeeds (no DI fatal)

## Why this targets `refactor/settings-accessor-api`, not `develop`

The settings-accessor migration is a multi-PR series staged on the `refactor/settings-accessor-api` integration branch. Sub-PRs land there; the whole series merges to `develop` once complete (per the design spec).