### PR TITLE
fix(settings): align AI Assist UI with legacy and fix AI key/model save sync

### DIFF
--- a/includes/Admin/Settings/Migration/LegacySettingsBridge.php
+++ b/includes/Admin/Settings/Migration/LegacySettingsBridge.php
@@ -583,11 +583,12 @@ class LegacySettingsBridge {
     /**
      * Build (and cache) the mapping, defaults index, and reverse-by-option index.
      *
-     * The map is memoized but keyed on the current callback count of
-     * `dokan_get_admin_settings_schema`. Pro modules register their
-     * filter callbacks during `init` at varying priorities; if a bridge
-     * caller fires before all are registered, the count grows on the next
-     * call and the memo invalidates automatically.
+     * The map is memoized but keyed on the combined callback count of
+     * `dokan_get_admin_settings_schema` and `dokan_intelligence_providers`
+     * (the latter drives the dynamic AI api_key/model fields). Contributors
+     * register at varying priorities during boot; if a bridge caller fires
+     * before all are registered, the count grows on the next call and the
+     * memo invalidates automatically.
      *
      * Recursion safety: see `$building_map`.
      *
@@ -599,9 +600,13 @@ class LegacySettingsBridge {
         }
 
         global $wp_filter;
-        $filter_count = ( isset( $wp_filter['dokan_get_admin_settings_schema'] ) && ! empty( $wp_filter['dokan_get_admin_settings_schema']->callbacks ) )
-            ? count( $wp_filter['dokan_get_admin_settings_schema']->callbacks, COUNT_RECURSIVE )
-            : 0;
+
+        $filter_count = 0;
+        foreach ( [ 'dokan_get_admin_settings_schema', 'dokan_intelligence_providers' ] as $hook ) {
+            if ( isset( $wp_filter[ $hook ] ) && ! empty( $wp_filter[ $hook ]->callbacks ) ) {
+                $filter_count += count( $wp_filter[ $hook ]->callbacks, COUNT_RECURSIVE );
+            }
+        }
 
         if ( $this->map !== null && $this->cached_filter_count === $filter_count ) {
             return $this->map;

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2187,24 +2187,7 @@ class SettingsSchema {
      * @return array
      */
     private static function ai_assist_page(): array {
-        $on_generate = [
-            [
-				'key' => 'ai_product_info_generate',
-				'value' => 'on',
-				'to_self' => true,
-				'attribute' => 'display',
-				'effect' => 'show',
-				'comparison' => '===',
-			],
-            [
-				'key' => 'ai_product_info_generate',
-				'value' => 'on',
-				'to_self' => true,
-				'attribute' => 'display',
-				'effect' => 'hide',
-				'comparison' => '!==',
-			],
-        ];
+        // Legacy `show_if` gate: reveal a provider's API key + model only while its engine is selected (single-entry show-on-===, per PR #5727).
         $when_engine = static function ( string $engine_key, string $value ): array {
             return [
                 [
@@ -2214,14 +2197,6 @@ class SettingsSchema {
 					'attribute' => 'display',
 					'effect' => 'show',
 					'comparison' => '===',
-				],
-                [
-					'key' => $engine_key,
-					'value' => $value,
-					'to_self' => true,
-					'attribute' => 'display',
-					'effect' => 'hide',
-					'comparison' => '!==',
 				],
             ];
         };
@@ -2258,40 +2233,25 @@ class SettingsSchema {
                 'doc_link'    => 'https://dokan.co/docs/wordpress/settings/dokan-ai-assistant/',
             ],
 
-            // ===== Product Info (text) =====
+            // ===== AI Product Info Generator (text) =====
+            // Header-only section like the legacy `dokan_ai_product_info` sub_section — no enable toggle, engine selector always visible.
             [
-                'id'         => 'product_image_section',
-                'type'       => 'section',
-                'subpage_id' => 'product_generation',
+                'id'          => 'product_info_section',
+                'type'        => 'section',
+                'subpage_id'  => 'product_generation',
+                'title'       => esc_html__( 'AI Product Info Generator', 'dokan-lite' ),
+                'description' => esc_html__( 'Let vendors generate product info by AI', 'dokan-lite' ),
             ],
             [
-                'id'            => 'ai_product_info_generate',
-                'type'          => 'field',
-                'variant'       => 'switch',
-                'section_id'    => 'product_image_section',
-                'title'         => esc_html__( 'Product Info Generate', 'dokan-lite' ),
-                'description'   => esc_html__( 'Let vendors generate product info by AI.', 'dokan-lite' ),
-                'default'       => 'on',
-                'enable_state'  => [
-					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
-					'value' => 'on',
-				],
-                'disable_state' => [
-					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
-					'value' => 'off',
-				],
-            ],
-            [
-                'id'           => 'ai_product_info_engine',
-                'type'         => 'field',
-                'variant'      => 'select',
-                'section_id'   => 'product_image_section',
-                'title'        => esc_html__( 'Engine', 'dokan-lite' ),
-                'description'  => esc_html__( 'Select which AI provider to use for generating content.', 'dokan-lite' ),
-                'default'      => 'openai',
-                'options'      => $provider_options( $text_providers ),
-                'legacy_key'   => 'dokan_ai.dokan_ai_engine',
-                'dependencies' => $on_generate,
+                'id'          => 'ai_product_info_engine',
+                'type'        => 'field',
+                'variant'     => 'select',
+                'section_id'  => 'product_info_section',
+                'title'       => esc_html__( 'Engine', 'dokan-lite' ),
+                'description' => esc_html__( 'Select which AI provider to use for generating content.', 'dokan-lite' ),
+                'default'     => 'openai',
+                'options'     => $provider_options( $text_providers ),
+                'legacy_key'  => 'dokan_ai.dokan_ai_engine',
             ],
         ];
 
@@ -2304,9 +2264,8 @@ class SettingsSchema {
                     [
                         'provider_id'     => $pid,
                         'provider'        => $provider,
-                        'section_id'      => 'product_image_section',
+                        'section_id'      => 'product_info_section',
                         'engine_field_id' => 'ai_product_info_engine',
-                        'toggle_deps'     => $on_generate,
                         'engine_deps'     => $when_engine( 'ai_product_info_engine', $pid ),
                         'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
                         'model_legacy'    => 'dokan_ai.dokan_ai_' . $pid . '_model',
@@ -2369,8 +2328,8 @@ class SettingsSchema {
     public static function ai_provider_group( array $cfg ): array {
         $pid          = $cfg['provider_id'];
         $provider     = $cfg['provider'];
-        $toggle_deps  = $cfg['toggle_deps'];
-        $engine_deps  = $cfg['engine_deps'];
+        $toggle_deps  = $cfg['toggle_deps'] ?? [];
+        $engine_deps  = $cfg['engine_deps'] ?? [];
         // Section-scoped prefix prevents id collisions when the same
         // provider id (e.g. "gemini") appears in both text and image
         // provider registries.
@@ -2403,6 +2362,50 @@ class SettingsSchema {
         $api_key_url = method_exists( $provider, 'get_api_key_url' ) ? (string) $provider->get_api_key_url() : '';
         $image_url   = method_exists( $provider, 'get_image_url' ) ? (string) $provider->get_image_url() : '';
 
+        // Children inherit the group's engine gate; only pin an extra toggle gate (Pro's image switch) when a caller supplies one — Lite text passes none.
+        $api_info = [
+            'id'             => $prefix . $pid . '_api_info',
+            'type'           => 'field',
+            'variant'        => 'base_field_label',
+            'field_group_id' => $group_id,
+            /* translators: %s: Provider title */
+            'title'          => sprintf( esc_html__( '%s API', 'dokan-lite' ), $provider->get_title() ),
+            'icon'           => 'CircleCheck',
+            /* translators: %s: Provider title */
+            'description'    => sprintf( esc_html__( 'Connect to your %s account with your website.', 'dokan-lite' ), $provider->get_title() ),
+            'image_url'      => $image_url,
+        ];
+        $api_notice = [
+            'id'             => $prefix . $pid . '_api_notice',
+            'type'           => 'field',
+            'variant'        => 'info',
+            'field_group_id' => $group_id,
+            /* translators: %s: Provider title */
+            'title'          => sprintf( esc_html__( 'You can get your API Keys in your %s Account.', 'dokan-lite' ), $provider->get_title() ),
+            /* translators: %s: Provider title */
+            'link_text'      => sprintf( esc_html__( '%s Account', 'dokan-lite' ), $provider->get_title() ),
+            'link_url'       => $api_key_url,
+            'show_icon'      => true,
+        ];
+        $api_key = [
+            'id'             => $prefix . $pid . '_api_key',
+            'type'           => 'field',
+            'variant'        => 'show_hide',
+            'field_group_id' => $group_id,
+            'title'          => esc_html__( 'API Key', 'dokan-lite' ),
+            /* translators: %s: Provider title */
+            'tooltip'        => sprintf( esc_html__( 'Enter your %s API key.', 'dokan-lite' ), $provider->get_title() ),
+            /* translators: %s: Provider title */
+            'placeholder'    => sprintf( esc_html__( 'Enter your %s API key', 'dokan-lite' ), $provider->get_title() ),
+            'legacy_key'     => $cfg['api_key_legacy'],
+        ];
+
+        if ( ! empty( $toggle_deps ) ) {
+            $api_info['dependencies']   = $toggle_deps;
+            $api_notice['dependencies'] = $toggle_deps;
+            $api_key['dependencies']    = $toggle_deps;
+        }
+
         return [
             [
                 'id'           => $group_id,
@@ -2410,45 +2413,9 @@ class SettingsSchema {
                 'section_id'   => $cfg['section_id'],
                 'dependencies' => $engine_deps,
             ],
-            [
-                'id'             => $prefix . $pid . '_api_info',
-                'type'           => 'field',
-                'variant'        => 'base_field_label',
-                'field_group_id' => $group_id,
-                /* translators: %s: Provider title */
-                'title'          => sprintf( esc_html__( '%s API', 'dokan-lite' ), $provider->get_title() ),
-                'icon'           => 'CircleCheck',
-                /* translators: %s: Provider title */
-                'description'    => sprintf( esc_html__( 'Connect to your %s account with your website.', 'dokan-lite' ), $provider->get_title() ),
-                'image_url'      => $image_url,
-                'dependencies'   => $toggle_deps,
-            ],
-            [
-                'id'             => $prefix . $pid . '_api_notice',
-                'type'           => 'field',
-                'variant'        => 'info',
-                'field_group_id' => $group_id,
-                /* translators: %s: Provider title */
-                'title'          => sprintf( esc_html__( 'You can get your API Keys in your %s Account.', 'dokan-lite' ), $provider->get_title() ),
-                /* translators: %s: Provider title */
-                'link_text'      => sprintf( esc_html__( '%s Account', 'dokan-lite' ), $provider->get_title() ),
-                'link_url'       => $api_key_url,
-                'show_icon'      => true,
-                'dependencies'   => $toggle_deps,
-            ],
-            [
-                'id'             => $prefix . $pid . '_api_key',
-                'type'           => 'field',
-                'variant'        => 'show_hide',
-                'field_group_id' => $group_id,
-                'title'          => esc_html__( 'API Key', 'dokan-lite' ),
-                /* translators: %s: Provider title */
-                'tooltip'        => sprintf( esc_html__( 'Enter your %s API key.', 'dokan-lite' ), $provider->get_title() ),
-                /* translators: %s: Provider title */
-                'placeholder'    => sprintf( esc_html__( 'Enter your %s API key', 'dokan-lite' ), $provider->get_title() ),
-                'legacy_key'     => $cfg['api_key_legacy'],
-                'dependencies'   => $toggle_deps,
-            ],
+            $api_info,
+            $api_notice,
+            $api_key,
             [
                 'id'           => $prefix . $pid . '_model',
                 'type'         => 'field',
@@ -2459,7 +2426,7 @@ class SettingsSchema {
                 'default'      => $default_model,
                 'options'      => $model_options,
                 'legacy_key'   => $cfg['model_legacy'],
-                'dependencies' => array_merge( $toggle_deps, $engine_deps ),
+                'dependencies' => empty( $toggle_deps ) ? $engine_deps : array_merge( $toggle_deps, $engine_deps ),
             ],
         ];
     }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the WordPress' coding standards
* [x] My code satisfies feature requirements
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Two fixes to the AI Assist (`dokan_ai`) flat-array migration.

**1. Render Product Info like the legacy form** (`SettingsSchema.php`)
- The `ai_product_info_generate` **toggle switch** had no legacy counterpart and its dependency gate was hiding the provider fields. Replaced it with a plain section header **"AI Product Info Generator"** (mirroring the legacy `dokan_ai_product_info` sub_section).
- The **Engine** selector is now always visible (no dependency), and each provider's **API Key + Model** reveal purely on the engine selection — single-entry show-on-`===`, matching the legacy `show_if`.
- `ai_provider_group()` now attaches the extra toggle gate only when a caller passes one, so **Pro's image section is byte-for-byte unchanged** (it still passes its image-enhancement toggle).

**2. Keep legacy ↔ flat AI data in sync** (`LegacySettingsBridge.php`)
- The per-provider `api_key`/`model` fields are generated dynamically from the `dokan_intelligence_providers` registry, but the bridge map memo only invalidated on `dokan_get_admin_settings_schema` callback changes — blind to provider registration.
- A map built before providers booted classified those keys as **unmapped**, so a save skipped the legacy↔flat mirror: `engine` migrated but `api_key`/`model` did not, and the two stores drifted (the "API Key / Model not saved" symptom).
- Fix: fold the `dokan_intelligence_providers` callback count into the memo signature, so the map rebuilds once providers enlist. Since every read-overlay and save path funnels through `build_map()`, this fixes both directions (and also covers Pro's image-provider fields).

**Closes:** https://github.com/getdokan/plugin-internal-tasks/issues/1925
**Related PR:** https://github.com/getdokan/dokan-pro/pull/5741

### How to test the changes in this Pull Request:

1. **wp-admin → Dokan → Settings → AI Assist → Content Generation.**
2. The section shows **AI Product Info Generator** (header, no toggle) → **Engine** → the selected provider's **API Key + Model**; switching Engine swaps which provider's fields show.
3. Set an API Key + Model, **Save**, reload — values persist. Verify `dokan_ai` (legacy) and `dokan_admin_settings` (flat) agree for `*_api_key`/`*_model` (no drift).

### Changelog entry

*Fix AI Assist settings: render like the legacy form and reliably save API Key + Model*

Previously the new AI Assist UI showed a "Product Info Generate" toggle that hid the provider fields, and saving the API Key/Model could silently fail to sync between the legacy `dokan_ai` option and the new flat option because the bridge mapping was built before AI providers registered. Now the UI mirrors the legacy form (header + engine-gated provider fields) and the legacy↔flat mirror is consistent for the dynamic per-provider fields.

### Before Changes

"Product Info Generate" rendered as a toggle and the OpenAI/Gemini API Key + Model fields were hidden; saved API Key/Model could drift between the legacy and flat option stores.

### After Changes

Section renders as a header with an always-visible Engine selector and the selected provider's API Key + Model; saves stay consistent across both stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)