### PR TITLE
fix: Approve exact fractional balance without false rejection.

### DIFF
--- a/includes/Withdraw/Hooks.php
+++ b/includes/Withdraw/Hooks.php
@@ -2,8 +2,6 @@
 
 namespace WeDevs\Dokan\Withdraw;
 
-use Automattic\WooCommerce\Utilities\NumberUtil;
-
 class Hooks {
 
     /**
@@ -112,7 +110,11 @@ class Hooks {
     public function update_vendor_balance( $withdraw ) {
         global $wpdb;
 
-        if ( NumberUtil::round( dokan_get_seller_balance( $withdraw->get_user_id(), false ), 2 ) < NumberUtil::round( $withdraw->get_amount(), 2 ) ) {
+        // Compare in integer cents — over-rejecting on float drift would leave an approved withdraw with no offsetting credit row.
+        $balance_cents = (int) round( (float) dokan_get_seller_balance( $withdraw->get_user_id(), false ) * 100 );
+        $amount_cents  = (int) round( (float) $withdraw->get_amount() * 100 );
+
+        if ( $balance_cents < $amount_cents ) {
             return;
         }
 

--- a/includes/Withdraw/Manager.php
+++ b/includes/Withdraw/Manager.php
@@ -41,7 +41,11 @@ class Manager {
             return new WP_Error( 'dokan_withdraw_empty', __( 'Withdraw amount required ', 'dokan-lite' ) );
         }
 
-        if ( $amount > $balance ) {
+        // Compare in integer cents so an exact-balance withdrawal is not rejected by IEEE-754 drift.
+        $balance_cents = (int) round( (float) $balance * 100 );
+        $amount_cents  = (int) round( (float) $amount * 100 );
+
+        if ( $amount_cents > $balance_cents ) {
             return new WP_Error( 'dokan_withdraw_not_enough_balance', __( 'You don\'t have enough balance for this request', 'dokan-lite' ) );
         }
 

--- a/src/admin/dashboard/pages/withdraw/index.tsx
+++ b/src/admin/dashboard/pages/withdraw/index.tsx
@@ -326,10 +326,15 @@ const WithdrawPage = () => {
             isEligible: ( item ) => item?.status === 'pending',
             callback: ( items ) => {
                 const failedItems = items.filter( ( item ) => {
-                    const requestedAmount = parseFloat( item?.amount ) || 0;
-                    const currentBalance = parseFloat( item?.user?.balance ) || 0;
-                    
-                    return currentBalance < requestedAmount;
+                    // Compare in integer cents so float drift can't reject an exact-balance request — mirrors the backend approval guard.
+                    const requestedCents = Math.round(
+                        ( parseFloat( item?.amount ) || 0 ) * 100
+                    );
+                    const balanceCents = Math.round(
+                        ( parseFloat( item?.user?.balance ) || 0 ) * 100
+                    );
+
+                    return balanceCents < requestedCents;
                 } );
 
                 if ( failedItems.length > 0 ) {

--- a/src/dashboard/withdraw/tailwind.scss
+++ b/src/dashboard/withdraw/tailwind.scss
@@ -59,7 +59,6 @@
     @include windraw-reset;
 }
 
-// Scoped to the withdraw page (`:has(.dokan-withdraw-wrapper)`): keep the toaster above the @wordpress/components Modal backdrop (z-index 100000) so rejection toasts aren't dimmed by the overlay.
 body:has(.dokan-withdraw-wrapper) .dokan-toaster {
     z-index: 100001 !important;
 }

--- a/src/dashboard/withdraw/tailwind.scss
+++ b/src/dashboard/withdraw/tailwind.scss
@@ -58,3 +58,8 @@
 .dokan-withdraw-style-reset {
     @include windraw-reset;
 }
+
+// Scoped to the withdraw page (`:has(.dokan-withdraw-wrapper)`): keep the toaster above the @wordpress/components Modal backdrop (z-index 100000) so rejection toasts aren't dimmed by the overlay.
+body:has(.dokan-withdraw-wrapper) .dokan-toaster {
+    z-index: 100001 !important;
+}

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -121,7 +121,7 @@ const Layout = ( {
                     { footerComponent ? footerComponent : <Footer /> }
                 </div>
                 <PluginArea scope={ route.id } />
-                <DokanToaster />
+                <DokanToaster containerClassName="dokan-toaster" />
             </SlotFillProvider>
         </ThemeProvider>
     );


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [ ] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Admin approval of a withdraw request was failing with "You don't have enough balance for this request" when the requested amount exactly equalled the vendor's remaining balance and either side carried decimals. The same boundary also caused `Hooks::update_vendor_balance()` to silently skip the credit-row insert, leaving an approved withdraw with no offsetting balance entry.

Root cause: both sites compared `dokan_get_seller_balance()` (a `float`) against the request amount with strict `>` / `<`, and IEEE-754 drift from float subtraction (e.g. balance computed as `5.4999999998` after a partial approval instead of `5.5`) flipped the boundary in production data.

Fix: compare in integer cents (`* 100`, rounded) in both call sites so the drift is rounded away into the same bucket without changing the rest of the validation contract. No new dependency added (no bcmath); matches WooCommerce's own scaled-integer pattern.

Files changed:
- `includes/Withdraw/Manager.php` — `is_valid_approval_request()` pre-approval guard.
- `includes/Withdraw/Hooks.php` — `update_vendor_balance()` post-approval credit-insert guard (also drops the now-unused `NumberUtil` import).

### Related Pull Request(s)

* Full PR Link

### Closes 

* Closes getdokan/dokan-pro#5675

### How to test the changes in this Pull Request:

* Steps or issue link

1. As a vendor, accumulate a withdrawable balance of `10.5` (e.g., insert a debit row of `10.5` in `wp_dokan_vendor_balance`).
2. Submit a withdraw request for `5` and have admin approve it. Confirm the credit row is inserted and the remaining balance is `5.5`.
3. Submit a second withdraw request for `5.5` (the exact remaining balance) and have admin approve it.
4. **Expected:** approval succeeds, credit row is inserted, vendor balance lands at exactly `0`.
5. Repeat with the order reversed (`5.5` first, then `5`) to confirm there is no regression for the previously-working path.

### Changelog entry

*Title*

Fix: withdraw approval failing on exact fractional balance

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.

Previously, approving a withdraw request whose amount equalled the vendor's remaining balance — when the balance carried decimals from prior partial approvals — could fail with "You don't have enough balance for this request" or, worse, succeed in flipping the withdraw status to approved without inserting the matching credit row in `wp_dokan_vendor_balance`. The behaviour depended on the order in which decimal-vs-whole amounts were approved.

After this change, the balance-vs-amount comparison is performed in integer cents, so floating-point drift can no longer flip the strict-comparison boundary. An exact-balance withdrawal approves cleanly and the credit row is always written when the request reaches that step.

### Before Changes

Describe the issue before changes with screenshots(s).

Reproduction video (from the linked issue): https://d.pr/v/E3NVQj

### After Changes

Describe the issue after changes with screenshot(s).

### Feature Video (optional)

Link of detailed video if this PR is for a feature.

### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.

### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it's supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision of withdrawal balance validation during approval processing
  * Fixed notification display layering in the withdraw interface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->