### PR TITLE
fix(settings): defer page-option queries off the front-end hot path

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsRegistry.php
+++ b/includes/Admin/Settings/Schema/SettingsRegistry.php
@@ -75,12 +75,47 @@ class SettingsRegistry {
         // 5. Populate field values from storage.
         $elements = $this->populate_values( $elements );
 
+        // 5b. Resolve lazily-declared option lists (e.g. DB-backed page
+        // selects) into concrete arrays. Deferred to here so the front-end
+        // legacy-settings bridge — which harvests SettingsSchema but never
+        // reads `options` — does not pay for the query on every request.
+        $elements = $this->resolve_dynamic_options( $elements );
+
         // 6. Validate in debug mode.
         $this->maybe_validate( $elements );
 
         $this->cache = $elements;
 
         return $this->cache;
+    }
+
+    /**
+     * Resolve lazily-declared option lists into concrete arrays.
+     *
+     * Fields whose option list is expensive to build (e.g. a DB-backed page
+     * select) declare `options` as a closure instead of an eager array, so
+     * the cost is paid only here — when the schema is built for the admin
+     * UI/REST. The front-end legacy-settings bridge harvests SettingsSchema
+     * directly and never reads `options`, so it never invokes these closures.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array $elements Flat schema elements.
+     *
+     * @return array
+     */
+    private function resolve_dynamic_options( array $elements ): array {
+        foreach ( $elements as &$element ) {
+            if ( ! isset( $element['options'] ) || ! ( $element['options'] instanceof \Closure ) ) {
+                continue;
+            }
+
+            $callback           = $element['options'];
+            $element['options'] = (array) $callback();
+        }
+        unset( $element );
+
+        return $elements;
     }
 
     /**

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -81,9 +81,22 @@ class SettingsSchema {
     /**
      * Helper to get pages for select dropdowns.
      *
+     * Memoized per request: this issues an unbounded page query, so the
+     * result is cached statically and looked up at most once. Field `options`
+     * reference this lazily (via a closure — see general_page() and the
+     * privacy policy field) so the query only fires when SettingsRegistry
+     * resolves the schema for the admin UI/REST — never on the front-end
+     * legacy-settings bridge harvest path, which ignores `options`.
+     *
      * @return array
      */
     private static function get_page_options(): array {
+        static $cache = null;
+
+        if ( null !== $cache ) {
+            return $cache;
+        }
+
         $pages_array = [];
         $pages       = get_posts(
             [
@@ -101,7 +114,32 @@ class SettingsSchema {
             }
         }
 
-        return $pages_array;
+        $cache = $pages_array;
+
+        return $cache;
+    }
+
+    /**
+     * Lazy provider for the page-select option list.
+     *
+     * Returns a closure that yields {@see get_page_options()} when invoked.
+     * Fields reference this so the page query is deferred until
+     * SettingsRegistry resolves the schema for the admin UI/REST — the
+     * front-end legacy-settings bridge harvests the schema but never reads
+     * `options`, so the query is skipped on every public request.
+     *
+     * Public so Pro modules (which always load alongside Lite) can reuse the
+     * same lazy page-option provider via the `dokan_get_admin_settings_schema`
+     * filter instead of duplicating the query. Sharing this also shares the
+     * per-request memo in {@see get_page_options()}, so the admin build runs
+     * the page query once across all consumers.
+     *
+     * @return \Closure
+     */
+    public static function get_lazy_page_options(): \Closure {
+        return static function () {
+            return self::get_page_options();
+        };
     }
 
     /**
@@ -110,7 +148,7 @@ class SettingsSchema {
      * @return array
      */
     private static function general_page(): array {
-        $pages_array = self::get_page_options();
+        $pages_options = self::get_lazy_page_options();
 
         return [
             // Page
@@ -247,7 +285,7 @@ class SettingsSchema {
 				'title'       => esc_html__( 'Dashboard', 'dokan-lite' ),
 				'description' => esc_html__( 'Select a page to show vendor dashboard.', 'dokan-lite' ),
 				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-				'options'     => $pages_array,
+				'options'     => $pages_options,
 			],
 			[
 				'id'         => 'my_orders_section',
@@ -266,7 +304,7 @@ class SettingsSchema {
 				'title'       => esc_html__( 'My Orders', 'dokan-lite' ),
 				'description' => esc_html__( 'Select a page to show my orders', 'dokan-lite' ),
 				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-				'options'     => $pages_array,
+				'options'     => $pages_options,
 			],
 			[
 				'id'         => 'store_listing_section',
@@ -285,7 +323,7 @@ class SettingsSchema {
 				'title'       => esc_html__( 'Store Listing', 'dokan-lite' ),
 				'description' => esc_html__( 'Select a page to show all stores', 'dokan-lite' ),
 				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-				'options'     => $pages_array,
+				'options'     => $pages_options,
 			],
 			[
 				'id'         => 'reg_tc_page_section',
@@ -305,7 +343,7 @@ class SettingsSchema {
 				'description' => esc_html__( 'Select where you want to add Dokan pages.', 'dokan-lite' ),
 				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
 				'tooltip'     => esc_html__( 'Select a page to display the Terms and Conditions of your store for Vendors.', 'dokan-lite' ),
-				'options'     => $pages_array,
+				'options'     => $pages_options,
 			],
             [
 				'id'         => 'vendor_onboarding_page_section',
@@ -324,7 +362,7 @@ class SettingsSchema {
 				'title'       => esc_html__( 'Vendor Onboarding Page', 'dokan-lite' ),
 				'description' => esc_html__( 'Select a page for vendor onboarding and login', 'dokan-lite' ),
 				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-				'options'     => $pages_array,
+				'options'     => $pages_options,
 			],
 
 			// === SubPage: Location ===
@@ -2043,7 +2081,7 @@ class SettingsSchema {
                 'section_id' => 'privacy_settings',
                 'title'      => esc_html__( 'Privacy Policy Page', 'dokan-lite' ),
                 'description' => esc_html__( 'Choose which page displays your privacy policy.', 'dokan-lite' ),
-                'options'    => self::get_page_options(),
+                'options'    => self::get_lazy_page_options(),
                 'legacy_key' => [
 					'option' => 'dokan_privacy',
 					'field' => 'privacy_page',

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
@@ -59,6 +59,50 @@ class SettingsRegistryStorageTest extends DokanTestCase {
         $this->assertSame( 'mapbox', $map_source_field['value'], 'map_api_source value must come from dokan_settings.' );
     }
 
+    /**
+     * DB-backed option lists (page selects) must be lazy on the raw schema —
+     * a closure, so the front-end legacy bridge never triggers the page query
+     * when it harvests SettingsSchema — and resolved to a concrete array by
+     * SettingsRegistry for the admin/REST consumer.
+     *
+     * @group settings-perf
+     */
+    public function test_dynamic_page_options_are_lazy_raw_and_resolved_by_registry(): void {
+        // Raw schema: the page-backed select carries a closure, not an array.
+        $raw       = \WeDevs\Dokan\Admin\Settings\Schema\SettingsSchema::get_schema();
+        $raw_field = null;
+        foreach ( $raw as $el ) {
+            if ( ( $el['id'] ?? '' ) === 'vendor_dashboard_page' ) {
+                $raw_field = $el;
+                break;
+            }
+        }
+
+        $this->assertNotNull( $raw_field, 'vendor_dashboard_page field must exist in the raw schema.' );
+        $this->assertArrayHasKey( 'options', $raw_field );
+        $this->assertInstanceOf(
+            \Closure::class,
+            $raw_field['options'],
+            'Page options must be lazy (a closure) on the raw schema so the bridge skips the query.'
+        );
+
+        // Registry output: the same field exposes a resolved array, no closure.
+        $resolved       = ( new SettingsRegistry() )->get_schema( true );
+        $resolved_field = null;
+        foreach ( $resolved as $el ) {
+            if ( ( $el['id'] ?? '' ) === 'vendor_dashboard_page' ) {
+                $resolved_field = $el;
+                break;
+            }
+        }
+
+        $this->assertNotNull( $resolved_field, 'vendor_dashboard_page field must exist in the registry schema.' );
+        $this->assertIsArray(
+            $resolved_field['options'],
+            'SettingsRegistry must resolve lazy page options to an array.'
+        );
+    }
+
     public function test_populate_values_falls_back_to_default_when_id_absent(): void {
         update_option( 'dokan_admin_settings', [] );
 

--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -323,11 +323,14 @@ class SettingsSchemaTest extends DokanTestCase {
         );
 
         foreach ( $fields as $field ) {
-            // Some selects have dynamic options (populated at runtime).
+            // Some selects declare dynamic options lazily as a closure on the
+            // raw schema (e.g. DB-backed page lists). SettingsRegistry resolves
+            // these to arrays before the UI/REST consumes them; the resolved
+            // contract is asserted in SettingsRegistryStorageTest.
             if ( isset( $field['options'] ) ) {
-                $this->assertIsArray(
-                    $field['options'],
-                    "Field '{$field['id']}' options should be an array."
+                $this->assertTrue(
+                    is_array( $field['options'] ) || $field['options'] instanceof \Closure,
+                    "Field '{$field['id']}' options must be an array or a lazy closure."
                 );
             }
         }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Performance fix for the flat-array settings refactor.

The legacy-settings bridge (`BridgeBootstrap`) registers its overlay filters on `init` priority 999 with no `is_admin`/REST guard, and to do so it harvests the full schema via `LegacySettingsBridge::harvest_from_schema() → SettingsSchema::get_schema()`. The page-backed selects (5 in `general_page()` + the Privacy Policy Page field) built their `options` **eagerly** with `get_posts( [ 'post_type' => 'page', 'numberposts' => -1 ] )` — so **two unbounded page queries ran on every front-end/public request**, even though `options` are only ever needed when the admin settings UI renders. The harvest reads only `id`/`default`/`legacy_key`/`legacy_transformer` — never `options`.

This PR makes those option lists lazy:

- `SettingsSchema`: the page selects now declare `options` as a **closure** instead of an eager array. `get_page_options()` is **memoized** (static cache) so it runs at most once per request.
- `SettingsRegistry`: a new `resolve_dynamic_options()` step invokes any closure `options` → concrete array. This runs **only** on the admin/REST schema build (`get_schema()`), never on the front-end bridge harvest, which ignores `options`.

No data-model, storage, or REST-contract changes. The frontend still receives fully-resolved `options` arrays from the registry.

### Closes

* N/A — surfaced by a performance audit of the refactor branch.

### How to test the changes in this Pull Request:

1. On a site with the flat-array settings branch active, load any front-end page with query logging on (e.g. Query Monitor or `SAVEQUERIES`).
2. Before: two `post_type = page` queries fire on each public request. After: **zero**.
3. Open **Dokan → Settings → General → Page Setup** and confirm every page dropdown (Dashboard, My Orders, Store Listing, Terms & Conditions, Vendor Onboarding) and **Compliance → Privacy → Privacy Policy Page** still list all pages and save correctly.

Empirical result (live site, Lite isolated, read-only `wp eval`):

| Path | Page queries (before → after) | `options` |
|---|---|---|
| Front-end / bridge harvest | **2 → 0** | stays a lazy closure (never invoked) |
| Admin / registry build | 2 → **1** (memoized) | resolved to an array of pages |

### Changelog entry

*Fix: settings page-option dropdowns no longer run page queries on every front-end request*

Previously the admin settings schema built its page-select dropdown options with an unbounded `get_posts()` call that, via the legacy-settings bridge, executed on **every** public page load (two queries that scale with the site's page count). These option lists are now resolved lazily — only when the admin settings UI/REST builds the schema — eliminating the queries from the front-end hot path while leaving the admin behaviour unchanged.

### Notes for the reviewer

- Scope is **Dokan Lite** only. Dokan **Pro** still appends an eager page-option field via the `dokan_get_admin_settings_schema` filter; isolating Lite shows 0 front-end page queries, but with Pro active one Pro-originated query remains — that is a separate Pro follow-up (apply the same lazy pattern there).
- New test: `SettingsRegistryStorageTest::test_dynamic_page_options_are_lazy_raw_and_resolved_by_registry` asserts the raw schema exposes a `Closure` (so the bridge skips the query) and the registry resolves it to an array. `php -l` clean; PHPCS clean on both source files. PHPUnit was not run locally (Docker/wp-env unavailable) — the test's assertions were confirmed against a live site via `wp eval`; it will run in CI.

### PR Self Review Checklist:

* [x] Follows code style guidelines
* [x] Clear naming
* [x] KISS / DRY
* [x] Readable
* [x] Addresses a measured performance issue
