### PR TITLE
fix(security): add order ownership checks to 6 order AJAX handlers

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -231,6 +231,10 @@ class Ajax {
             wp_die( - 1 );
         }
 
+        if ( ! dokan_is_seller_has_order( dokan_get_current_user_id(), intval( wp_unslash( $_POST['order_id'] ) ) ) ) {
+            wp_die( - 1 );
+        }
+
         $order_id     = isset( $_POST['order_id'] ) ? intval( $_POST['order_id'] ) : 0;
         $product_ids  = isset( $_POST['product_ids'] ) ? intval( $_POST['product_ids'] ) : 0;
         $loop         = isset( $_POST['loop'] ) ? intval( $_POST['loop'] ) : 0;
@@ -302,7 +306,20 @@ class Ajax {
         $order_id     = isset( $_POST['order_id'] ) ? intval( $_POST['order_id'] ) : '';
         $order_status = isset( $_POST['order_status'] ) ? sanitize_text_field( wp_unslash( $_POST['order_status'] ) ) : '';
 
+        if ( ! dokan_is_seller_has_order( dokan_get_current_user_id(), $order_id ) ) {
+            wp_send_json_error( __( 'You have no permission to manage this order', 'dokan-lite' ) );
+
+            return;
+        }
+
         $order = dokan()->order->get( $order_id );
+
+        if ( ! $order ) {
+            wp_send_json_error( __( 'Invalid order.', 'dokan-lite' ) );
+
+            return;
+        }
+
         $order->update_status( $order_status );
 
         // Get the new order status. This is needed since plugin/theme authors might
@@ -387,6 +404,15 @@ class Ajax {
         $order_id      = intval( $_POST['order_id'] );
         $permission_id = absint( $_POST['permission_id'] );
 
+        // Resolve the order from the permission itself, then verify the current
+        // vendor owns that order. Trusting the posted order_id alone would allow a
+        // vendor to pair their own order_id with another vendor's permission_id.
+        $download_permission = new \WC_Customer_Download( $permission_id );
+
+        if ( ! $download_permission->get_id() || ! dokan_is_seller_has_order( dokan_get_current_user_id(), $download_permission->get_order_id() ) ) {
+            wp_die( - 1 );
+        }
+
         $data_store = WC_Data_Store::load( 'customer-download' );
         $data_store->delete_by_id( $permission_id );
 
@@ -411,6 +437,10 @@ class Ajax {
         $post_id   = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : '';
         $note      = isset( $_POST['note'] ) ? sanitize_textarea_field( wp_unslash( $_POST['note'] ) ) : '';
         $note_type = isset( $_POST['note_type'] ) ? sanitize_text_field( wp_unslash( $_POST['note_type'] ) ) : '';
+
+        if ( ! dokan_is_seller_has_order( dokan_get_current_user_id(), $post_id ) ) {
+            die( - 1 );
+        }
 
         $is_customer_note = ( $note_type === 'customer' ) ? 1 : 0;
 
@@ -454,6 +484,10 @@ class Ajax {
         $shipping_number   = isset( $_POST['shipping_number'] ) ? sanitize_text_field( wp_unslash( $_POST['shipping_number'] ) ) : '';
         $shipping_number   = trim( stripslashes( $shipping_number ) );
         $shipped_date      = isset( $_POST['shipped_date'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['shipped_date'] ) ) ) : '';
+
+        if ( ! dokan_is_seller_has_order( dokan_get_current_user_id(), $post_id ) ) {
+            die( - 1 );
+        }
 
         $ship_info = __( 'Shipping provider: ', 'dokan-lite' ) . $shipping_provider . '<br />' . __( 'Shipping number: ', 'dokan-lite' ) . $shipping_number . '<br />' . __( 'Shipped date: ', 'dokan-lite' ) . $shipped_date;
 
@@ -522,6 +556,18 @@ class Ajax {
         $note_id = isset( $_POST['note_id'] ) ? intval( $_POST['note_id'] ) : '';
 
         if ( $note_id > 0 ) {
+            $comment = get_comment( $note_id );
+
+            // Only allow deleting genuine order notes whose parent order belongs to
+            // the current vendor. Without this, a raw note_id deletes any comment.
+            if ( ! $comment || 'order_note' !== $comment->comment_type ) {
+                die( - 1 );
+            }
+
+            if ( ! dokan_is_seller_has_order( dokan_get_current_user_id(), $comment->comment_post_ID ) ) {
+                die( - 1 );
+            }
+
             wp_delete_comment( $note_id );
         }
 


### PR DESCRIPTION
Six order AJAX handlers validated capability but never verified the target order belonged to the requesting vendor, allowing an authenticated vendor to manipulate arbitrary orders across the marketplace (IDOR / CWE-639). Nonces only prove a logged-in session, not ownership, so a vendor could harvest a valid nonce from their own dashboard and replay it against any order ID.

Add dokan_is_seller_has_order() ownership guards, mirroring the pattern already used by complete_order() and process_order():

- change_order_status(): ownership check + null-order guard
- add_order_note(): ownership check on post_id
- add_shipping_tracking_info(): ownership check on post_id
- grant_access_to_download(): ownership check on order_id
- delete_order_note(): require comment_type order_note and verify the parent order belongs to the vendor before wp_delete_comment()
- revoke_access_to_download(): resolve the order from the permission_id itself, preventing an own-order_id + victim-permission_id pairing

Ref: CVE-2026-10023

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes https://github.com/getdokan/dokan-pro/issues/5704


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

```
  - **fix:** Prevented vendors from manipulating orders they don't own by adding ownership checks to order status, order note, shipping tracking, and download-permission AJAX handlers.
```

### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced seller authorization validation across order operations to ensure sellers can only modify their own orders, including status changes, download permissions, notes, and shipping tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->