### PR TITLE
fix(settings): drop un-bustable page-options memo; assert dropdown membership

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -81,22 +81,21 @@ class SettingsSchema {
     /**
      * Helper to get pages for select dropdowns.
      *
-     * Memoized per request: this issues an unbounded page query, so the
-     * result is cached statically and looked up at most once. Field `options`
-     * reference this lazily (via a closure — see general_page() and the
-     * privacy policy field) so the query only fires when SettingsRegistry
+     * Field `options` reference this lazily (via a closure — see general_page()
+     * and the privacy policy field) so the query only fires when SettingsRegistry
      * resolves the schema for the admin UI/REST — never on the front-end
      * legacy-settings bridge harvest path, which ignores `options`.
+     *
+     * Intentionally NOT memoized in a function-static. WordPress's per-request
+     * WP_Query cache already dedupes this identical page query across the field
+     * call sites (a repeat call issues no SQL), and that cache is invalidated
+     * when pages change. A function-static here would instead be un-resettable
+     * (no reflection access, clear_cache() can't reach it) and could serve stale
+     * options within a long-lived process or after a page is created mid-request.
      *
      * @return array
      */
     private static function get_page_options(): array {
-        static $cache = null;
-
-        if ( null !== $cache ) {
-            return $cache;
-        }
-
         $pages_array = [];
         $pages       = get_posts(
             [
@@ -114,9 +113,7 @@ class SettingsSchema {
             }
         }
 
-        $cache = $pages_array;
-
-        return $cache;
+        return $pages_array;
     }
 
     /**

--- a/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsRegistryStorageTest.php
@@ -103,6 +103,54 @@ class SettingsRegistryStorageTest extends DokanTestCase {
         );
     }
 
+    /**
+     * The resolved page-select options must contain the site's actual pages
+     * (value = ID, title = post_title) and must reflect pages created after an
+     * earlier build — guarding against an un-bustable per-process options memo.
+     *
+     * @group settings-perf
+     */
+    public function test_resolved_page_options_include_pages_and_reflect_new_pages(): void {
+        // A page that exists at build time must appear in the resolved options.
+        $page_a    = self::factory()->post->create(
+            [ 'post_type' => 'page', 'post_title' => 'Dokan Lazy Options Page A' ]
+        );
+        $by_value  = wp_list_pluck( $this->resolved_page_options( 'vendor_dashboard_page' ), 'title', 'value' );
+
+        $this->assertArrayHasKey( $page_a, $by_value, 'Resolved page options must include a page that exists at build time.' );
+        $this->assertSame( 'Dokan Lazy Options Page A', $by_value[ $page_a ], 'Resolved option title must match the page title.' );
+
+        // A page created AFTER the first build must appear in a subsequent build.
+        // An un-bustable static memo would serve the stale first result here;
+        // WP_Query's own cache (invalidated on page creation) makes the fresh
+        // build reflect it.
+        $page_b   = self::factory()->post->create(
+            [ 'post_type' => 'page', 'post_title' => 'Dokan Lazy Options Page B' ]
+        );
+        $values_b = wp_list_pluck( $this->resolved_page_options( 'vendor_dashboard_page' ), 'value' );
+
+        $this->assertContains( $page_b, $values_b, 'Page options must reflect pages created after an earlier build (no stale memo).' );
+    }
+
+    /**
+     * Build the schema via the registry and return one field's resolved options.
+     *
+     * @param string $field_id Field id to locate.
+     *
+     * @return array Resolved options array for the field.
+     */
+    private function resolved_page_options( string $field_id ): array {
+        foreach ( ( new SettingsRegistry() )->get_schema( true ) as $el ) {
+            if ( ( $el['id'] ?? '' ) === $field_id ) {
+                $this->assertIsArray( $el['options'], "Field {$field_id} options must resolve to an array." );
+
+                return $el['options'];
+            }
+        }
+
+        $this->fail( "Field {$field_id} not found in the resolved schema." );
+    }
+
     public function test_populate_values_falls_back_to_default_when_id_absent(): void {
         update_option( 'dokan_admin_settings', [] );
 


### PR DESCRIPTION
Follow-up to #3252 — hardens the lazy page-options work against a latent staleness footgun surfaced by an evaluation pass.

### Changes proposed in this Pull Request:

**1. Drop the function-static memo in `SettingsSchema::get_page_options()`.**
#3252 added `static $cache` to dedupe the page query across the ~6 admin-build call sites. A function-static is **un-resettable** (no reflection access; `SettingsRegistry::clear_cache()` can't reach it), so it can serve **stale options** within a long-lived worker or after a page is created in the same request — and it makes a content-level test order-dependent.

It's also unnecessary: WordPress's per-request `WP_Query` cache already dedupes the identical `get_posts(['post_type'=>'page','numberposts'=>-1])` (a repeat call issues **no SQL** — measured), and that cache is invalidated when pages change. So dropping the memo:
- **Front end:** unaffected — the `options` closure is never invoked on the bridge-harvest path.
- **Admin/REST build:** a few extra `WP_Query` **cache-hit** lookups (microseconds) for the **same single cold SQL**. No query-count regression.
- **Correctness:** options now always reflect the current pages.

**2. Strengthen the test** (`SettingsRegistryStorageTest`): assert the resolved options actually **contain the site's pages** (value = ID, title = post_title), and that a page created **after** an earlier build appears in a **later** build — which catches a stale per-process memo (the previous test only checked the option *type*, not membership).

### How to test:

- `composer phpcs` clean on the source change (the 6 pre-existing `priority`-alignment notices elsewhere in the file are untouched).
- New PHPUnit test `test_resolved_page_options_include_pages_and_reflect_new_pages` passes: it creates pages via the factory and asserts they appear in the registry-resolved dropdown, including one created between two builds.

> Note: PHPUnit was **not run locally** (Docker/wp-env unavailable in this environment). The membership behavior was verified against a live site read-only (19 real pages resolve as `value=ID / title=post_title`); the staleness assertion relies on WP's standard `WP_Query` cache invalidation on `wp_insert_post`. CI runs the suite.

### Changelog entry

*Fix: admin settings page-select dropdowns always reflect the current pages.*

Removed an un-resettable per-process cache from the settings page-option helper that could serve stale page lists in long-lived processes / after mid-request page creation; relies on WordPress's own query cache instead. Added a test asserting dropdown membership and staleness-freedom.

### PR Self Review Checklist:

* [x] Correct — removes a latent staleness path; behavior parity otherwise
* [x] No front-end impact; admin SQL unchanged (same single cold query)
* [x] Test now asserts membership + staleness, not just type