### PR TITLE
feat(components): export Switch + DokanSwitch/DokanTimePicker aliases

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -6,7 +6,39 @@ export {
     VIEW_LAYOUTS,
 } from '@wordpress/dataviews/wp';
 export { default as AdminDataViews } from './dataviews/AdminDataViewTable';
-export { DataViews } from '@wedevs/plugin-ui';
+export { DataViews, Switch, LabeledSwitch } from '@wedevs/plugin-ui';
+
+import { Switch as _PluginUISwitch } from '@wedevs/plugin-ui';
+
+/**
+ * Legacy alias for the old `DokanSwitch` component. The underlying
+ * plugin-ui `Switch` is a Radix primitive that exposes
+ * `onCheckedChange(value: boolean)`. Old call sites (e.g., dokan-pro's
+ * delivery-time module) pass `onChange(value: boolean)`. This adapter
+ * forwards both names so neither API change breaks consumers.
+ */
+type DokanSwitchProps = {
+	checked?: boolean;
+	onChange?: ( value: boolean ) => void;
+	onCheckedChange?: ( value: boolean ) => void;
+	[ key: string ]: unknown;
+};
+
+export const DokanSwitch = ( {
+	onChange,
+	onCheckedChange,
+	checked = false,
+	...rest
+}: DokanSwitchProps ) => {
+	const handler = onCheckedChange ?? onChange;
+	return (
+		<_PluginUISwitch
+			checked={ checked }
+			onCheckedChange={ handler }
+			{ ...rest }
+		/>
+	);
+};
 export { default as DokanModal } from './modals/DokanModal';
 export { default as SortableList } from './sortable-list';
 export { default as ListEmpty } from './dataviews/ListEmpty';
@@ -41,7 +73,7 @@ export { default as SearchInput } from './SearchInput';
 export { default as Select } from './Select';
 export { default as ShortContent } from './ShortContent';
 export { default as DokanTab } from './Tab';
-export { default as TimePicker } from './TimePicker';
+export { default as TimePicker, default as DokanTimePicker } from './TimePicker';
 export { default as MediaUploader } from './Upload';
 export { default as UserCard } from './UserCard';
 export { default as StatCard } from './StatCard';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -73,7 +73,10 @@ export { default as SearchInput } from './SearchInput';
 export { default as Select } from './Select';
 export { default as ShortContent } from './ShortContent';
 export { default as DokanTab } from './Tab';
-export { default as TimePicker, default as DokanTimePicker } from './TimePicker';
+export {
+    default as TimePicker,
+    default as DokanTimePicker,
+} from './TimePicker';
 export { default as MediaUploader } from './Upload';
 export { default as UserCard } from './UserCard';
 export { default as StatCard } from './StatCard';


### PR DESCRIPTION
## Summary

Adds three missing exports to \`@dokan/components\` so Pro modules importing the legacy \`Dokan\`-prefixed names keep rendering instead of crashing.

## Why

An older Pro delivery-time component imports:

\`\`\`tsx
import { DokanSwitch, DokanTimePicker } from '@dokan/components';
\`\`\`

But \`@dokan/components\` dropped the \`Dokan\` prefix on primitive exports — today it exposes \`TimePicker\` (no Dokan) and no Switch at all. The legacy names resolved to \`undefined\` at runtime and crashed React with:

\`\`\`
Element type is invalid: expected a string... but got: undefined.
Check the render method of `ce`.
\`\`\`

## Fix

- Re-export \`Switch\` and \`LabeledSwitch\` from \`@wedevs/plugin-ui\` (same pattern as the existing \`DataViews\` re-export on line 9 — pre-existing precedent for surfacing plugin-ui primitives under \`@dokan/components\`).
- Alias \`Switch as DokanSwitch\` and \`TimePicker as DokanTimePicker\` so Pro modules with legacy imports work without touching their source.

The non-prefixed \`Switch\` / \`LabeledSwitch\` / \`TimePicker\` exports are the canonical going-forward names; the prefixed aliases are back-compat.

## Verified locally

After \`npm run build\`, on the new admin dashboard:

- \`window.dokan.components.Switch\` is a function
- \`window.dokan.components.DokanSwitch\` is a function (aliased)
- \`window.dokan.components.DokanTimePicker\` is a function (aliased)
- The delivery-time settings card renders without crashing (see dokan-pro#5685)

## Stacked PR

The delivery-time module's component fix (dokan-pro #5685) depends on this PR. Once this merges, the Pro PR's import line stays unchanged and just starts working.