### PR TITLE
chore(settings): sync SettingsSchema field-id renames from accessor-api

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1006,6 +1006,7 @@ class SettingsSchema {
 					'option' => 'dokan_reverse_withdrawal',
 					'field' => 'enabled',
 				],
+                'priority'    => 50,
             ],
             [
                 'id'          => 'reverse_withdrawal_billing_type',
@@ -1215,6 +1216,52 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
+            self::reverse_withdrawal_payment_gateways_field(),
+        ];
+    }
+
+    /**
+     * Build the `reverse_withdrawal_payment_gateways` multicheck field.
+     *
+     * Options are derived from the `dokan_reverse_withdrawal_payment_gateways`
+     * filter (the same source the legacy {@see SettingsHelper::get_reverse_withrawal_payment_gateways()}
+     * uses) so Pro modules / extensions that already extend that filter continue
+     * to register gateways with one declaration. The new field stores a flat
+     * list of selected gateway ids; each slot bridges through
+     * {@see MulticheckArrayTransformer} to the legacy WP-multicheck shape under
+     * `dokan_reverse_withdrawal.payment_gateways`.
+     *
+     * @return array
+     */
+    private static function reverse_withdrawal_payment_gateways_field(): array {
+        $gateways = apply_filters(
+            'dokan_reverse_withdrawal_payment_gateways',
+            [ 'cod' => esc_html__( 'Cash on delivery', 'dokan-lite' ) ]
+        );
+
+        $options    = [];
+        $legacy_key = [];
+        foreach ( $gateways as $value => $label ) {
+            $options[]            = [
+                'value' => (string) $value,
+                'label' => (string) $label,
+            ];
+            $legacy_key[ $value ] = 'dokan_reverse_withdrawal.payment_gateways.' . $value;
+        }
+        $slot_keys = array_keys( $legacy_key );
+
+        return [
+            'id'                 => 'reverse_withdrawal_payment_gateways',
+            'type'               => 'field',
+            'variant'            => 'multicheck',
+            'section_id'         => 'reverse_withdrawal_section',
+            'title'              => esc_html__( 'Enable Reverse Withdrawal for this Gateway', 'dokan-lite' ),
+            'description'        => esc_html__( 'Check the payment gateways you want to enable reverse withdrawal for. For now, only cash on delivery is available.', 'dokan-lite' ),
+            'options'            => $options,
+            'default'            => [ 'cod' ],
+            'legacy_key'         => $legacy_key,
+            'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
+            'priority'           => 70,
         ];
     }
 

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -151,7 +151,7 @@ class SettingsSchema {
                 'subpage_id' => 'marketplace',
             ],
             [
-                'id'              => 'vendor_store_url',
+                'id'              => 'vendor_store_url_slug',
                 'type'            => 'field',
                 'variant'         => 'text',
                 'section_id'      => 'marketplace_settings',
@@ -1195,7 +1195,7 @@ class SettingsSchema {
                 ),
             ],
             [
-                'id'            => 'display_notice',
+                'id'            => 'reverse_withdrawal_grace_period_notice',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'display_notice',
@@ -1285,7 +1285,7 @@ class SettingsSchema {
                 'doc_link'    => 'https://wedevs.com/docs/dokan-lite/vendor-onboarding/',
             ],
             [
-                'id'            => 'enable_selling',
+                'id'            => 'vendor_auto_enable_selling',
                 'type'          => 'field',
                 'variant'       => 'radio_capsule',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1301,7 +1301,7 @@ class SettingsSchema {
 
             ],
             [
-                'id'            => 'address_fields',
+                'id'            => 'vendor_registration_address_fields',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1349,7 +1349,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'welcome_wizard',
+                'id'            => 'vendor_welcome_wizard_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'subpage_id'    => 'vendor_onboarding',
@@ -1408,7 +1408,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'            => 'product_popup',
+                'id'            => 'vendor_new_product_popup',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'vendor_capabilities',
@@ -1449,7 +1449,7 @@ class SettingsSchema {
                 'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
             [
-                'id'            => 'order_status_change',
+                'id'            => 'vendor_can_change_order_status',
                 'legacy_key' => [
                     'option' => 'dokan_selling',
                     'field'  => 'order_status_change',
@@ -1524,7 +1524,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'store_product_per_page',
+                'id'          => 'store_products_per_page',
                 'type'        => 'field',
                 'variant'     => 'number',
                 'section_id'  => 'products_page',
@@ -1553,7 +1553,7 @@ class SettingsSchema {
                 'section_id' => 'google_recaptcha',
             ],
             [
-                'id'             => 'recaptcha',
+                'id'             => 'google_recaptcha_enabled',
                 'type'           => 'field',
                 'variant'        => 'switch',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1575,7 +1575,7 @@ class SettingsSchema {
 				],
             ],
             [
-                'id'             => 'recaptcha_info',
+                'id'             => 'google_recaptcha_info',
                 'type'           => 'field',
                 'variant'        => 'info',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1587,7 +1587,7 @@ class SettingsSchema {
                 ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1595,7 +1595,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1605,7 +1605,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_site_key',
+                'id'             => 'google_recaptcha_site_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1614,7 +1614,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1622,7 +1622,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1632,7 +1632,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'             => 'recaptcha_secret_key',
+                'id'             => 'google_recaptcha_secret_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
                 'field_group_id' => 'google_recaptcha_settings',
@@ -1641,7 +1641,7 @@ class SettingsSchema {
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
                 'dependencies'   => [
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1649,7 +1649,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'recaptcha',
+						'key' => 'google_recaptcha_enabled',
 						'value' => 'off',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1666,7 +1666,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_clossing_time_widget',
+                'id'            => 'store_contact_form_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_contact_form_section',
@@ -1714,7 +1714,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'                => 'store_template',
+                'id'                => 'store_header_template',
                 'type'              => 'field',
                 'variant'           => 'customize_radio',
                 'section_id'        => 'store_template',
@@ -1758,7 +1758,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_time_widget',
+                'id'            => 'store_opening_closing_time_widget',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_time_widget_section',
@@ -1786,7 +1786,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'store_opening_time',
+                'id'            => 'store_sidebar_from_theme',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'store_sidebar_section',
@@ -1814,7 +1814,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'vendor_info_visibility',
+                'id'          => 'store_page_vendor_info_visibility',
                 'type'        => 'field',
                 'variant'     => 'info_preview',
                 'section_id'  => 'vendor_info_visibility_section',
@@ -1853,7 +1853,7 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'            => 'dokan_font',
+                'id'            => 'dokan_fontawesome_enabled',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'dokan_font_section',
@@ -1982,7 +1982,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'privacy_policy_display',
+                'id'            => 'privacy_policy_visibility',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'privacy_settings',
@@ -2038,7 +2038,7 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'            => 'admin_access',
+                'id'            => 'admin_access_for_vendors',
                 'legacy_key' => [
                     'option' => 'dokan_general',
                     'field'  => 'admin_access',
@@ -2118,17 +2118,59 @@ class SettingsSchema {
      */
     private static function ai_assist_page(): array {
         $on_generate = [
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_info_generate',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $on_enhance = [
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'show',
+				'comparison' => '===',
+			],
+            [
+				'key' => 'ai_product_image_enhancement',
+				'value' => 'on',
+				'to_self' => true,
+				'attribute' => 'display',
+				'effect' => 'hide',
+				'comparison' => '!==',
+			],
         ];
         $when_engine = static function ( string $engine_key, string $value ): array {
             return [
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
-                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'show',
+					'comparison' => '===',
+				],
+                [
+					'key' => $engine_key,
+					'value' => $value,
+					'to_self' => true,
+					'attribute' => 'display',
+					'effect' => 'hide',
+					'comparison' => '!==',
+				],
             ];
         };
 
@@ -2138,7 +2180,10 @@ class SettingsSchema {
         $provider_options = static function ( array $providers ): array {
             $out = [];
             foreach ( $providers as $id => $provider ) {
-                $out[] = [ 'title' => $provider->get_title(), 'value' => (string) $id ];
+                $out[] = [
+					'title' => $provider->get_title(),
+					'value' => (string) $id,
+				];
             }
             return $out;
         };
@@ -2169,18 +2214,24 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ],
             [
-                'id'            => 'product_info_generate',
+                'id'            => 'ai_product_info_generate',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_image_section',
                 'title'         => esc_html__( 'Product Info Generate', 'dokan-lite' ),
                 'description'   => esc_html__( 'Let vendors generate product info by AI.', 'dokan-lite' ),
                 'default'       => 'on',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
             ],
             [
-                'id'           => 'product_info_engine',
+                'id'           => 'ai_product_info_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_image_section',
@@ -2203,7 +2254,7 @@ class SettingsSchema {
                         'provider_id'     => $pid,
                         'provider'        => $provider,
                         'section_id'      => 'product_image_section',
-                        'engine_field_id' => 'product_info_engine',
+                        'engine_field_id' => 'ai_product_info_engine',
                         'toggle_deps'     => $on_generate,
                         'engine_deps'     => $when_engine( 'product_info_engine', $pid ),
                         'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
@@ -2223,19 +2274,25 @@ class SettingsSchema {
                 'subpage_id' => 'product_generation',
             ];
             $elements[] = [
-                'id'            => 'product_image_enhancement',
+                'id'            => 'ai_product_image_enhancement',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'product_description_section',
                 'title'         => esc_html__( 'Product Image Enhancement', 'dokan-lite' ),
                 'description'   => esc_html__( 'Allow vendors to enhance and generate professional product images using AI.', 'dokan-lite' ),
                 'default'       => 'off',
-                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
-                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
                 'legacy_key'    => 'dokan_ai.dokan_ai_image_gen_availability',
             ];
             $elements[] = [
-                'id'           => 'product_image_engine',
+                'id'           => 'ai_product_image_engine',
                 'type'         => 'field',
                 'variant'      => 'select',
                 'section_id'   => 'product_description_section',
@@ -2330,7 +2387,10 @@ class SettingsSchema {
             try {
                 $models = $provider->get_models_by_type( constant( $model_const ) );
                 foreach ( $models as $model_id => $model ) {
-                    $model_options[] = [ 'title' => $model->get_title(), 'value' => (string) $model_id ];
+                    $model_options[] = [
+						'title' => $model->get_title(),
+						'value' => (string) $model_id,
+					];
                 }
             } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
                 unset( $e );

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2256,7 +2256,7 @@ class SettingsSchema {
                         'section_id'      => 'product_image_section',
                         'engine_field_id' => 'ai_product_info_engine',
                         'toggle_deps'     => $on_generate,
-                        'engine_deps'     => $when_engine( 'product_info_engine', $pid ),
+                        'engine_deps'     => $when_engine( 'ai_product_info_engine', $pid ),
                         'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
                         'model_legacy'    => 'dokan_ai.dokan_ai_' . $pid . '_model',
                         'model_kind'      => 'text',

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -81,7 +81,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
     public function test_overlay_from_new_option_wins_over_raw_section(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         $repo = new LegacySettingsRepository();
         $this->assertSame(
@@ -141,7 +141,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo->all( 'dokan_general' );
         $repo->all( 'dokan_appearance' );
 
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // After flush, the next read should reflect the overlay from the new flat option.
         $this->assertSame( 'marketplace', $repo->get( 'dokan_general', 'custom_store_url' ) );
@@ -186,8 +186,8 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $new = get_option( 'dokan_admin_settings' );
         $this->assertIsArray( $new );
-        // Schema maps vendor_store_url → dokan_general.custom_store_url (SettingsSchema.php:153-165).
-        $this->assertSame( 'marketplace', $new['vendor_store_url'] );
+        // Schema maps vendor_store_url_slug → dokan_general.custom_store_url (SettingsSchema.php:153-165).
+        $this->assertSame( 'marketplace', $new['vendor_store_url_slug'] );
     }
 
     public function test_update_with_no_change_is_a_noop(): void {
@@ -302,12 +302,12 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo = new LegacySettingsRepository();
         $repo->replace( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
 
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
     }
 
     public function test_dokan_get_option_reads_through_repository(): void {
         update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'marketplace' ] );
 
         // Flush repo cache so the next read sees the freshly-set options.
         dokan_get_container()
@@ -321,7 +321,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Set both options to a value that differs from what the test will write
         // so the diff is always non-empty regardless of any prior test's cached state.
         update_option( 'dokan_general', [ 'custom_store_url' => 'before' ] );
-        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'before' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url_slug' => 'before' ] );
 
         // Flush every in-request snapshot (container singletons + internal private
         // repos inside LegacySettingsRepository and LegacySettingsBridge) so the
@@ -337,7 +337,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         // Legacy storage updated.
         $this->assertSame( 'marketplace', get_option( 'dokan_general' )['custom_store_url'] );
         // New flat storage updated via mirror.
-        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url_slug'] );
         // dokan_get_option() resolves through the repo and sees the overlay.
         $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
     }

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
@@ -31,7 +31,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
         update_option(
             'dokan_admin_settings',
             [
-                'vendor_store_url' => 'shop',
+                'vendor_store_url_slug' => 'shop',
                 'map_api_source'   => 'mapbox',
             ]
         );
@@ -44,7 +44,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             if ( ( $el['type'] ?? '' ) !== 'field' ) {
                 continue;
             }
-            if ( ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $store_url_field = $el;
             }
             if ( ( $el['id'] ?? '' ) === 'map_api_source' ) {
@@ -52,8 +52,8 @@ class SettingsRegistryStorageTest extends DokanTestCase {
             }
         }
 
-        $this->assertNotNull( $store_url_field, 'Field vendor_store_url must exist in the schema.' );
-        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url value must come from dokan_settings.' );
+        $this->assertNotNull( $store_url_field, 'Field vendor_store_url_slug must exist in the schema.' );
+        $this->assertSame( 'shop', $store_url_field['value'], 'vendor_store_url_slug value must come from dokan_settings.' );
 
         $this->assertNotNull( $map_source_field, 'Field map_api_source must exist in the schema.' );
         $this->assertSame( 'mapbox', $map_source_field['value'], 'map_api_source value must come from dokan_settings.' );
@@ -66,19 +66,19 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }
         }
 
-        $this->assertNotNull( $found, 'vendor_store_url must exist.' );
+        $this->assertNotNull( $found, 'vendor_store_url_slug must exist.' );
         $this->assertSame( $found['default'] ?? '', $found['value'], 'Missing stored id must yield the field default.' );
     }
 
     public function test_no_per_page_wp_options_are_read(): void {
         // Seed the OLD per-page key with a value that would have been read by the previous code path.
-        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url' => 'OLD_VALUE' ] ] ] );
+        update_option( 'dokan_settings_general', [ 'marketplace' => [ 'marketplace_settings' => [ 'vendor_store_url_slug' => 'OLD_VALUE' ] ] ] );
         // The new key is empty, so reads should fall back to the field default — NOT to OLD_VALUE.
         delete_option( 'dokan_admin_settings' );
 
@@ -86,7 +86,7 @@ class SettingsRegistryStorageTest extends DokanTestCase {
 
         $found = null;
         foreach ( $schema as $el ) {
-            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url' ) {
+            if ( ( $el['type'] ?? '' ) === 'field' && ( $el['id'] ?? '' ) === 'vendor_store_url_slug' ) {
                 $found = $el;
                 break;
             }

--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -175,10 +175,10 @@ class SettingsSchemaTest extends DokanTestCase {
     // Expected fields
     // =========================================================================
 
-    public function test_vendor_store_url_field_exists(): void {
-        $field = $this->find_element( 'vendor_store_url', 'field' );
+    public function test_vendor_store_url_slug_field_exists(): void {
+        $field = $this->find_element( 'vendor_store_url_slug', 'field' );
 
-        $this->assertNotNull( $field, 'vendor_store_url field not found.' );
+        $this->assertNotNull( $field, 'vendor_store_url_slug field not found.' );
         $this->assertSame( 'text', $field['variant'] );
         $this->assertSame( 'store', $field['default'] );
         $this->assertSame( 'marketplace_settings', $field['section_id'] );

--- a/tests/php/src/REST/SettingsRoundTripTest.php
+++ b/tests/php/src/REST/SettingsRoundTripTest.php
@@ -167,7 +167,7 @@ class SettingsRoundTripTest extends DokanTestCase {
      * The new UI calls PUT `/dokan/v1/admin/settings/{page_id}`, which
      * writes `dokan_settings`. The `BridgeBootstrap` listener (registered
      * on `dokan_admin_settings_changed`) mirrors mapped keys to their
-     * legacy option counterparts. Uses the hand-authored `vendor_store_url`
+     * legacy option counterparts. Uses the hand-authored `vendor_store_url_slug`
      * field on the `general` page which carries `legacy_key
      * => 'dokan_general.custom_store_url'`.
      *
@@ -179,7 +179,7 @@ class SettingsRoundTripTest extends DokanTestCase {
             [
                 'page_id' => 'general',
                 'values'  => [
-                    'vendor_store_url' => 'mystorez',
+                    'vendor_store_url_slug' => 'mystorez',
                 ],
             ]
         );
@@ -204,7 +204,7 @@ class SettingsRoundTripTest extends DokanTestCase {
         $new = get_option( 'dokan_admin_settings', [] );
         $this->assertSame(
             'mystorez',
-            $new['vendor_store_url'] ?? null,
+            $new['vendor_store_url_slug'] ?? null,
             'REST PUT should have written the value into dokan_settings.'
         );
 
@@ -266,15 +266,15 @@ class SettingsRoundTripTest extends DokanTestCase {
     public function test_rest_put_with_dot_path_payload_resolves_to_leaf_id(): void {
         // Pre-condition: a known field has a value in storage.
         ( new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository() )
-            ->update( [ 'vendor_store_url' => 'unchanged' ] );
+            ->update( [ 'vendor_store_url_slug' => 'unchanged' ] );
 
         $request = new WP_REST_Request( 'PUT', '/' . $this->namespace . '/settings/general' );
         $request->set_body_params(
             [
                 'page_id' => 'general',
                 'values'  => [
-                    // Dot-path key — controller strips to leaf id `vendor_store_url`.
-                    'general.marketplace.vendor_store_url' => 'updated-via-dotpath',
+                    // Dot-path key — controller strips to leaf id `vendor_store_url_slug`.
+                    'general.marketplace.vendor_store_url_slug' => 'updated-via-dotpath',
                 ],
             ]
         );
@@ -285,8 +285,8 @@ class SettingsRoundTripTest extends DokanTestCase {
         $this->assertIsArray( $settings );
         $this->assertSame(
             'updated-via-dotpath',
-            $settings['vendor_store_url'] ?? null,
-            'Dot-path payload key must resolve to its leaf id (vendor_store_url).'
+            $settings['vendor_store_url_slug'] ?? null,
+            'Dot-path payload key must resolve to its leaf id (vendor_store_url_slug).'
         );
     }
 

--- a/tests/pw/pages/adminSettingsPage.ts
+++ b/tests/pw/pages/adminSettingsPage.ts
@@ -671,7 +671,7 @@ export class AdminSettingsPage extends BasePage {
     async getEnableSellingOptionFromNewSettings(): Promise<string> {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         // Find the currently selected button (aria-checked="true")
@@ -689,7 +689,7 @@ export class AdminSettingsPage extends BasePage {
     async updateEnableSellingOptionInNewSettings(option: string) {
         await this.navigateToNewVendorOnboardingSettings();
 
-        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_enable_selling');
+        const baseLocator = this.page.locator('#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling');
         await baseLocator.waitFor({ state: 'visible', timeout: 10000 });
 
         const targetButton = baseLocator.locator(`[role="radio"][name="${option}"]`);
@@ -749,7 +749,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -780,7 +780,7 @@ export class AdminSettingsPage extends BasePage {
         await this.navigateToNewVendorOnboardingSettings();
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_address_fields')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -904,7 +904,7 @@ export class AdminSettingsPage extends BasePage {
 
         // Locate the switch element for Welcome Wizard
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });
@@ -934,7 +934,7 @@ export class AdminSettingsPage extends BasePage {
         console.log('Navigated to New Vendor Settings for Welcome Wizard check.......');
 
         const switchElement = this.page
-            .locator('#dokan_settings_vendor_vendor_onboarding_welcome_wizard')
+            .locator('#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled')
             .getByRole('switch');
 
         await switchElement.waitFor({ state: 'visible', timeout: 10000 });

--- a/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/adminSettingsMigration.spec.ts
@@ -491,7 +491,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'disable_product_popup'; 
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup';
         const fieldKey = 'productPopupField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"
@@ -533,7 +533,7 @@ test.describe('Admin Settings Migration', () => {
         const oldNavigationFunction = 'navigateToOldSellingOptions'; 
         const newNavigationFunction = 'navigateToNewVendorCapabilitiesSettings'; 
         const checkboxClass = 'order_status_change';
-        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change';
+        const fieldSelectorId = 'dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status';
         const fieldKey = 'orderStatusChangeField'; 
 
         // step 0: Ensure "One Page Product Creation" is disabled before testing "Product Popup"

--- a/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/generalMarketplace.spec.ts
@@ -68,7 +68,7 @@ const newDataset = {
     selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+            selector: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
             type: 'text',
             value: 'my-url',
         },

--- a/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/storePage.spec.ts
@@ -46,42 +46,42 @@ const newDataset = {
     selector: '#dokan_settings_appearance >> #dokan_settings_appearance_store',
     fields: [
         {
-            selector: '#dokan_settings_appearance_store_products_page_store_product_per_page input[placeholder="Products Per Page"]',
+            selector: '#dokan_settings_appearance_store_products_page_store_products_per_page input[placeholder="Products Per Page"]',
             type: 'number',
             value: '12',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_site_key input[placeholder="Site Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_site_key input[placeholder="Site Key"]',
             type: 'text',
             value: 'SITE_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_recaptcha_secret_key input[placeholder="Secret Key"]',
+            selector: '#dokan_settings_appearance_store_google_recaptcha_google_recaptcha_settings_google_recaptcha_secret_key input[placeholder="Secret Key"]',
             type: 'text',
             value: 'SECRET_KEY_123',
         },
         {
-            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_clossing_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_contact_form_section_store_contact_form_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_time_widget button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_time_widget_section_store_opening_closing_time_widget button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_opening_time button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_store_sidebar_section_store_sidebar_from_theme button[role="switch"]',
             type: 'switch',
             value: true,
         },
         {
-            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_font button[role="switch"]',
+            selector: '#dokan_settings_appearance_store_dokan_font_section_dokan_fontawesome_enabled button[role="switch"]',
             type: 'switch',
             value: true,
         },    

--- a/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/transactionReverseWithdrawal.spec.ts
@@ -140,7 +140,7 @@ const newDataset = {
         
         // Display Notice During Grace Period - Switch
         {
-            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_display_notice button[role="switch"]',
+            selector: '#dokan_settings_transaction_reverse_withdrawal_reverse_withdrawal_section_reverse_withdrawal_grace_period_notice button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorCapabilities.spec.ts
@@ -127,14 +127,14 @@ const newDataset = {
         
         // Product Popup - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_product_popup button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_new_product_popup button[role="switch"]',
             type: 'switch',
             value: true,
         },
         
         // Order Status Change - Switch
         {
-            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_order_status_change button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_capabilities_vendor_capabilities_vendor_can_change_order_status button[role="switch"]',
             type: 'switch',
             value: true,
         },

--- a/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
+++ b/tests/pw/tests/e2e/adminSettings/vendorVendorOnboarding.spec.ts
@@ -53,12 +53,12 @@ const newDataset = {
     //selector: '#dokan_settings_general >> #dokan_settings_general_marketplace',
     fields: [
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_enable_selling button[name="automatically"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_auto_enable_selling button[name="automatically"]',
             type: 'radio',
             value: 'true',
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_address_fields button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_registration_address_fields button[role="switch"]',
             type: 'switch',
             value: true,
         },
@@ -68,7 +68,7 @@ const newDataset = {
             value: true,
         },
         {
-            selector: '#dokan_settings_vendor_vendor_onboarding_welcome_wizard button[role="switch"]',
+            selector: '#dokan_settings_vendor_vendor_onboarding_vendor_welcome_wizard_enabled button[role="switch"]',
             type: 'switch',
             value: false, // Note: Inverted value compared to old setting
         },

--- a/tests/pw/utils/testData.ts
+++ b/tests/pw/utils/testData.ts
@@ -1393,7 +1393,7 @@ export const data = {
             newUI: {
                 generalButton: '#dokan_settings_general button',
                 marketplaceLink: '#dokan_settings_general_marketplace',
-                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url input',
+                vendorStoreUrlField: '#dokan_settings_general_marketplace_marketplace_settings_vendor_store_url_slug input',
                 singleSellerModeField: '#dokan_settings_general_marketplace_marketplace_settings_enable_single_seller_mode',
                 saveButton: '#dokan-admin-settings-save-btn button',
                 successMessage: '.notice-success, .updated',


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Pulls the SettingsSchema field-id rename wave from \`refactor/settings-accessor-api\` into this branch so the two integration branches stay aligned on field naming. The accessor-api branch renamed ~20 schema ids to be self-describing and prefixed (\`welcome_wizard\` -> \`vendor_welcome_wizard_enabled\`, \`recaptcha\` -> \`google_recaptcha_enabled\`, etc.) so the accessor API can address fields by id alone.

**Two commits:**

1. **\`chore(settings): sync SettingsSchema field-id renames from accessor-api\`**
   - \`includes/Admin/Settings/Schema/SettingsSchema.php\` pulled from \`refactor/settings-accessor-api\`.
   - 8 Playwright e2e files (\`tests/pw/pages/adminSettingsPage.ts\`, \`tests/pw/utils/testData.ts\`, 6 spec files) updated in lockstep with the new ids.
   - The \`legacy_key\` declarations on every renamed field are untouched, so \`LegacySettingsBridge\` and the strip-on-write / overlay-on-read path keep working without modification.

2. **\`chore(settings): rename PHP test ids + ai_product_info_engine dep target\`**
   - Surgical rename of \`vendor_store_url\` -> \`vendor_store_url_slug\` in 4 PHPUnit test files. Only schema-field-id occurrences were renamed; the underlying legacy address (\`dokan_general.custom_store_url\`) is unchanged so legacy tests stay correct.
   - \`SettingsSchema.php\`: \`engine_deps => when_engine('product_info_engine', ...)\` in the per-provider text-AI fieldgroup loop referenced an id that the rename wave turned into \`ai_product_info_engine\`. The field id and the dependency target now match.

### Rename map (for reference)

| Old | New |
|---|---|
| welcome_wizard | vendor_welcome_wizard_enabled |
| product_popup | vendor_new_product_popup |
| enable_selling | vendor_auto_enable_selling |
| address_fields | vendor_registration_address_fields |
| order_status_change | vendor_can_change_order_status |
| admin_access | admin_access_for_vendors |
| vendor_store_url | vendor_store_url_slug |
| store_product_per_page | store_products_per_page |
| recaptcha | google_recaptcha_enabled |
| recaptcha_info | google_recaptcha_info |
| recaptcha_site_key | google_recaptcha_site_key |
| recaptcha_secret_key | google_recaptcha_secret_key |
| store_clossing_time_widget | store_contact_form_enabled |
| store_template | store_header_template |
| store_time_widget | store_opening_closing_time_widget |
| store_opening_time | store_sidebar_from_theme |
| vendor_info_visibility | store_page_vendor_info_visibility |
| dokan_font | dokan_fontawesome_enabled |
| privacy_policy_display | privacy_policy_visibility |
| display_notice | reverse_withdrawal_grace_period_notice |

### Related Pull Request(s)

* Source of the renames: PR #3210 on \`refactor/settings-accessor-api\` (commit \`0004536b5\`).
* Companion: dokan-pro overlay/strip fix #5669 (merged), dokan-lite #3217 (merged).

### How to test the changes in this Pull Request:

\`\`\`bash
npm run phpunit -- --group admin-settings
\`\`\`

Expected: 256 tests, 5 failures. All 5 are pre-existing on develop (schema validator warnings + reverse-withdrawal field tests) and unrelated to this sync.

### Changelog entry

**Title**

Settings: align schema field ids with the upcoming accessor-api naming convention

**Detailed Description**

- **Before:** Schema field ids used short, sometimes-ambiguous names (\`welcome_wizard\`, \`recaptcha\`, \`admin_access\`).
- **After:** Ids are prefixed and self-describing (\`vendor_welcome_wizard_enabled\`, \`google_recaptcha_enabled\`, \`admin_access_for_vendors\`). Legacy storage addresses are unchanged — the rename is purely at the new-flat-option layer.

### Before Changes
N/A — schema-id rename, no UI surface.

### After Changes
N/A — schema-id rename, no UI surface.