### PR TITLE
fix(reverse-withdrawal): single COD enable toggle in new settings

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1200,52 +1200,6 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
-            self::reverse_withdrawal_payment_gateways_field(),
-        ];
-    }
-
-    /**
-     * Build the `reverse_withdrawal_payment_gateways` multicheck field.
-     *
-     * Options are derived from the `dokan_reverse_withdrawal_payment_gateways`
-     * filter (the same source the legacy {@see SettingsHelper::get_reverse_withrawal_payment_gateways()}
-     * uses) so Pro modules / extensions that already extend that filter continue
-     * to register gateways with one declaration. The new field stores a flat
-     * list of selected gateway ids; each slot bridges through
-     * {@see MulticheckArrayTransformer} to the legacy WP-multicheck shape under
-     * `dokan_reverse_withdrawal.payment_gateways`.
-     *
-     * @return array
-     */
-    private static function reverse_withdrawal_payment_gateways_field(): array {
-        $gateways = apply_filters(
-            'dokan_reverse_withdrawal_payment_gateways',
-            [ 'cod' => esc_html__( 'Cash on delivery', 'dokan-lite' ) ]
-        );
-
-        $options    = [];
-        $legacy_key = [];
-        foreach ( $gateways as $value => $label ) {
-            $options[]            = [
-                'value' => (string) $value,
-                'label' => (string) $label,
-            ];
-            $legacy_key[ $value ] = 'dokan_reverse_withdrawal.payment_gateways.' . $value;
-        }
-        $slot_keys = array_keys( $legacy_key );
-
-        return [
-            'id'                 => 'reverse_withdrawal_payment_gateways',
-            'type'               => 'field',
-            'variant'            => 'multicheck',
-            'section_id'         => 'reverse_withdrawal_section',
-            'title'              => esc_html__( 'Enable Reverse Withdrawal for this Gateway', 'dokan-lite' ),
-            'description'        => esc_html__( 'Check the payment gateways you want to enable reverse withdrawal for. For now, only cash on delivery is available.', 'dokan-lite' ),
-            'options'            => $options,
-            'default'            => [ 'cod' ],
-            'legacy_key'         => $legacy_key,
-            'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
-            'priority'           => 70,
         ];
     }
 

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -962,8 +962,9 @@ class SettingsSchema {
                 'page_id'     => 'transaction',
                 'title'       => esc_html__( 'Reverse Withdrawal', 'dokan-lite' ),
                 'description' => esc_html__( 'Set up commission collection from vendors on Cash on Delivery orders. Control when and how to charge money from vendor accounts when they owe you.', 'dokan-lite' ),
-                'priority'    => 400,
-                'doc_link'    => 'https://wedevs.com/docs/dokan/withdraw/dokan-reverse-withdrawal/',
+                'priority'      => 400,
+                'doc_link'      => 'https://wedevs.com/docs/dokan/withdraw/dokan-reverse-withdrawal/',
+                'doc_link_text' => esc_html__( 'Doc', 'dokan-lite' ),
             ],
             [
                 'id'         => 'reverse_withdrawal_section',

--- a/includes/ReverseWithdrawal/SettingsHelper.php
+++ b/includes/ReverseWithdrawal/SettingsHelper.php
@@ -21,7 +21,7 @@ class SettingsHelper {
      * @return bool
      */
     public static function is_enabled() {
-        return 'on' === dokan_get_option( 'reverse_withdrawal_enabled', 'dokan_reverse_withdrawal', 'off' );
+        return 'on' === dokan_get_option( 'enabled', 'dokan_reverse_withdrawal', 'off' );
     }
 
     /**
@@ -32,7 +32,11 @@ class SettingsHelper {
      * @return array
      */
     public static function get_enabled_payment_gateways() {
-        $payment_methods = dokan_get_option( 'payment_gateways', 'dokan_reverse_withdrawal', [] );
+        if ( ! self::is_enabled() ) {
+            return [];
+        }
+
+        $payment_methods = array_keys( static::get_reverse_withrawal_payment_gateways() );
 
         return array_filter( $payment_methods );
     }


### PR DESCRIPTION
## Summary

Maps the two legacy Reverse Withdrawal settings ("Enable Reverse Withdrawal" + "Enable Reverse Withdrawal for this Gateway") onto the single new **"Activate Reverse Withdrawal (Cash On Delivery)"** toggle, and fixes a bug that left the feature permanently disabled.

Refs and closes: getdokan/plugin-internal-tasks#1943

## What changed

- **Single toggle in new settings.** Removed the standalone `reverse_withdrawal_payment_gateways` multicheck field (and its builder) from `SettingsSchema`. The new UI now shows one switch, mapped 1:1 to legacy `dokan_reverse_withdrawal.enabled`. COD is the only shipped gateway, so it follows the master switch.
- **Gateway list derives from the toggle.** `SettingsHelper::get_enabled_payment_gateways()` now returns the registered gateways when `is_enabled()` is true (and `[]` otherwise), instead of reading the now-unused `payment_gateways` option. The 2nd legacy field is ignored at runtime.
- **Bug fix — `is_enabled()` was always `false`.** It read the *new* flat id `reverse_withdrawal_enabled` out of the *legacy* `dokan_reverse_withdrawal` section. The bridge overlay only ever projects onto the legacy path `enabled`, so that key never existed there and the helper was stuck at `'off'` — disabling every Reverse Withdrawal hook (order, cart, cron, dashboard) even when the admin had turned it on. Now reads the legacy `enabled` key, consistent with every sibling helper.

## Why ignore the gateway field

COD is the only available gateway. Gating the feature behind a second checkbox added no value, so the master switch alone now controls it — enabling it activates COD reverse withdrawal directly.

## Verification

Exercised the full read/write round-trip via `wp eval` against both stores:

| Scenario | new id | `is_enabled()` | COD gate |
|---|---|---|---|
| New toggle ON | `on` | `true` | `true` |
| Old form: master ON, gateway unchecked | `on` | `true` | `true` |
| New toggle OFF | `off` | `false` | `false` |

All other Reverse Withdrawal fields (`billing_type`, `reverse_balance_threshold`, `monthly_billing_day`, `due_period`, `failed_actions`, `display_notice`, `send_announcement`) remain mapped as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)