### PR TITLE
chore: remove unused html-react-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@wordpress/url": "^4.32.0",
         "d3": "^7.9.0",
         "dompurify": "^3.2.6",
-        "html-react-parser": "^5.2.7",
         "lucide-react": "^0.546.0",
         "path": "^0.12.7",
         "prop-types": "^15.8.1",
@@ -16969,22 +16968,6 @@
       "version": "1.4.0",
       "license": "MIT"
     },
-    "node_modules/html-dom-parser": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.8.tgz",
-      "integrity": "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/remarkablemark"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "htmlparser2": "10.1.0"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "dev": true,
@@ -17016,37 +16999,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-react-parser": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
-      "integrity": "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/remarkablemark"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/html-react-parser"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "html-dom-parser": "5.1.8",
-        "react-property": "2.0.2",
-        "style-to-js": "1.1.21"
-      },
-      "peerDependencies": {
-        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
-        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "devOptional": true,
@@ -17056,37 +17008,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -17445,12 +17366,6 @@
       "version": "1.3.8",
       "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/inline-style-parser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-      "license": "MIT"
     },
     "node_modules/input-otp": {
       "version": "1.4.2",
@@ -22917,12 +22832,6 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
-      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "dev": true,
@@ -25103,24 +25012,6 @@
       "version": "0.1.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/style-to-js": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
-      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "style-to-object": "1.0.14"
-      }
-    },
-    "node_modules/style-to-object": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-      "license": "MIT",
-      "dependencies": {
-        "inline-style-parser": "0.2.7"
-      }
     },
     "node_modules/stylehacks": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@wordpress/url": "^4.32.0",
     "d3": "^7.9.0",
     "dompurify": "^3.2.6",
-    "html-react-parser": "^5.2.7",
     "lucide-react": "^0.546.0",
     "path": "^0.12.7",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`html-react-parser` was declared in `package.json` `dependencies` but is **never imported** anywhere in `src/` (0 usages) and is **absent from the built bundles** — confirmed during the settings-refactor performance audit (`FE-BUNDLE-03`).

This removes it and its now-orphaned transitive deps from the lockfile (`html-dom-parser`, `htmlparser2`, `entities`, `inline-style-parser`, `react-property`, `style-to-js`, `style-to-object`). `domhandler` is retained — it's shared by `css-select`/`domutils`/etc.

**Removal-only diff** (110 deletions, 0 insertions); no other dependency versions touched. The lockfile edit was done surgically (deleting exactly the dead cluster) to avoid the cross-platform optional-dep churn a full `npm install` regen introduces.

### How to test:

- `npm ci` resolves cleanly (the dep was already missing from some lock states; package.json and lockfile are now consistent).
- `npm run build` succeeds; no bundle changes (the package was never imported).

### Changelog entry

*Chore: remove the unused `html-react-parser` dependency.*

Dead dependency cleanup — `html-react-parser` was in `package.json` but never imported or bundled. Removed it and its orphaned transitive deps from the lockfile.

### PR Self Review Checklist:

* [x] DRY / no dead weight
* [x] Removal-only, no unrelated lockfile churn
* [x] `npm run build` unaffected (package was never imported)