### PR TITLE
feat: AgentDiscovery — llms.txt + ai-agent-policy endpoints (F-04)

### DIFF
--- a/docs/agent-discovery.md
+++ b/docs/agent-discovery.md
@@ -1,0 +1,115 @@
+# Agent Discovery — llms.txt + AI Agent Policy (F-04)
+
+**Strategy ref:** [Dokan Agentic Commerce Strategy](https://hackmd.io/@anikfahmid/dokan-agentic-strategy) — F-04  
+**Horizon:** H1 — Agent Accessible  
+**Ships in:** Dokan Lite (free)
+
+---
+
+## What It Does
+
+Dokan automatically generates two machine-readable files at your marketplace root that tell AI crawlers and agents what your marketplace is, what it sells, and what operations agents can perform.
+
+| Endpoint | Format | Purpose |
+|----------|--------|---------|
+| `/llms.txt` | Plain text (llmstxt.org spec) | AI crawlers (OAI-SearchBot, PerplexityBot, GPTBot) use this before indexing |
+| `/ai-agent-policy` | JSON | Structured capability declaration for agent clients |
+
+**Why this matters:** AI crawlers check `llms.txt` before indexing a site. Without it, crawlers guess what a marketplace is and skip ambiguous sites. This is half a day of effort for zero-cost discoverability.
+
+---
+
+## What Gets Published
+
+Both files include a snapshot of your marketplace:
+
+- Marketplace name and description
+- Vendor count and product count
+- Top product categories
+- API endpoint links (REST, MCP, ACP feed when active)
+- Agent permissions (read catalog, create cart, etc.)
+- Return and shipping policy signals
+
+Example `/llms.txt` output:
+```
+# Marketplace: My Outdoor Store
+> A multi-vendor marketplace for outdoor and adventure gear.
+
+Vendors: 24
+Products: 847
+Categories: Camping, Hiking, Climbing, Water Sports
+
+## API
+- REST: https://mystore.com/wp-json/dokan/v2/
+- MCP: https://mystore.com/wp-json/wc/mcp/v1/ (when WC MCP active)
+
+## Agent Permissions
+- read:catalog
+- read:vendor-profiles
+- read:product-availability
+
+## Policies
+- Returns: 30-day returns on all vendor orders
+- Shipping: Vendor-managed shipping zones
+```
+
+---
+
+## Technical Details
+
+- **Delivery:** WordPress rewrite rules, not static files. Works on hardened hosts; content is always fresh.
+- **Cache:** 6-hour transient. Bypassed when `WP_DEBUG` is true for development.
+- **Cache invalidation triggers:** Product save/delete, vendor registration/deletion/role change, Dokan settings save, daily WP-Cron safety net.
+- **SEO:** `X-Robots-Tag: noindex` on `/llms.txt` so the file itself doesn't get indexed — only the content it describes matters.
+
+---
+
+## Filters & Extensibility
+
+Other Dokan modules (and third-party plugins) can contribute data via filters:
+
+```php
+// Add custom endpoints to llms.txt
+add_filter( 'dokan_agent_discovery_endpoints', function( array $endpoints ): array {
+    $endpoints['custom_feed'] = home_url( '/my-custom-feed.json' );
+    return $endpoints;
+});
+
+// Add capability flags
+add_filter( 'dokan_agent_discovery_capabilities', function( array $caps ): array {
+    $caps[] = 'checkout:ucp'; // e.g., when UCP is active
+    return $caps;
+});
+
+// Modify full llms.txt body
+add_filter( 'dokan_llms_txt_body', function( string $body ): string {
+    return $body . "\n## Custom Section\nExtra info for agents.";
+});
+
+// Modify ai-agent-policy JSON payload
+add_filter( 'dokan_agent_policy_payload', function( array $payload ): array {
+    $payload['custom_data'] = 'value';
+    return $payload;
+});
+```
+
+**AI Product Feed integration:** When F-03 (AI Product Feed) is active and ACP is enabled, it auto-registers its feed URL via `dokan_agent_discovery_endpoints`.
+
+---
+
+## Implementation Files
+
+| File | Role |
+|------|------|
+| `includes/AgentDiscovery/Manager.php` | Rewrite rules, request dispatch, cache, invalidation hooks |
+| `includes/AgentDiscovery/DataProvider.php` | Snapshot aggregator — vendor count, product count, categories, endpoints |
+| `includes/AgentDiscovery/LLMsTxt.php` | Plain text renderer (llmstxt.org spec) |
+| `includes/AgentDiscovery/AgentPolicy.php` | JSON renderer |
+
+---
+
+## Related Features
+
+- **F-09 Vendor Structured Data** — JSON-LD on product/store pages (same H1 agent-accessibility push)
+- **F-03 AI Product Feed** — registers its ACP feed URL into Agent Discovery when active
+- **F-16 Agent Abilities** — auto-registers ability endpoint in agent policy

--- a/includes/AgentDiscovery/AgentPolicy.php
+++ b/includes/AgentDiscovery/AgentPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WeDevs\Dokan\AgentDiscovery;
+
+class AgentPolicy {
+
+    private $data;
+
+    public function __construct( DataProvider $data ) {
+        $this->data = $data;
+    }
+
+    public function render() {
+        $snapshot = $this->data->snapshot();
+
+        $payload = [
+            'marketplace' => [
+                'name'        => $snapshot['name'],
+                'description' => $snapshot['description'],
+                'url'         => $snapshot['home_url'],
+                'vendors'     => $snapshot['vendor_count'],
+                'products'    => $snapshot['product_count'],
+                'categories'  => $snapshot['top_categories'],
+            ],
+            'capabilities' => $snapshot['capabilities'],
+            'endpoints'    => $snapshot['endpoints'],
+            'policies'     => $snapshot['policies'],
+            'pages'        => $snapshot['pages'],
+            'generated_at' => gmdate( 'c', $snapshot['generated_at'] ),
+        ];
+
+        $payload = apply_filters( 'dokan_agent_policy_payload', $payload, $snapshot );
+
+        return wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+    }
+}

--- a/includes/AgentDiscovery/DataProvider.php
+++ b/includes/AgentDiscovery/DataProvider.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace WeDevs\Dokan\AgentDiscovery;
+
+class DataProvider {
+
+    public function snapshot() {
+        return [
+            'name'           => $this->marketplace_name(),
+            'description'    => $this->marketplace_description(),
+            'home_url'       => home_url( '/' ),
+            'vendor_count'   => $this->vendor_count(),
+            'product_count'  => $this->product_count(),
+            'top_categories' => $this->top_categories(),
+            'endpoints'      => $this->api_endpoints(),
+            'capabilities'   => $this->agent_capabilities(),
+            'policies'       => $this->policies(),
+            'pages'          => $this->important_pages(),
+            'generated_at'   => time(),
+        ];
+    }
+
+    public function marketplace_name() {
+        return get_bloginfo( 'name' );
+    }
+
+    public function marketplace_description() {
+        $description = get_bloginfo( 'description' );
+        return $description ?: __( 'Multi-vendor marketplace powered by Dokan.', 'dokan-lite' );
+    }
+
+    public function vendor_count() {
+        if ( function_exists( 'dokan_get_seller_count' ) ) {
+            $counts = dokan_get_seller_count();
+            if ( is_array( $counts ) && isset( $counts['active'] ) ) {
+                return (int) $counts['active'];
+            }
+        }
+
+        $query = new \WP_User_Query(
+            [
+                'role'   => 'seller',
+                'fields' => 'ID',
+                'number' => 0,
+            ]
+        );
+        return (int) $query->get_total();
+    }
+
+    public function product_count() {
+        $counts = wp_count_posts( 'product' );
+        return isset( $counts->publish ) ? (int) $counts->publish : 0;
+    }
+
+    public function top_categories( $limit = 5 ) {
+        $terms = get_terms(
+            [
+                'taxonomy'   => 'product_cat',
+                'orderby'    => 'count',
+                'order'      => 'DESC',
+                'number'     => $limit,
+                'hide_empty' => true,
+            ]
+        );
+
+        if ( is_wp_error( $terms ) || empty( $terms ) ) {
+            return [];
+        }
+
+        return array_map(
+            function ( $term ) {
+                return [
+                    'name'  => $term->name,
+                    'slug'  => $term->slug,
+                    'count' => (int) $term->count,
+                ];
+            },
+            $terms
+        );
+    }
+
+    public function api_endpoints() {
+        $endpoints = [
+            'rest_api' => rest_url( 'dokan/v2/' ),
+            'wc_rest'  => rest_url( 'wc/v3/' ),
+        ];
+        return apply_filters( 'dokan_agent_discovery_endpoints', $endpoints );
+    }
+
+    public function agent_capabilities() {
+        $caps = [
+            'read_catalog'     => true,
+            'search_products'  => true,
+            'filter_by_vendor' => true,
+            'create_cart'      => false,
+            'checkout'         => false,
+        ];
+        return apply_filters( 'dokan_agent_discovery_capabilities', $caps );
+    }
+
+    public function policies() {
+        $selling_settings = get_option( 'dokan_selling', [] );
+
+        $returns = isset( $selling_settings['refund_policy'] )
+            ? wp_strip_all_tags( (string) $selling_settings['refund_policy'] )
+            : __( 'Return policy varies by vendor. See individual vendor store pages.', 'dokan-lite' );
+
+        $shipping = __( 'Shipping varies by vendor. See individual vendor store pages.', 'dokan-lite' );
+
+        return [
+            'returns'  => $returns,
+            'shipping' => $shipping,
+        ];
+    }
+
+    public function important_pages() {
+        $pages = [];
+
+        if ( function_exists( 'dokan_get_page_url' ) ) {
+            $vendor_listing = dokan_get_page_url( 'store_listing' );
+            if ( $vendor_listing ) {
+                $pages['vendor_directory'] = $vendor_listing;
+            }
+        }
+
+        $shop_page_id = function_exists( 'wc_get_page_id' ) ? wc_get_page_id( 'shop' ) : 0;
+        if ( $shop_page_id > 0 ) {
+            $pages['shop'] = get_permalink( $shop_page_id );
+        }
+
+        return $pages;
+    }
+}

--- a/includes/AgentDiscovery/LLMsTxt.php
+++ b/includes/AgentDiscovery/LLMsTxt.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace WeDevs\Dokan\AgentDiscovery;
+
+class LLMsTxt {
+
+    private $data;
+
+    public function __construct( DataProvider $data ) {
+        $this->data = $data;
+    }
+
+    public function render() {
+        $snapshot = $this->data->snapshot();
+
+        $lines = [];
+
+        $lines[] = '# ' . $snapshot['name'];
+        $lines[] = '';
+        $lines[] = sprintf(
+            '> %s',
+            sprintf(
+                /* translators: 1: marketplace description 2: vendor count 3: product count */
+                __( '%1$s Vendors: %2$d | Products: %3$d', 'dokan-lite' ),
+                $snapshot['description'],
+                $snapshot['vendor_count'],
+                $snapshot['product_count']
+            )
+        );
+
+        if ( ! empty( $snapshot['top_categories'] ) ) {
+            $names    = array_map(
+                function ( $cat ) {
+                    return $cat['name'];
+                },
+                $snapshot['top_categories']
+            );
+            $lines[]  = '';
+            $lines[]  = '> ' . sprintf( /* translators: %s: comma-separated category list */
+                __( 'Top categories: %s', 'dokan-lite' ),
+                implode( ', ', $names )
+            );
+        }
+
+        $lines[] = '';
+
+        $lines[] = '## Agent Capabilities';
+        $lines[] = '';
+        foreach ( $snapshot['capabilities'] as $cap => $enabled ) {
+            $lines[] = sprintf( '- %s: %s', $cap, $enabled ? 'true' : 'false' );
+        }
+        $lines[] = '';
+
+        $lines[] = '## API Endpoints';
+        $lines[] = '';
+        foreach ( $snapshot['endpoints'] as $label => $url ) {
+            $lines[] = sprintf( '- %s: %s', $label, $url );
+        }
+        $lines[] = '';
+
+        $lines[] = '## Policies';
+        $lines[] = '';
+        $lines[] = '- Returns: ' . $snapshot['policies']['returns'];
+        $lines[] = '- Shipping: ' . $snapshot['policies']['shipping'];
+        $lines[] = '';
+
+        if ( ! empty( $snapshot['pages'] ) ) {
+            $lines[] = '## Important pages';
+            $lines[] = '';
+            foreach ( $snapshot['pages'] as $label => $url ) {
+                $lines[] = sprintf( '- %s: %s', $label, $url );
+            }
+            $lines[] = '';
+        }
+
+        $lines[] = sprintf( '<!-- generated: %s -->', gmdate( 'c', $snapshot['generated_at'] ) );
+
+        $body = implode( "\n", $lines ) . "\n";
+
+        return apply_filters( 'dokan_llms_txt_body', $body, $snapshot );
+    }
+}

--- a/includes/AgentDiscovery/Manager.php
+++ b/includes/AgentDiscovery/Manager.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace WeDevs\Dokan\AgentDiscovery;
+
+class Manager {
+
+    const QUERY_VAR_LLMS   = 'dokan_llms_txt';
+    const QUERY_VAR_POLICY = 'dokan_ai_policy';
+    const CACHE_KEY_LLMS   = 'dokan_llms_txt_body';
+    const CACHE_KEY_POLICY = 'dokan_ai_policy_body';
+    const CACHE_TTL        = 6 * HOUR_IN_SECONDS;
+    const CRON_HOOK        = 'dokan_agent_discovery_refresh';
+    const REWRITE_FLAG     = 'dokan_agent_discovery_rewrites_v1';
+
+    private $data;
+    private $llms;
+    private $policy;
+
+    public function __construct() {
+        $this->data   = new DataProvider();
+        $this->llms   = new LLMsTxt( $this->data );
+        $this->policy = new AgentPolicy( $this->data );
+
+        $this->register_hooks();
+    }
+
+    public function register_hooks() {
+        add_action( 'init', [ $this, 'register_rewrites' ] );
+        add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+        add_action( 'template_redirect', [ $this, 'maybe_render' ] );
+        add_filter( 'redirect_canonical', [ $this, 'suppress_canonical_redirect' ], 10, 2 );
+
+        add_action( 'save_post_product', [ $this, 'invalidate' ], 20 );
+        add_action( 'deleted_post', [ $this, 'on_post_deleted' ], 20, 2 );
+        add_action( 'user_register', [ $this, 'on_user_changed' ] );
+        add_action( 'delete_user', [ $this, 'on_user_changed' ] );
+        add_action( 'set_user_role', [ $this, 'on_user_changed' ] );
+        add_action( 'dokan_after_saving_settings', [ $this, 'invalidate' ] );
+
+        add_action( self::CRON_HOOK, [ $this, 'invalidate' ] );
+        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+            wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+        }
+
+        add_action( 'wp_loaded', [ $this, 'maybe_flush_rewrites' ] );
+    }
+
+    public function register_rewrites() {
+        add_rewrite_rule( '^llms\.txt/?$', 'index.php?' . self::QUERY_VAR_LLMS . '=1', 'top' );
+        add_rewrite_rule( '^ai-agent-policy/?$', 'index.php?' . self::QUERY_VAR_POLICY . '=1', 'top' );
+    }
+
+    public function suppress_canonical_redirect( $redirect_url, $requested_url ) {
+        $path = wp_parse_url( $requested_url, PHP_URL_PATH );
+        if ( $path === '/llms.txt' || $path === '/ai-agent-policy' ) {
+            return false;
+        }
+        return $redirect_url;
+    }
+
+    public function add_query_vars( $vars ) {
+        $vars[] = self::QUERY_VAR_LLMS;
+        $vars[] = self::QUERY_VAR_POLICY;
+        return $vars;
+    }
+
+    public function maybe_flush_rewrites() {
+        if ( get_option( self::REWRITE_FLAG ) === DOKAN_PLUGIN_VERSION ) {
+            return;
+        }
+        flush_rewrite_rules( false );
+        update_option( self::REWRITE_FLAG, DOKAN_PLUGIN_VERSION );
+    }
+
+    public function maybe_render() {
+        if ( get_query_var( self::QUERY_VAR_LLMS ) ) {
+            $this->respond_text( $this->cached_body( self::CACHE_KEY_LLMS, [ $this->llms, 'render' ] ) );
+        }
+        if ( get_query_var( self::QUERY_VAR_POLICY ) ) {
+            $this->respond_json( $this->cached_body( self::CACHE_KEY_POLICY, [ $this->policy, 'render' ] ) );
+        }
+    }
+
+    private function cached_body( $cache_key, callable $renderer ) {
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            return (string) call_user_func( $renderer );
+        }
+        $cached = get_transient( $cache_key );
+        if ( false !== $cached ) {
+            return (string) $cached;
+        }
+        $body = (string) call_user_func( $renderer );
+        set_transient( $cache_key, $body, self::CACHE_TTL );
+        return $body;
+    }
+
+    private function respond_text( $body ) {
+        nocache_headers();
+        header( 'Content-Type: text/plain; charset=utf-8' );
+        header( 'X-Robots-Tag: noindex' );
+        echo $body; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    private function respond_json( $body ) {
+        nocache_headers();
+        header( 'Content-Type: application/json; charset=utf-8' );
+        echo $body; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    public function invalidate() {
+        delete_transient( self::CACHE_KEY_LLMS );
+        delete_transient( self::CACHE_KEY_POLICY );
+    }
+
+    public function on_post_deleted( $post_id, $post ) {
+        if ( $post instanceof \WP_Post && 'product' === $post->post_type ) {
+            $this->invalidate();
+        }
+    }
+
+    public function on_user_changed( $user_id ) {
+        $user = get_userdata( $user_id );
+        if ( $user && in_array( 'seller', (array) $user->roles, true ) ) {
+            $this->invalidate();
+        }
+    }
+
+    public function llms_renderer() {
+        return $this->llms;
+    }
+
+    public function policy_renderer() {
+        return $this->policy;
+    }
+
+    public function data_provider() {
+        return $this->data;
+    }
+}

--- a/includes/DependencyManagement/Providers/CommonServiceProvider.php
+++ b/includes/DependencyManagement/Providers/CommonServiceProvider.php
@@ -26,6 +26,7 @@ class CommonServiceProvider extends BaseServiceProvider {
         \WeDevs\Dokan\Exceptions\Handler::class,
         \WeDevs\Dokan\Shortcodes\FullWidthVendorLayout::class,
         \WeDevs\Dokan\Vendor\ApiMeta::class,
+        \WeDevs\Dokan\AgentDiscovery\Manager::class,
 	];
 
 	/**


### PR DESCRIPTION
📄 **Specs:** [Dokan Agentic Specs — Phase 1](https://docs.google.com/document/d/1_27BOlNAxpmHjUi0gLXCNMe9ADW9THH68oXpr4zFJD4/edit?usp=sharing)

## Summary

Auto-generates `/llms.txt` and `/ai-agent-policy` at the marketplace root. AI crawlers (OAI-SearchBot, PerplexityBot, GPTBot) check `llms.txt` before indexing — without it, they guess or skip ambiguous sites. Half a day of effort for zero-cost discoverability.

**Strategy:** [Dokan Agentic Commerce Strategy](https://hackmd.io/@anikfahmid/dokan-agentic-strategy) — F-04, H1

### Changes

- `/llms.txt` — plain text per [llmstxt.org](https://llmstxt.org/) spec: marketplace name, vendor count, product count, categories, API endpoints, agent permissions, policies
- `/ai-agent-policy` — JSON variant of the same snapshot
- Delivery via WP rewrite rules (not static files) — works on hardened hosts
- 6h transient cache; bypassed when `WP_DEBUG` true
- Cache invalidation: product save/delete, vendor role change, Dokan settings save, daily WP-Cron
- `X-Robots-Tag: noindex` on `/llms.txt` so the file itself isn't indexed
- Filters: `dokan_agent_discovery_endpoints`, `dokan_agent_discovery_capabilities`, `dokan_llms_txt_body`, `dokan_agent_policy_payload`

## Test plan

- [ ] `GET /llms.txt` → 200, `text/plain`, correct vendor + product counts
- [ ] `GET /ai-agent-policy` → 200, `application/json`
- [ ] Cache invalidates after saving a Dokan setting
- [ ] `X-Robots-Tag: noindex` present in response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)