### PR TITLE
feat(settings): bridge appearance legacy keys + Moderation > Captcha page

### DIFF
--- a/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
@@ -2,11 +2,9 @@
 
 namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
 
-use Closure;
-
 /**
- * Builds a callable transformer pair for a `double_input` variant whose two
- * inputs each bridge to an independent scalar legacy key.
+ * Bridges a `double_input` field whose two inputs each map to an independent
+ * scalar legacy key.
  *
  * Shapes:
  *   legacy: two separate keys (e.g. `store_banner_width`, `store_banner_height`)
@@ -16,59 +14,67 @@ use Closure;
  * same slot names the value uses (`first` / `second`), so the reshape is a
  * straight pass-through with integer coercion and a default fallback for any
  * slot the legacy row is missing (e.g. when the Pro-injected width/height keys
- * were never saved).
+ * were never saved). Both directions share the same shape, so the conversion is
+ * symmetric.
  *
  *     'legacy_key' => [
  *         'first'  => 'dokan_appearance.store_banner_width',
  *         'second' => 'dokan_appearance.store_banner_height',
  *     ],
- *     'legacy_transformer' => DoubleInputTransformer::for_slots( 625, 300 ),
- *
- * Closures are filter-safe in the current pipeline (no schema persistence);
- * swap to a dedicated class if the schema ever gets cached to a transient.
+ *     'legacy_transformer' => DoubleInputTransformer::class,
  *
  * @since DOKAN_SINCE
  */
-final class DoubleInputTransformer {
+final class DoubleInputTransformer implements TransformerInterface {
 
     /**
-     * Build the callable pair for the two-input field.
-     *
-     * @param int    $first_default  Fallback for the first slot when the legacy
-     *                              key is absent or empty.
-     * @param int    $second_default Fallback for the second slot.
-     * @param string $first_slot     Slot name for the first input (matches the
-     *                              `double_input` value key and the `legacy_key`
-     *                              slot name).
-     * @param string $second_slot    Slot name for the second input.
-     *
-     * @return array{to_new: Closure, to_legacy: Closure}
+     * Default store banner width when the legacy `first` slot is missing.
      */
-    public static function for_slots(
-        int $first_default,
-        int $second_default,
-        string $first_slot = 'first',
-        string $second_slot = 'second'
-    ): array {
-        $coerce = static function ( $value, int $fallback ): int {
-            return ( is_numeric( $value ) ) ? (int) $value : $fallback;
-        };
+    const FIRST_DEFAULT = 625;
+
+    /**
+     * Default store banner height when the legacy `second` slot is missing.
+     */
+    const SECOND_DEFAULT = 300;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed>|null $legacy_value
+     *
+     * @return array{first:int,second:int}
+     */
+    public function to_new( $legacy_value ) {
+        return $this->reshape( $legacy_value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed>|null $new_value
+     *
+     * @return array{first:int,second:int}
+     */
+    public function to_legacy( $new_value ) {
+        return $this->reshape( $new_value );
+    }
+
+    /**
+     * Coerce both slots to integers, falling back to the slot default.
+     *
+     * Legacy and new share the same `first`/`second` slot shape, so the
+     * conversion is symmetric and both directions reuse this method.
+     *
+     * @param mixed $value
+     *
+     * @return array{first:int,second:int}
+     */
+    private function reshape( $value ): array {
+        $values = is_array( $value ) ? $value : [];
 
         return [
-            'to_new'    => static function ( $legacy_values ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
-                $values = is_array( $legacy_values ) ? $legacy_values : [];
-                return [
-                    $first_slot  => $coerce( $values[ $first_slot ] ?? null, $first_default ),
-                    $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
-                ];
-            },
-            'to_legacy' => static function ( $new_value ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
-                $values = is_array( $new_value ) ? $new_value : [];
-                return [
-                    $first_slot  => $coerce( $values[ $first_slot ] ?? null, $first_default ),
-                    $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
-                ];
-            },
+            'first'  => is_numeric( $values['first'] ?? null ) ? (int) $values['first'] : self::FIRST_DEFAULT,
+            'second' => is_numeric( $values['second'] ?? null ) ? (int) $values['second'] : self::SECOND_DEFAULT,
         ];
     }
 }

--- a/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+use Closure;
+
+/**
+ * Builds a callable transformer pair for a `double_input` variant whose two
+ * inputs each bridge to an independent scalar legacy key.
+ *
+ *   legacy: two separate keys (e.g. `store_banner_width`, `store_banner_height`)
+ *   new:    [ 'first' => <int>, 'second' => <int> ]   // the double_input value shape
+ *
+ * The field's multi-mapped `legacy_key` addresses the two legacy keys under the
+ * same slot names the value uses (`first` / `second`), so the reshape is a
+ * straight pass-through with integer coercion and a default fallback for any
+ * slot the legacy row is missing (e.g. when the Pro-injected width/height keys
+ * were never saved).
+ *
+ *     'legacy_key' => [
+ *         'first'  => 'dokan_appearance.store_banner_width',
+ *         'second' => 'dokan_appearance.store_banner_height',
+ *     ],
+ *     'legacy_transformer' => DoubleInputTransformer::for_slots( 625, 300 ),
+ *
+ * Closures are filter-safe in the current pipeline (no schema persistence);
+ * swap to a dedicated class if the schema ever gets cached to a transient.
+ *
+ * @since DOKAN_SINCE
+ */
+final class DoubleInputTransformer {
+
+    /**
+     * Build the callable pair for the two-input field.
+     *
+     * @param int    $first_default  Fallback for the first slot when the legacy
+     *                              key is absent or empty.
+     * @param int    $second_default Fallback for the second slot.
+     * @param string $first_slot     Slot name for the first input (matches the
+     *                              `double_input` value key and the `legacy_key`
+     *                              slot name).
+     * @param string $second_slot    Slot name for the second input.
+     *
+     * @return array{to_new: Closure, to_legacy: Closure}
+     */
+    public static function for_slots(
+        int $first_default,
+        int $second_default,
+        string $first_slot = 'first',
+        string $second_slot = 'second'
+    ): array {
+        $coerce = static function ( $value, int $default ): int {
+            return ( is_numeric( $value ) ) ? (int) $value : $default;
+        };
+
+        return [
+            'to_new'    => static function ( $legacy_values ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
+                $values = is_array( $legacy_values ) ? $legacy_values : [];
+                return [
+                    $first_slot  => $coerce( $values[ $first_slot ]  ?? null, $first_default ),
+                    $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
+                ];
+            },
+            'to_legacy' => static function ( $new_value ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
+                $values = is_array( $new_value ) ? $new_value : [];
+                return [
+                    $first_slot  => $coerce( $values[ $first_slot ]  ?? null, $first_default ),
+                    $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
+                ];
+            },
+        ];
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/DoubleInputTransformer.php
@@ -8,6 +8,7 @@ use Closure;
  * Builds a callable transformer pair for a `double_input` variant whose two
  * inputs each bridge to an independent scalar legacy key.
  *
+ * Shapes:
  *   legacy: two separate keys (e.g. `store_banner_width`, `store_banner_height`)
  *   new:    [ 'first' => <int>, 'second' => <int> ]   // the double_input value shape
  *
@@ -49,22 +50,22 @@ final class DoubleInputTransformer {
         string $first_slot = 'first',
         string $second_slot = 'second'
     ): array {
-        $coerce = static function ( $value, int $default ): int {
-            return ( is_numeric( $value ) ) ? (int) $value : $default;
+        $coerce = static function ( $value, int $fallback ): int {
+            return ( is_numeric( $value ) ) ? (int) $value : $fallback;
         };
 
         return [
             'to_new'    => static function ( $legacy_values ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
                 $values = is_array( $legacy_values ) ? $legacy_values : [];
                 return [
-                    $first_slot  => $coerce( $values[ $first_slot ]  ?? null, $first_default ),
+                    $first_slot  => $coerce( $values[ $first_slot ] ?? null, $first_default ),
                     $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
                 ];
             },
             'to_legacy' => static function ( $new_value ) use ( $coerce, $first_default, $second_default, $first_slot, $second_slot ) {
                 $values = is_array( $new_value ) ? $new_value : [];
                 return [
-                    $first_slot  => $coerce( $values[ $first_slot ]  ?? null, $first_default ),
+                    $first_slot  => $coerce( $values[ $first_slot ] ?? null, $first_default ),
                     $second_slot => $coerce( $values[ $second_slot ] ?? null, $second_default ),
                 ];
             },

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1392,6 +1392,27 @@ class SettingsSchema {
                 ],
             ],
             [
+                'id'            => 'show_register_as_vendor',
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'subpage_id'    => 'vendor_onboarding',
+                'title'         => __( 'Show "Register as a Vendor" in Sign Up Page', 'dokan-lite' ),
+                'description'   => __( 'Adds the "I am a customer / I am a vendor" role toggle to the WooCommerce My Account sign-up form.', 'dokan-lite' ),
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'show_register_as_vendor',
+                ],
+            ],
+            [
                 'id'            => 'vendor_setup_wizard_logo',
                 'type'          => 'field',
                 'variant'       => 'wp_media_upload',
@@ -1610,124 +1631,6 @@ class SettingsSchema {
                 ],
             ],
 
-            // Google reCAPTCHA
-            [
-                'id'         => 'google_recaptcha',
-                'type'       => 'section',
-                'subpage_id' => 'store',
-            ],
-            [
-                'id'         => 'google_recaptcha_settings',
-                'type'       => 'fieldgroup',
-                'section_id' => 'google_recaptcha',
-            ],
-            [
-                'id'             => 'google_recaptcha_enabled',
-                'type'           => 'field',
-                'variant'        => 'switch',
-                'field_group_id' => 'google_recaptcha_settings',
-                'title'          => esc_html__( 'Google reCaptcha Validation', 'dokan-lite' ),
-                'description'    => sprintf(
-                    /* translators: %s: Help link */
-                    __( 'Connect to enable spam protection that works automatically in the background <a href="%s" target="_blank" rel="noopener noreferrer">Get Help</a>', 'dokan-lite' ),
-                    'https://developers.google.com/recaptcha/docs/v3'
-                ),
-                'default'        => 'off',
-                'image_url'      => DOKAN_PLUGIN_ASSEST . '/images/admin-settings-icons/social-onboarding/google.svg',
-                'enable_state'   => [
-					'label' => esc_html__( 'Enable', 'dokan-lite' ),
-					'value' => 'on',
-				],
-                'disable_state'  => [
-					'label' => esc_html__( 'Disable', 'dokan-lite' ),
-					'value' => 'off',
-				],
-            ],
-            [
-                'id'             => 'google_recaptcha_info',
-                'type'           => 'field',
-                'variant'        => 'info',
-                'field_group_id' => 'google_recaptcha_settings',
-                'title'          => esc_html__( 'Need Help?', 'dokan-lite' ),
-                'description'    => sprintf(
-                    /* translators: %s: Google reCaptcha URL */
-                    __( "If you don't have a Google reCaptcha account, <a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">+ Create Google reCaptcha</a>", 'dokan-lite' ),
-                    'https://www.google.com/recaptcha/admin/create'
-                ),
-                'dependencies'   => [
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'on',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'show',
-						'comparison' => '===',
-					],
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'off',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'hide',
-						'comparison' => '===',
-					],
-                ],
-            ],
-            [
-                'id'             => 'google_recaptcha_site_key',
-                'type'           => 'field',
-                'variant'        => 'show_hide',
-                'field_group_id' => 'google_recaptcha_settings',
-                'title'          => esc_html__( 'Site Key', 'dokan-lite' ),
-                'placeholder'    => esc_html__( 'Site Key', 'dokan-lite' ),
-                'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
-                'dependencies'   => [
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'on',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'show',
-						'comparison' => '===',
-					],
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'off',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'hide',
-						'comparison' => '===',
-					],
-                ],
-            ],
-            [
-                'id'             => 'google_recaptcha_secret_key',
-                'type'           => 'field',
-                'variant'        => 'show_hide',
-                'field_group_id' => 'google_recaptcha_settings',
-                'title'          => esc_html__( 'Secret Key', 'dokan-lite' ),
-                'placeholder'    => esc_html__( 'Secret Key', 'dokan-lite' ),
-                'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
-                'dependencies'   => [
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'on',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'show',
-						'comparison' => '===',
-					],
-                    [
-						'key' => 'google_recaptcha_enabled',
-						'value' => 'off',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'hide',
-						'comparison' => '===',
-					],
-                ],
-            ],
-
             // Contact Form
             [
                 'id'         => 'store_contact_form_section',
@@ -1756,6 +1659,39 @@ class SettingsSchema {
 				],
             ],
 
+            // Default Store Media
+            [
+                'id'         => 'store_default_media_section',
+                'type'       => 'section',
+                'subpage_id' => 'store',
+            ],
+            [
+                'id'            => 'default_store_banner',
+                'type'          => 'field',
+                'variant'       => 'wp_media_upload',
+                'section_id'    => 'store_default_media_section',
+                'title'         => esc_html__( 'Default Store Banner', 'dokan-lite' ),
+                'allowed_types' => [ 'image/jpeg', 'image/png', 'image/gif' ],
+                'default'       => DOKAN_PLUGIN_ASSEST . '/images/default-store-banner.png',
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'default_store_banner',
+                ],
+            ],
+            [
+                'id'            => 'default_store_profile',
+                'type'          => 'field',
+                'variant'       => 'wp_media_upload',
+                'section_id'    => 'store_default_media_section',
+                'title'         => esc_html__( 'Default Store Profile Picture', 'dokan-lite' ),
+                'allowed_types' => [ 'image/jpeg', 'image/png', 'image/gif' ],
+                'default'       => DOKAN_PLUGIN_ASSEST . '/images/mystery-person.jpg',
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'default_store_profile',
+                ],
+            ],
+
             // Banner Dimension
             [
                 'id'         => 'store_banner_dimension_section',
@@ -1774,6 +1710,14 @@ class SettingsSchema {
 					'first' => 625,
 					'second' => 300,
 				],
+                // Legacy stores width/height as two separate keys under
+                // `dokan_appearance` (Pro-injected). Bridge each to its own
+                // slot of the `double_input` value via {@see DoubleInputTransformer}.
+                'legacy_key'         => [
+                    'first'  => 'dokan_appearance.store_banner_width',
+                    'second' => 'dokan_appearance.store_banner_height',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\DoubleInputTransformer::for_slots( 625, 300 ),
             ],
 
             // Store Template
@@ -2478,6 +2422,281 @@ class SettingsSchema {
                 'description' => esc_html__( 'Configure moderation settings, return policies, and customer request management.', 'dokan-lite' ),
                 'icon'        => 'Settings2',
                 'priority'    => 900,
+            ],
+
+            // === SubPage: Captcha ===
+            [
+                'id'            => 'captcha',
+                'type'          => 'subpage',
+                'page_id'       => 'moderation',
+                'title'         => esc_html__( 'Captcha', 'dokan-lite' ),
+                'description'   => esc_html__( 'Add bot and spam protection to the forms across your store.', 'dokan-lite' ),
+                'priority'      => 100,
+                'doc_link'      => 'https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration/',
+                'doc_link_text' => esc_html__( 'Doc', 'dokan-lite' ),
+            ],
+            [
+                'id'         => 'captcha_section',
+                'type'       => 'section',
+                'subpage_id' => 'captcha',
+            ],
+            [
+                'id'            => 'captcha_enable_status',
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'section_id'    => 'captcha_section',
+                'title'         => esc_html__( 'Captcha Service', 'dokan-lite' ),
+                'description'   => esc_html__( 'Activate captcha on every form that supports it.', 'dokan-lite' ),
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'captcha_enable_status',
+                ],
+            ],
+            [
+                'id'           => 'captcha_provider',
+                'type'         => 'field',
+                'variant'      => 'select',
+                'section_id'   => 'captcha_section',
+                'title'        => esc_html__( 'Captcha Provider', 'dokan-lite' ),
+                'description'  => esc_html__( 'Select the captcha provider to use for this marketplace', 'dokan-lite' ),
+                'default'      => 'google_recaptcha_v3',
+                'options'      => [
+                    [
+						'title' => esc_html__( 'Google reCAPTCHA v3', 'dokan-lite' ),
+						'value' => 'google_recaptcha_v3',
+					],
+                    [
+						'title' => esc_html__( 'Cloudflare Turnstile', 'dokan-lite' ),
+						'value' => 'cloudflare_turnstile',
+					],
+                ],
+                'legacy_key'   => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'captcha_provider',
+                ],
+                'dependencies' => [
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'off',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '===',
+					],
+                ],
+            ],
+            // Provider card — collapsible switch (icon header + toggle). The
+            // toggle bridges to the legacy `recaptcha_enable_status` flag;
+            // credential fields nest below.
+            [
+                'id'            => 'recaptcha_validation_label',
+                'type'          => 'field',
+                'variant'       => 'collapsible_switch',
+                'section_id'    => 'captcha_section',
+                'title'         => esc_html__( 'Google reCAPTCHA v3 Validation', 'dokan-lite' ),
+                'description'   => sprintf(
+                    /* translators: 1: opening anchor tag, 2: closing anchor tag */
+                    esc_html__( 'Google reCAPTCHA v3 credentials are required to enable captcha for supported forms. %1$sGet Help%2$s', 'dokan-lite' ),
+                    '<a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration/" target="_blank" rel="noopener noreferrer">',
+                    '</a>'
+                ),
+                'image_url'     => DOKAN_PLUGIN_ASSEST . '/images/admin-settings-icons/social-onboarding/google.svg',
+                'collapsed'     => false,
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'recaptcha_enable_status',
+                ],
+                'dependencies'  => [
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'google_recaptcha_v3',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'google_recaptcha_v3',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                ],
+            ],
+            [
+                'id'             => 'recaptcha_admin_notice',
+                'type'           => 'field',
+                'variant'        => 'info',
+                'field_group_id' => 'recaptcha_validation_label',
+                'show_icon'      => true,
+                'title'          => esc_html__( 'You can get your Site Key and Secret Key from your reCAPTCHA admin console.', 'dokan-lite' ),
+                'link_title'     => esc_html__( 'Admin Console', 'dokan-lite' ),
+                'link_url'       => 'https://www.google.com/recaptcha/admin',
+            ],
+            [
+                'id'             => 'recaptcha_site_key',
+                'type'           => 'field',
+                'variant'        => 'show_hide',
+                'field_group_id' => 'recaptcha_validation_label',
+                'title'          => esc_html__( 'Site Key', 'dokan-lite' ),
+                'placeholder'    => esc_html__( 'Site Key', 'dokan-lite' ),
+                'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
+                'default'        => '',
+                'legacy_key'     => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'recaptcha_site_key',
+                ],
+            ],
+            [
+                'id'             => 'recaptcha_secret_key',
+                'type'           => 'field',
+                'variant'        => 'show_hide',
+                'field_group_id' => 'recaptcha_validation_label',
+                'title'          => esc_html__( 'Secret Key', 'dokan-lite' ),
+                'placeholder'    => esc_html__( 'Secret Key', 'dokan-lite' ),
+                'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
+                'default'        => '',
+                'legacy_key'     => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'recaptcha_secret_key',
+                ],
+            ],
+
+            // Provider card — Cloudflare Turnstile. Shown when that provider is
+            // selected; credential fields bridge to the legacy `turnstile_*` keys.
+            [
+                'id'            => 'turnstile_validation_label',
+                'type'          => 'field',
+                'variant'       => 'collapsible_switch',
+                'section_id'    => 'captcha_section',
+                'title'         => esc_html__( 'Cloudflare Turnstile Validation', 'dokan-lite' ),
+                'description'   => sprintf(
+                    /* translators: 1: opening anchor tag, 2: closing anchor tag */
+                    esc_html__( 'Cloudflare Turnstile credentials are required to enable captcha for supported forms. %1$sGet Help%2$s', 'dokan-lite' ),
+                    '<a href="https://developers.cloudflare.com/turnstile/" target="_blank" rel="noopener noreferrer">',
+                    '</a>'
+                ),
+                'image_url'     => DOKAN_PLUGIN_ASSEST . '/images/cloudflare.png',
+                'collapsed'     => false,
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'turnstile_enable_status',
+                ],
+                'dependencies'  => [
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'cloudflare_turnstile',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'cloudflare_turnstile',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                ],
+            ],
+            [
+                'id'             => 'turnstile_admin_notice',
+                'type'           => 'field',
+                'variant'        => 'info',
+                'field_group_id' => 'turnstile_validation_label',
+                'show_icon'      => true,
+                'title'          => esc_html__( 'You can get your Site Key and Secret Key from your Cloudflare Turnstile dashboard.', 'dokan-lite' ),
+                'link_title'     => esc_html__( 'Turnstile Dashboard', 'dokan-lite' ),
+                'link_url'       => 'https://dash.cloudflare.com/?to=/:account/turnstile',
+            ],
+            [
+                'id'             => 'turnstile_site_key',
+                'type'           => 'field',
+                'variant'        => 'show_hide',
+                'field_group_id' => 'turnstile_validation_label',
+                'title'          => esc_html__( 'Site Key', 'dokan-lite' ),
+                'placeholder'    => esc_html__( 'Site Key', 'dokan-lite' ),
+                'tooltip'        => esc_html__( 'Insert Cloudflare Turnstile site key.', 'dokan-lite' ),
+                'default'        => '',
+                'legacy_key'     => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'turnstile_site_key',
+                ],
+            ],
+            [
+                'id'             => 'turnstile_secret_key',
+                'type'           => 'field',
+                'variant'        => 'show_hide',
+                'field_group_id' => 'turnstile_validation_label',
+                'title'          => esc_html__( 'Secret Key', 'dokan-lite' ),
+                'placeholder'    => esc_html__( 'Secret Key', 'dokan-lite' ),
+                'tooltip'        => esc_html__( 'Insert Cloudflare Turnstile secret key.', 'dokan-lite' ),
+                'default'        => '',
+                'legacy_key'     => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'turnstile_secret_key',
+                ],
             ],
         ];
     }

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1613,12 +1613,15 @@ class SettingsSchema {
                 'type'        => 'subpage',
                 'page_id'     => 'appearance',
                 'title'       => esc_html__( 'Vendor Dashboard', 'dokan-lite' ),
+                'description' => esc_html__( 'Choose the interface style vendors see for their dashboard and product editor.', 'dokan-lite' ),
                 'priority'    => 150,
             ],
             [
-                'id'         => 'vendor_dashboard_section',
-                'type'       => 'section',
-                'subpage_id' => 'vendor_dashboard',
+                'id'          => 'vendor_dashboard_section',
+                'type'        => 'section',
+                'subpage_id'  => 'vendor_dashboard',
+                'title'       => esc_html__( 'Vendor Dashboard Appearance', 'dokan-lite' ),
+                'description' => esc_html__( 'Configure the appearance and style of the vendor dashboard.', 'dokan-lite' ),
             ],
             [
                 'id'          => 'vendor_layout_style',

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1607,19 +1607,19 @@ class SettingsSchema {
                 'priority'    => 100,
             ],
 
-            // === SubPage: Vendor Dashboard ===
+            // === SubPage: Vendor Panel ===
             [
-                'id'          => 'vendor_dashboard',
+                'id'          => 'vendor_panel',
                 'type'        => 'subpage',
                 'page_id'     => 'appearance',
-                'title'       => esc_html__( 'Vendor Dashboard', 'dokan-lite' ),
-                'description' => esc_html__( 'Manage vendor dashboard settings and appearance for your marketplace.', 'dokan-lite' ),
-                'priority'    => 150,
+                'title'       => esc_html__( 'Vendor Panel', 'dokan-lite' ),
+                'description' => esc_html__( 'Manage Vendor Panel appearance settings and modifications', 'dokan-lite' ),
+                'priority'    => 50,
             ],
             [
                 'id'          => 'vendor_dashboard_section',
                 'type'        => 'section',
-                'subpage_id'  => 'vendor_dashboard',
+                'subpage_id'  => 'vendor_panel',
                 'title'       => esc_html__( 'Vendor Dashboard Appearance', 'dokan-lite' ),
                 'description' => esc_html__( 'Configure the appearance and style of the vendor dashboard.', 'dokan-lite' ),
             ],

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1780,7 +1780,7 @@ class SettingsSchema {
                     'first'  => 'dokan_appearance.store_banner_width',
                     'second' => 'dokan_appearance.store_banner_height',
                 ],
-                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\DoubleInputTransformer::for_slots( 625, 300 ),
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\DoubleInputTransformer::class,
             ],
 
             // Store Template

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1607,6 +1607,66 @@ class SettingsSchema {
                 'priority'    => 100,
             ],
 
+            // === SubPage: Vendor Dashboard ===
+            [
+                'id'          => 'vendor_dashboard',
+                'type'        => 'subpage',
+                'page_id'     => 'appearance',
+                'title'       => esc_html__( 'Vendor Dashboard', 'dokan-lite' ),
+                'priority'    => 150,
+            ],
+            [
+                'id'         => 'vendor_dashboard_section',
+                'type'       => 'section',
+                'subpage_id' => 'vendor_dashboard',
+            ],
+            [
+                'id'          => 'vendor_layout_style',
+                'type'        => 'field',
+                'variant'     => 'radio_capsule',
+                'section_id'  => 'vendor_dashboard_section',
+                'title'       => esc_html__( 'Vendor Dashboard Style', 'dokan-lite' ),
+                'description' => esc_html__( 'Select the user interface for the vendor dashboard.', 'dokan-lite' ),
+                'default'     => 'legacy',
+                'options'     => [
+                    [
+						'title' => esc_html__( 'New UI', 'dokan-lite' ),
+						'value' => 'latest',
+					],
+                    [
+						'title' => esc_html__( 'Legacy UI', 'dokan-lite' ),
+						'value' => 'legacy',
+					],
+                ],
+                'legacy_key'  => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'vendor_layout_style',
+                ],
+            ],
+            [
+                'id'          => 'vendor_product_editor',
+                'type'        => 'field',
+                'variant'     => 'radio_capsule',
+                'section_id'  => 'vendor_dashboard_section',
+                'title'       => esc_html__( 'Vendor Product Editor', 'dokan-lite' ),
+                'description' => esc_html__( 'Select the user interface for the vendor product editor.', 'dokan-lite' ),
+                'default'     => 'legacy',
+                'options'     => [
+                    [
+						'title' => esc_html__( 'New UI', 'dokan-lite' ),
+						'value' => 'latest',
+					],
+                    [
+						'title' => esc_html__( 'Legacy UI', 'dokan-lite' ),
+						'value' => 'legacy',
+					],
+                ],
+                'legacy_key'  => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'vendor_product_editor',
+                ],
+            ],
+
             // Products Per Page
             [
                 'id'         => 'products_page',

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1613,7 +1613,7 @@ class SettingsSchema {
                 'type'        => 'subpage',
                 'page_id'     => 'appearance',
                 'title'       => esc_html__( 'Vendor Dashboard', 'dokan-lite' ),
-                'description' => esc_html__( 'Choose the interface style vendors see for their dashboard and product editor.', 'dokan-lite' ),
+                'description' => esc_html__( 'Manage vendor dashboard settings and appearance for your marketplace.', 'dokan-lite' ),
                 'priority'    => 150,
             ],
             [


### PR DESCRIPTION
closes: 
https://github.com/getdokan/plugin-internal-tasks/issues/1927
## Summary

Maps the remaining **Appearance** legacy settings into the new flat-array schema, and rebuilds the captcha settings as a dedicated **Moderation → Captcha** page with provider selection (Google reCAPTCHA v3 + Cloudflare Turnstile).

## Appearance mappings (legacy `dokan_appearance`)

| Old key | New field | Page | Mapping |
|---|---|---|---|
| `show_register_as_vendor` | `switch` | Vendor → Vendor Onboarding | 1:1 |
| `default_store_banner` | `wp_media_upload` | Appearance → Store | 1:1 |
| `default_store_profile` | `wp_media_upload` | Appearance → Store | 1:1 |
| `store_banner_width` + `store_banner_height` | `store_banner_dimension` (`double_input`) | Appearance → Store | **2→1** via new `DoubleInputTransformer` |

## Moderation → Captcha page

Replaces the old `google_recaptcha` block under Appearance → Store with a dedicated page matching the new design:

| Field | Variant | Maps to (`dokan_appearance`) |
|---|---|---|
| Captcha Service | `switch` | `captcha_enable_status` |
| Captcha Provider | `select` (reCAPTCHA v3 / Turnstile) | `captcha_provider` |
| Google reCAPTCHA v3 Validation | `collapsible_switch` | `recaptcha_enable_status` |
| ↳ Site / Secret Key | `show_hide` | `recaptcha_site_key` / `recaptcha_secret_key` |
| Cloudflare Turnstile Validation | `collapsible_switch` | `turnstile_enable_status` |
| ↳ Site / Secret Key | `show_hide` | `turnstile_site_key` / `turnstile_secret_key` |

Each provider card shows only for its selected provider (via `show(===)`/`hide(!==)` dependency pairs on `captcha_enable_status` + `captcha_provider`), and both hide when the service is off.

## Notes

- All new-field defaults match the old settings defaults.
- `turnstile_enable_status` has no old-settings counterpart (Turnstile never had a per-provider enable flag); it's kept for UI symmetry — the runtime gate is the global toggle + provider selection + keys present.

## Verification

- Bridge round-trip verified both directions for all mapped keys.
- Runtime `CaptchaManager` resolves the active provider correctly for both reCAPTCHA and Turnstile (`is_enabled()` + `get_active_provider()`).
- PHP lint clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)