### PR TITLE
feat: Vendor Structured Data — vendor-attributed Schema.org JSON-LD (F-09)

### DIFF
--- a/docs/vendor-structured-data.md
+++ b/docs/vendor-structured-data.md
@@ -1,0 +1,129 @@
+# Vendor Structured Data — Schema.org JSON-LD (F-09)
+
+**Strategy ref:** [Dokan Agentic Commerce Strategy](https://hackmd.io/@anikfahmid/dokan-agentic-strategy) — F-09  
+**Horizon:** H1 — Agent Accessible  
+**Ships in:** Dokan Lite (free)
+
+---
+
+## What It Does
+
+Injects vendor-attributed Schema.org JSON-LD markup on every product page and vendor storefront. This makes each vendor's identity visible to Google Shopping Graph, Bing Shopping, Perplexity, and any AI agent that reads page markup.
+
+**The problem:** WooCommerce's default product schema has no `seller` field. Every product appears to be sold by the marketplace operator — vendor identity is invisible to AI agents and search engines before they even reach your catalog.
+
+**After F-09:** Each product's structured data names the actual vendor as the seller. Agents can distinguish between vendors, compare sellers, and surface vendor-specific trust signals.
+
+---
+
+## Before / After
+
+**Before (WooCommerce default):**
+```json
+{
+  "@type": "Product",
+  "name": "Trail Running Shoes",
+  "offers": [{
+    "@type": "Offer",
+    "price": "129.00",
+    "availability": "https://schema.org/InStock"
+  }]
+}
+```
+
+**After (with F-09):**
+```json
+{
+  "@type": "Product",
+  "name": "Trail Running Shoes",
+  "offers": [{
+    "@type": "Offer",
+    "price": "129.00",
+    "availability": "https://schema.org/InStock",
+    "seller": {
+      "@type": "Organization",
+      "@id": "https://mystore.com/store/greenleather/#organization",
+      "name": "GreenLeather Co",
+      "url": "https://mystore.com/store/greenleather/",
+      "logo": "https://mystore.com/.../logo.jpg"
+    }
+  }],
+  "brand": {
+    "@type": "Brand",
+    "name": "GreenLeather Co"
+  }
+}
+```
+
+Vendor storefront pages also emit a full `Store` + `Organization` `@graph` with a stable `@id` so Google and agents can cross-link vendor cards across product listings and the storefront page.
+
+---
+
+## Admin Attribution Control
+
+WP Admin → Dokan → Settings → **Agent Attribution**
+
+| Mode | Behavior |
+|------|---------|
+| **Per Vendor** (default) | `seller.name` = vendor store name; `seller.url` = vendor storefront |
+| **Marketplace** | `seller.name` = site name; `seller.url` = site URL (white-label: buyers see marketplace brand, not individual vendors) |
+| **Disabled** | No JSON-LD injected by Dokan (use when an SEO plugin handles all schema) |
+
+The same setting controls attribution across F-03 (AI Product Feed) and F-05 (Semantic Search API responses) via the global `dokan_agent_attribution_mode()` helper.
+
+---
+
+## Filters & Extensibility
+
+```php
+// Opt out entirely (e.g., SEO plugin handles all schema)
+add_filter( 'dokan_jsonld_enabled', '__return_false' );
+
+// Modify product JSON-LD after Dokan builds it
+add_filter( 'dokan_jsonld_product', function( array $data, WC_Product $product ): array {
+    // Add aggregate rating from your review system
+    $data['aggregateRating'] = [ ... ];
+    return $data;
+}, 10, 2 );
+
+// Modify vendor store JSON-LD
+add_filter( 'dokan_jsonld_vendor_store', function( array $data, int $vendor_id ): array {
+    $data['address'] = [ '@type' => 'PostalAddress', ... ];
+    return $data;
+}, 10, 2 );
+```
+
+**Global attribution helper** (usable by Pro modules and themes):
+```php
+$mode = dokan_agent_attribution_mode(); // returns 'vendor' | 'marketplace' | 'off'
+```
+
+---
+
+## Implementation Files
+
+| File | Role |
+|------|------|
+| `includes/StructuredData/Manager.php` | Bootstrap; instantiates ProductSchema + VendorStoreSchema; arg-less constructor (League container constraint) |
+| `includes/StructuredData/Helper.php` | Vendor lookup, Organization node builder, logo resolution, current-store detection |
+| `includes/StructuredData/ProductSchema.php` | Hooks `woocommerce_structured_data_product`; attaches seller to each Offer; injects brand |
+| `includes/StructuredData/VendorStoreSchema.php` | Emits Store + Organization @graph on store pages via `wp_head` |
+| `includes/StructuredData/Settings.php` | Admin attribution control (Per Vendor / Marketplace / Disabled) |
+| `includes/functions.php` | `dokan_agent_attribution_mode()` global helper |
+
+---
+
+## Planned Extensions (P2)
+
+- Marketplace homepage `Organization` schema with `subOrganization` list of top vendors
+- `aggregateRating` on vendor `Organization` — conditional when Dokan Store Reviews module is active
+- `hasMerchantReturnPolicy` + `shippingDetails` from vendor settings
+- `location` address node when vendor has a structured address
+
+---
+
+## Related Features
+
+- **F-04 Agent Discovery** — sibling H1 free build; llms.txt signals what agents can access
+- **F-03 AI Product Feed** — same vendor attribution differentiator applied to ACP/UCP/Perplexity feeds
+- **F-05 Semantic Search** — uses `dokan_agent_attribution_mode()` for consistent vendor identity in API responses

--- a/includes/DependencyManagement/Providers/CommonServiceProvider.php
+++ b/includes/DependencyManagement/Providers/CommonServiceProvider.php
@@ -26,6 +26,8 @@ class CommonServiceProvider extends BaseServiceProvider {
         \WeDevs\Dokan\Exceptions\Handler::class,
         \WeDevs\Dokan\Shortcodes\FullWidthVendorLayout::class,
         \WeDevs\Dokan\Vendor\ApiMeta::class,
+        \WeDevs\Dokan\StructuredData\Manager::class,
+        \WeDevs\Dokan\StructuredData\Settings::class,
 	];
 
 	/**

--- a/includes/StructuredData/Helper.php
+++ b/includes/StructuredData/Helper.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace WeDevs\Dokan\StructuredData;
+
+class Helper {
+
+    public static function vendor_for_product( $product ) {
+        if ( is_numeric( $product ) ) {
+            $product = wc_get_product( $product );
+        }
+        if ( ! $product instanceof \WC_Product ) {
+            return null;
+        }
+
+        $author_id = (int) get_post_field( 'post_author', $product->get_id() );
+        if ( ! $author_id || ! function_exists( 'dokan_get_vendor' ) ) {
+            return null;
+        }
+
+        $vendor = dokan_get_vendor( $author_id );
+        if ( ! $vendor || ! $vendor->get_id() ) {
+            return null;
+        }
+
+        return $vendor;
+    }
+
+    public static function vendor_organization_node( $vendor ) {
+        $shop_url = $vendor->get_shop_url();
+        $name     = $vendor->get_shop_name();
+
+        $node = [
+            '@type' => 'Organization',
+            '@id'   => trailingslashit( $shop_url ) . '#organization',
+            'name'  => $name ?: get_the_author_meta( 'display_name', $vendor->get_id() ),
+            'url'   => $shop_url,
+        ];
+
+        $logo = self::vendor_logo_url( $vendor );
+        if ( $logo ) {
+            $node['logo'] = $logo;
+        }
+
+        return $node;
+    }
+
+    public static function vendor_logo_url( $vendor ) {
+        $gravatar_id = method_exists( $vendor, 'get_avatar_id' ) ? (int) $vendor->get_avatar_id() : 0;
+        if ( $gravatar_id ) {
+            $url = wp_get_attachment_image_url( $gravatar_id, 'full' );
+            if ( $url ) {
+                return $url;
+            }
+        }
+
+        if ( method_exists( $vendor, 'get_avatar' ) ) {
+            $avatar = $vendor->get_avatar();
+            if ( $avatar && filter_var( $avatar, FILTER_VALIDATE_URL ) ) {
+                return $avatar;
+            }
+        }
+
+        return '';
+    }
+
+    public static function current_store_vendor() {
+        if ( ! function_exists( 'dokan_is_store_page' ) || ! dokan_is_store_page() ) {
+            return null;
+        }
+        if ( ! function_exists( 'dokan_get_vendor' ) ) {
+            return null;
+        }
+
+        $store_user = get_query_var( 'author_name' );
+        if ( ! $store_user ) {
+            return null;
+        }
+
+        $user = get_user_by( 'slug', $store_user );
+        if ( ! $user ) {
+            return null;
+        }
+
+        return dokan_get_vendor( $user->ID );
+    }
+}

--- a/includes/StructuredData/Manager.php
+++ b/includes/StructuredData/Manager.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WeDevs\Dokan\StructuredData;
+
+class Manager {
+
+    public function __construct() {
+        if ( ! apply_filters( 'dokan_jsonld_enabled', true ) ) {
+            return;
+        }
+
+        new ProductSchema();
+        new VendorStoreSchema();
+    }
+}

--- a/includes/StructuredData/ProductSchema.php
+++ b/includes/StructuredData/ProductSchema.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WeDevs\Dokan\StructuredData;
+
+class ProductSchema {
+
+    public function __construct() {
+        add_filter( 'woocommerce_structured_data_product', [ $this, 'inject_vendor' ], 20, 2 );
+    }
+
+    public function inject_vendor( $markup, $product ) {
+        if ( ! is_array( $markup ) || ! $product instanceof \WC_Product ) {
+            return $markup;
+        }
+
+        $vendor = Helper::vendor_for_product( $product );
+        if ( ! $vendor ) {
+            return $markup;
+        }
+
+        $organization = Helper::vendor_organization_node( $vendor );
+
+        if ( empty( $markup['brand'] ) ) {
+            $markup['brand'] = [
+                '@type' => 'Brand',
+                'name'  => $organization['name'],
+            ];
+        }
+
+        if ( ! empty( $markup['offers'] ) ) {
+            if ( $this->is_offer_node( $markup['offers'] ) ) {
+                $markup['offers']['seller'] = $organization;
+            } elseif ( is_array( $markup['offers'] ) ) {
+                foreach ( $markup['offers'] as $key => $offer ) {
+                    if ( $this->is_offer_node( $offer ) ) {
+                        $offer['seller']          = $organization;
+                        $markup['offers'][ $key ] = $offer;
+                    }
+                }
+            }
+        }
+
+        return apply_filters( 'dokan_jsonld_product', $markup, $product, $vendor );
+    }
+
+    private function is_offer_node( $node ) {
+        return is_array( $node ) && isset( $node['@type'] ) && 'Offer' === $node['@type'];
+    }
+}

--- a/includes/StructuredData/Settings.php
+++ b/includes/StructuredData/Settings.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace WeDevs\Dokan\StructuredData;
+
+class Settings {
+
+    const SECTION_ID        = 'dokan_agent_visibility';
+    const OPTION_KEY        = 'dokan_agent_visibility';
+    const FIELD_SELLER      = 'seller_attribution';
+    const VALUE_PER_VENDOR  = 'vendor';
+    const VALUE_MARKETPLACE = 'marketplace';
+    const VALUE_OFF         = 'off';
+
+    public function __construct() {
+        add_filter( 'dokan_settings_sections', [ $this, 'register_section' ], 26 );
+        add_filter( 'dokan_settings_fields', [ $this, 'register_fields' ], 26 );
+
+        add_filter( 'dokan_jsonld_enabled', [ $this, 'maybe_disable' ] );
+        add_filter( 'dokan_jsonld_product', [ $this, 'maybe_swap_to_marketplace' ], 30 );
+        add_filter( 'dokan_jsonld_vendor_store', [ $this, 'maybe_blank_store_schema' ], 30 );
+    }
+
+    public function register_section( $sections ) {
+        $sections[] = [
+            'id'                   => self::SECTION_ID,
+            'title'                => __( 'Agent Attribution', 'dokan-lite' ),
+            'icon_url'             => '',
+            'description'          => __( 'Vendor identity across all AI agent surfaces', 'dokan-lite' ),
+            'settings_title'       => __( 'Agent Attribution', 'dokan-lite' ),
+            'settings_description' => __( 'Controls vendor identity across every AI agent surface — page markup (Schema.org JSON-LD) and product feeds (ACP feed for ChatGPT, when the AI Product Feed module is active). One switch keeps attribution consistent across every door agents use to find your products. Human-facing pages and your store theme are unchanged.', 'dokan-lite' ),
+        ];
+        return $sections;
+    }
+
+    public function register_fields( $fields ) {
+        $callout = function ( $title, $body, $tone = 'info' ) {
+            $bg     = 'info' === $tone ? '#eef6ff' : ( 'warn' === $tone ? '#fff7e6' : '#fdecea' );
+            $border = 'info' === $tone ? '#7cb1ee' : ( 'warn' === $tone ? '#e6a23c' : '#e74c3c' );
+            return sprintf(
+                '<div style="padding:12px 14px;background:%1$s;border-left:4px solid %2$s;border-radius:3px;line-height:1.5;"><strong>%3$s</strong><br>%4$s</div>',
+                esc_attr( $bg ),
+                esc_attr( $border ),
+                esc_html( $title ),
+                esc_html( $body )
+            );
+        };
+
+        $fields[ self::SECTION_ID ] = [
+            self::FIELD_SELLER => [
+                'name'    => self::FIELD_SELLER,
+                'label'   => __( 'Seller Attribution', 'dokan-lite' ),
+                'desc'    => __( 'Choose who appears as the seller of each product across every AI agent surface — both page schema and product feeds. The selected option’s details show below.', 'dokan-lite' ),
+                'type'    => 'select',
+                'default' => self::VALUE_PER_VENDOR,
+                'options' => [
+                    self::VALUE_PER_VENDOR  => __( 'Per Vendor (Recommended)', 'dokan-lite' ),
+                    self::VALUE_MARKETPLACE => __( 'Marketplace (White-label)', 'dokan-lite' ),
+                    self::VALUE_OFF         => __( 'Disabled', 'dokan-lite' ),
+                ],
+                'tooltip' => __( 'Affects Schema.org markup on pages AND the ACP product feed sent to OpenAI. Your store theme and human-facing pages are unchanged.', 'dokan-lite' ),
+            ],
+            'attribution_help_vendor' => [
+                'name'    => 'attribution_help_vendor',
+                'label'   => '',
+                'type'    => 'html',
+                'show_if' => [
+                    self::FIELD_SELLER => [ 'equal' => self::VALUE_PER_VENDOR ],
+                ],
+                'desc'    => $callout(
+                    __( 'Per Vendor (Recommended)', 'dokan-lite' ),
+                    __( 'Each product attributed to the vendor who listed it — on product pages, vendor storefronts, AND in the ACP feed pushed to ChatGPT. Required for Dokan’s multi-vendor advantage in AI shopping — buyers asking AI assistants for products from specific shops will find your vendors.', 'dokan-lite' ),
+                    'info'
+                ),
+            ],
+            'attribution_help_marketplace' => [
+                'name'    => 'attribution_help_marketplace',
+                'label'   => '',
+                'type'    => 'html',
+                'show_if' => [
+                    self::FIELD_SELLER => [ 'equal' => self::VALUE_MARKETPLACE ],
+                ],
+                'desc'    => $callout(
+                    __( 'Marketplace (White-label)', 'dokan-lite' ),
+                    __( 'All products attributed to the marketplace name — on pages AND in feeds. Use for white-label / single-brand marketplaces. Vendors become invisible to AI agents across every surface. You lose Dokan’s multi-vendor differentiator in AI search.', 'dokan-lite' ),
+                    'warn'
+                ),
+            ],
+            'attribution_help_off' => [
+                'name'    => 'attribution_help_off',
+                'label'   => '',
+                'type'    => 'html',
+                'show_if' => [
+                    self::FIELD_SELLER => [ 'equal' => self::VALUE_OFF ],
+                ],
+                'desc'    => $callout(
+                    __( 'Disabled', 'dokan-lite' ),
+                    __( 'Removes the Schema.org seller field from product and storefront pages. ACP feed still emits vendor as seller — OpenAI requires the field and it cannot be empty. Not recommended; Google Shopping and Perplexity also rely on the seller field. Only use to avoid conflicts with another SEO plugin managing structured data.', 'dokan-lite' ),
+                    'danger'
+                ),
+            ],
+        ];
+        return $fields;
+    }
+
+    public function maybe_disable( $enabled ) {
+        return self::VALUE_OFF === self::current_mode() ? false : $enabled;
+    }
+
+    public function maybe_swap_to_marketplace( $markup ) {
+        if ( self::VALUE_MARKETPLACE !== self::current_mode() ) {
+            return $markup;
+        }
+
+        $marketplace = [
+            '@type' => 'Organization',
+            '@id'   => home_url( '/' ) . '#organization',
+            'name'  => get_bloginfo( 'name' ),
+            'url'   => home_url( '/' ),
+        ];
+
+        if ( ! empty( $markup['offers'] ) ) {
+            if ( $this->is_offer( $markup['offers'] ) ) {
+                $markup['offers']['seller'] = $marketplace;
+            } elseif ( is_array( $markup['offers'] ) ) {
+                foreach ( $markup['offers'] as $k => $offer ) {
+                    if ( $this->is_offer( $offer ) ) {
+                        $offer['seller']         = $marketplace;
+                        $markup['offers'][ $k ] = $offer;
+                    }
+                }
+            }
+        }
+
+        $markup['brand'] = [
+            '@type' => 'Brand',
+            'name'  => get_bloginfo( 'name' ),
+        ];
+
+        return $markup;
+    }
+
+    public function maybe_blank_store_schema( $graph ) {
+        return self::VALUE_MARKETPLACE === self::current_mode() ? [] : $graph;
+    }
+
+    public static function current_mode() {
+        $settings = get_option( self::OPTION_KEY, [] );
+        $value    = isset( $settings[ self::FIELD_SELLER ] ) ? (string) $settings[ self::FIELD_SELLER ] : self::VALUE_PER_VENDOR;
+        return in_array(
+            $value,
+            [ self::VALUE_PER_VENDOR, self::VALUE_MARKETPLACE, self::VALUE_OFF ],
+            true
+        ) ? $value : self::VALUE_PER_VENDOR;
+    }
+
+    private function is_offer( $node ) {
+        return is_array( $node ) && isset( $node['@type'] ) && 'Offer' === $node['@type'];
+    }
+}

--- a/includes/StructuredData/VendorStoreSchema.php
+++ b/includes/StructuredData/VendorStoreSchema.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WeDevs\Dokan\StructuredData;
+
+class VendorStoreSchema {
+
+    public function __construct() {
+        add_action( 'wp_head', [ $this, 'output' ], 30 );
+    }
+
+    public function output() {
+        $vendor = Helper::current_store_vendor();
+        if ( ! $vendor ) {
+            return;
+        }
+
+        $organization = Helper::vendor_organization_node( $vendor );
+        $shop_url     = $vendor->get_shop_url();
+
+        $store = [
+            '@type' => 'Store',
+            '@id'   => trailingslashit( $shop_url ) . '#store',
+            'name'  => $organization['name'],
+            'url'   => $shop_url,
+        ];
+
+        $logo = Helper::vendor_logo_url( $vendor );
+        if ( $logo ) {
+            $store['image'] = $logo;
+        }
+
+        $description = $this->vendor_description( $vendor );
+        if ( $description ) {
+            $store['description'] = $description;
+        }
+
+        $store['parentOrganization'] = [ '@id' => $organization['@id'] ];
+
+        $graph = [
+            '@context' => 'https://schema.org',
+            '@graph'   => [ $store, $organization ],
+        ];
+
+        $graph = apply_filters( 'dokan_jsonld_vendor_store', $graph, $vendor );
+
+        if ( empty( $graph ) || ( isset( $graph['@graph'] ) && empty( $graph['@graph'] ) ) ) {
+            return;
+        }
+
+        $json = wp_json_encode( $graph, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+        if ( false === $json ) {
+            return;
+        }
+
+        echo "\n" . '<script type="application/ld+json">' . $json . '</script>' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    private function vendor_description( $vendor ) {
+        if ( method_exists( $vendor, 'get_info_part' ) ) {
+            $bio = $vendor->get_info_part( 'store_biography' );
+            if ( $bio ) {
+                return wp_strip_all_tags( $bio );
+            }
+        }
+
+        $about = get_user_meta( $vendor->get_id(), 'description', true );
+        return $about ? wp_strip_all_tags( $about ) : '';
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4348,3 +4348,15 @@ function dokan_get_new_product_url() {
         dokan_get_navigation_url( 'new-product' )
     );
 }
+
+/**
+ * Get the current Agent Attribution mode.
+ *
+ * @return string 'vendor' | 'marketplace' | 'off'. Defaults to 'vendor'.
+ */
+function dokan_agent_attribution_mode() {
+    if ( class_exists( '\WeDevs\Dokan\StructuredData\Settings' ) ) {
+        return \WeDevs\Dokan\StructuredData\Settings::current_mode();
+    }
+    return 'vendor';
+}


### PR DESCRIPTION
📄 **Specs:** [Dokan Agentic Specs — Phase 1](https://docs.google.com/document/d/1_27BOlNAxpmHjUi0gLXCNMe9ADW9THH68oXpr4zFJD4/edit?usp=sharing)

## Summary

Injects vendor identity into WooCommerce's product schema and emits a full Store + Organization graph on vendor storefronts. Fixes the default WC behaviour where every product appears sold by the marketplace operator, erasing vendor identity from Google Shopping Graph, Bing, and Perplexity.

**Strategy:** [Dokan Agentic Commerce Strategy](https://hackmd.io/@anikfahmid/dokan-agentic-strategy) — F-09, H1

### Changes

- **ProductSchema** — filters `woocommerce_structured_data_product`; attaches `seller` Organization to each Offer; injects vendor `brand`
- **VendorStoreSchema** — emits Store + Organization @graph via `wp_head` on store pages; stable `@id` keyed on vendor shop URL for cross-page dedup by Google/agents
- **Settings** — admin control under **Dokan → Settings → Agent Attribution**: Per Vendor (default) / Marketplace (white-label) / Disabled
- **`dokan_agent_attribution_mode()`** global helper in `functions.php` — canonical accessor for Pro modules (F-03 AI Product Feed, F-05 Semantic Search read this)
- Filters: `dokan_jsonld_product`, `dokan_jsonld_vendor_store`, `dokan_jsonld_enabled`

### Before / After — Product page

```json
// BEFORE: WC default — no seller field
{ "@type": "Product", "offers": [{ "@type": "Offer", "price": "129.00" }] }

// AFTER: vendor named as seller
{ "@type": "Product", "offers": [{ "@type": "Offer", "price": "129.00",
  "seller": { "@type": "Organization", "name": "GreenLeather Co",
    "url": "https://mystore.com/store/greenleather/" } }] }
```

## Test plan

- [ ] Product page JSON-LD contains `offers[].seller` with vendor name + storefront URL
- [ ] Vendor storefront page emits `Store` + `Organization` @graph
- [ ] Attribution → Marketplace mode: `seller.name` = site name
- [ ] Attribution → Disabled: no JSON-LD injected by Dokan
- [ ] `dokan_agent_attribution_mode()` returns `'vendor'` by default
- [ ] Google Rich Results test passes on a sample product URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced WooCommerce product pages with Schema.org JSON-LD structured data, now including vendor/seller information for improved search engine recognition.
  * Added structured data support for vendor storefront pages.
  * Added admin settings to control vendor attribution mode: Per Vendor, Marketplace, or Disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->