### PR TITLE
fix: exclude api job setup summary from merged e2e report

### DIFF
--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -699,6 +699,12 @@ jobs:
               run: |
                   npm run wp-env run tests-cli wp db export wp-data/db.sql
 
+            # playwright-report/e2e is excluded: the docker:setup step runs the
+            # site/auth/env setup projects through playwright.config.ts, which
+            # writes setup-run blob/summary/spec-duration files under
+            # playwright-report/e2e/. Shipping those in this artifact made the
+            # merge-reports job count the api job's setup run as an extra e2e
+            # shard (inflating e2e totals) and fed its blob into the html report.
             - name: Archive test artifacts (screenshots, HTML snapshots, Reports)
               if: always() && steps.debug-log.outcome == 'success'
               uses: actions/upload-artifact@v4
@@ -708,6 +714,7 @@ jobs:
                       tests/pw/wp-data
                       tests/pw/playwright
                       tests/pw/playwright-report
+                      !tests/pw/playwright-report/e2e/**
                   if-no-files-found: ignore
                   retention-days: 1
 

--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -367,12 +367,69 @@ jobs:
                   # Wait for the daemon socket instead of a fixed sleep.
                   for i in $(seq 1 15); do docker info >/dev/null 2>&1 && break; sleep 1; done
 
+            # wp-env pulls four Docker Hub library images on every run: mariadb:lts and
+            # phpmyadmin via compose, plus the wordpress / wordpress:cli build bases.
+            # Anonymous Docker Hub pulls from shared runner IPs randomly time out even
+            # with the gcr mirror configured (the daemon silently falls back to
+            # registry-1.docker.io when the mirror misses), so pre-seed the images:
+            # restore them from the actions cache, else pull from AWS's public mirror
+            # of Docker official images and retag. Once the images exist locally,
+            # compose/build skip the Docker Hub pull entirely. The ISO week in the
+            # cache key stops the floating tags (lts, latest) from pinning forever.
+            - name: Compute wp-env image list and cache key
+              id: wp-env-images
+              working-directory: tests/pw
+              run: |
+                  PHP=$(jq -r '.env.tests.phpVersion // empty' .wp-env.override.json)
+                  if [ -z "$PHP" ]; then PHP=$(jq -r '.env.tests.phpVersion // empty' .wp-env.json); fi
+                  IMAGES="mariadb:lts phpmyadmin:latest wordpress${PHP:+:php$PHP} wordpress:cli${PHP:+-php$PHP}"
+                  echo "list=$IMAGES" >> "$GITHUB_OUTPUT"
+                  echo "key=wp-env-images-v1-php${PHP:-default}-$(date +%G-%V)" >> "$GITHUB_OUTPUT"
+                  echo "images: $IMAGES"
+
+            - name: Restore wp-env docker images from cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/wp-env-images
+                  key: ${{ steps.wp-env-images.outputs.key }}
+
+            - name: Pre-seed wp-env docker images
+              run: |
+                  IMAGES="${{ steps.wp-env-images.outputs.list }}"
+                  TAR="$HOME/.cache/wp-env-images/images.tar"
+                  if [ -f "$TAR" ]; then
+                      docker load -i "$TAR"
+                  else
+                      mkdir -p "$(dirname "$TAR")"
+                      complete=true
+                      for img in $IMAGES; do
+                          pulled=false
+                          for attempt in 1 2 3; do
+                              if docker pull "public.ecr.aws/docker/library/$img"; then pulled=true; break; fi
+                              sleep 15
+                          done
+                          if [ "$pulled" = true ]; then
+                              docker tag "public.ecr.aws/docker/library/$img" "$img"
+                              docker rmi "public.ecr.aws/docker/library/$img" >/dev/null
+                          else
+                              echo "::warning::could not pre-seed $img from the ECR mirror; wp-env will pull it from Docker Hub"
+                              complete=false
+                          fi
+                      done
+                      # Only cache a complete set so a partial failure is retried next run.
+                      if [ "$complete" = true ]; then docker save -o "$TAR" $IMAGES; fi
+                  fi
+                  docker image ls
+
             - name: Start WordPress Env
               id: wp-env
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 6
                   max_attempts: 3
+                  # Space the attempts out: Docker Hub's anonymous throttle window
+                  # outlives back-to-back retries, so waiting beats hammering.
+                  retry_wait_seconds: 90
                   retry_on: error
                   command: |
                       cd tests/pw
@@ -623,12 +680,69 @@ jobs:
                   # Wait for the daemon socket instead of a fixed sleep.
                   for i in $(seq 1 15); do docker info >/dev/null 2>&1 && break; sleep 1; done
 
+            # wp-env pulls four Docker Hub library images on every run: mariadb:lts and
+            # phpmyadmin via compose, plus the wordpress / wordpress:cli build bases.
+            # Anonymous Docker Hub pulls from shared runner IPs randomly time out even
+            # with the gcr mirror configured (the daemon silently falls back to
+            # registry-1.docker.io when the mirror misses), so pre-seed the images:
+            # restore them from the actions cache, else pull from AWS's public mirror
+            # of Docker official images and retag. Once the images exist locally,
+            # compose/build skip the Docker Hub pull entirely. The ISO week in the
+            # cache key stops the floating tags (lts, latest) from pinning forever.
+            - name: Compute wp-env image list and cache key
+              id: wp-env-images
+              working-directory: tests/pw
+              run: |
+                  PHP=$(jq -r '.env.tests.phpVersion // empty' .wp-env.override.json)
+                  if [ -z "$PHP" ]; then PHP=$(jq -r '.env.tests.phpVersion // empty' .wp-env.json); fi
+                  IMAGES="mariadb:lts phpmyadmin:latest wordpress${PHP:+:php$PHP} wordpress:cli${PHP:+-php$PHP}"
+                  echo "list=$IMAGES" >> "$GITHUB_OUTPUT"
+                  echo "key=wp-env-images-v1-php${PHP:-default}-$(date +%G-%V)" >> "$GITHUB_OUTPUT"
+                  echo "images: $IMAGES"
+
+            - name: Restore wp-env docker images from cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/wp-env-images
+                  key: ${{ steps.wp-env-images.outputs.key }}
+
+            - name: Pre-seed wp-env docker images
+              run: |
+                  IMAGES="${{ steps.wp-env-images.outputs.list }}"
+                  TAR="$HOME/.cache/wp-env-images/images.tar"
+                  if [ -f "$TAR" ]; then
+                      docker load -i "$TAR"
+                  else
+                      mkdir -p "$(dirname "$TAR")"
+                      complete=true
+                      for img in $IMAGES; do
+                          pulled=false
+                          for attempt in 1 2 3; do
+                              if docker pull "public.ecr.aws/docker/library/$img"; then pulled=true; break; fi
+                              sleep 15
+                          done
+                          if [ "$pulled" = true ]; then
+                              docker tag "public.ecr.aws/docker/library/$img" "$img"
+                              docker rmi "public.ecr.aws/docker/library/$img" >/dev/null
+                          else
+                              echo "::warning::could not pre-seed $img from the ECR mirror; wp-env will pull it from Docker Hub"
+                              complete=false
+                          fi
+                      done
+                      # Only cache a complete set so a partial failure is retried next run.
+                      if [ "$complete" = true ]; then docker save -o "$TAR" $IMAGES; fi
+                  fi
+                  docker image ls
+
             - name: Start WordPress Env
               id: wp-env
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 6
                   max_attempts: 3
+                  # Space the attempts out: Docker Hub's anonymous throttle window
+                  # outlives back-to-back retries, so waiting beats hammering.
+                  retry_wait_seconds: 90
                   retry_on: error
                   command: |
                       cd tests/pw

--- a/tests/pw/package-lock.json
+++ b/tests/pw/package-lock.json
@@ -10,12 +10,12 @@
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@faker-js/faker": "^10.0.0",
-                "@playwright/test": "^1.57.0",
+                "@playwright/test": "^1.60.0",
                 "@wordpress/env": "^10.20.0",
                 "dotenv": "^16.4.7",
                 "mysql2": "^3.13.0",
                 "php-serialize": "^5.1.2",
-                "playwright": "^1.57.0",
+                "playwright": "^1.60.0",
                 "zod": "^3.24.2"
             },
             "devDependencies": {
@@ -25,7 +25,7 @@
                 "@typescript-eslint/parser": "^8.26.1",
                 "eslint": "^9.22.0",
                 "eslint-config-prettier": "^10.1.1",
-                "eslint-plugin-playwright": "^2.2.0",
+                "eslint-plugin-playwright": "^2.10.4",
                 "js-yaml": "^4.1.0",
                 "prettier": "^3.5.3",
                 "ts-node": "^10.9.2",
@@ -1977,12 +1977,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-            "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.58.2"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -3738,13 +3738,13 @@
             }
         },
         "node_modules/eslint-plugin-playwright": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.5.1.tgz",
-            "integrity": "sha512-q7oqVQTTfa3VXJQ8E+ln0QttPGrs/XmSO1FjOMzQYBMYF3btih4FIrhEYh34JF184GYDmq3lJ/n7CMa49OHBvA==",
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.4.tgz",
+            "integrity": "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "globals": "^16.4.0"
+                "globals": "^17.3.0"
             },
             "engines": {
                 "node": ">=16.9.0"
@@ -3754,9 +3754,9 @@
             }
         },
         "node_modules/eslint-plugin-playwright/node_modules/globals": {
-            "version": "16.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5590,12 +5590,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.58.2"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -5608,9 +5608,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"

--- a/tests/pw/package.json
+++ b/tests/pw/package.json
@@ -70,7 +70,7 @@
         "@typescript-eslint/parser": "^8.26.1",
         "eslint": "^9.22.0",
         "eslint-config-prettier": "^10.1.1",
-        "eslint-plugin-playwright": "^2.2.0",
+        "eslint-plugin-playwright": "^2.10.4",
         "js-yaml": "^4.1.0",
         "prettier": "^3.5.3",
         "ts-node": "^10.9.2",
@@ -79,12 +79,12 @@
     },
     "dependencies": {
         "@faker-js/faker": "^10.0.0",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.60.0",
         "@wordpress/env": "^10.20.0",
         "dotenv": "^16.4.7",
         "mysql2": "^3.13.0",
         "php-serialize": "^5.1.2",
-        "playwright": "^1.57.0",
+        "playwright": "^1.60.0",
         "zod": "^3.24.2"
     }
 }

--- a/tests/pw/utils/generateQualityReport.js
+++ b/tests/pw/utils/generateQualityReport.js
@@ -114,6 +114,11 @@ const suiteShape = report => {
         passRate,
         durationMs: num(report.suite_duration),
         durationFormatted: report.suite_duration_formatted || formatDuration(report.suite_duration),
+        // Shard accounting from mergeSummaryReport — a shard that died before
+        // uploading its results makes the suite incomplete, not green.
+        mergedReports: num(report.merged_reports),
+        expectedReports: num(report.expected_reports),
+        missingReports: num(report.missing_reports),
     };
 };
 
@@ -155,7 +160,15 @@ if (combinedTotal > 0) {
 }
 
 const overallFailed = totals.failed > 0;
-const overallStatus = overallFailed ? 'failed' : 'passed';
+const missingReports = num(api?.missingReports) + num(e2e?.missingReports);
+const overallIncomplete = !overallFailed && missingReports > 0;
+const overallStatus = overallFailed ? 'failed' : overallIncomplete ? 'incomplete' : 'passed';
+const incompleteDescription = () => {
+    const parts = [];
+    if (num(api?.missingReports) > 0) parts.push(`API: ${api.mergedReports} of ${api.expectedReports} shard reports`);
+    if (num(e2e?.missingReports) > 0) parts.push(`E2E: ${e2e.mergedReports} of ${e2e.expectedReports} shard reports`);
+    return `Incomplete run — only ${parts.join(', ')} uploaded; totals under-count the suite`;
+};
 
 // ----------------------------------------------------------------------------
 // Artifacts (best-effort: list immediate subdirs under ARTIFACTS_DIR)
@@ -205,12 +218,14 @@ const placeholders = {
     DURATION: formatDuration(totals.durationMs),
     RUN_ID: runId,
 
-    STATUS_CLASS: overallFailed ? 'failed' : '',
-    STATUS_ICON: overallFailed ? '✕' : '✓',
-    STATUS_MESSAGE: overallFailed ? 'Tests failed' : 'All tests passed',
+    STATUS_CLASS: overallFailed || overallIncomplete ? 'failed' : '',
+    STATUS_ICON: overallFailed ? '✕' : overallIncomplete ? '!' : '✓',
+    STATUS_MESSAGE: overallFailed ? 'Tests failed' : overallIncomplete ? 'Incomplete run' : 'All tests passed',
     STATUS_DESCRIPTION: overallFailed
         ? `${totals.failed} failure${totals.failed === 1 ? '' : 's'} across the suite`
-        : 'Build is green and ready for review',
+        : overallIncomplete
+          ? incompleteDescription()
+          : 'Build is green and ready for review',
     PASS_RATE: fmtPct(totals.passRate),
 
     TOTAL_TESTS: fmtCount(totals.total),
@@ -221,8 +236,8 @@ const placeholders = {
     TOTAL_DURATION: formatDuration(totals.durationMs),
     TOTAL_COVERAGE: fmtPct(totalCoveragePct),
 
-    API_STATUS: api ? (api.failed > 0 ? 'Failed' : 'Passed') : 'No data',
-    API_STATUS_CLASS: api && api.failed > 0 ? 'failed' : '',
+    API_STATUS: api ? (api.failed > 0 ? 'Failed' : api.missingReports > 0 ? 'Incomplete' : 'Passed') : 'No data',
+    API_STATUS_CLASS: api && (api.failed > 0 || api.missingReports > 0) ? 'failed' : '',
     API_TOTAL: api ? fmtCount(api.total) : '—',
     API_PASSED: api ? fmtCount(api.passed) : '—',
     API_FAILED: api ? fmtCount(api.failed) : '—',
@@ -234,8 +249,8 @@ const placeholders = {
     API_PROGRESS_CLASS: api && api.failed > 0 ? 'failed' : '',
     API_TOTAL_RUN: api ? fmtCount(api.ran) : '—',
 
-    E2E_STATUS: e2e ? (e2e.failed > 0 ? 'Failed' : 'Passed') : 'No data',
-    E2E_STATUS_CLASS: e2e && e2e.failed > 0 ? 'failed' : '',
+    E2E_STATUS: e2e ? (e2e.failed > 0 ? 'Failed' : e2e.missingReports > 0 ? 'Incomplete' : 'Passed') : 'No data',
+    E2E_STATUS_CLASS: e2e && (e2e.failed > 0 || e2e.missingReports > 0) ? 'failed' : '',
     E2E_TOTAL: e2e ? fmtCount(e2e.total) : '—',
     E2E_PASSED: e2e ? fmtCount(e2e.passed) : '—',
     E2E_FAILED: e2e ? fmtCount(e2e.failed) : '—',
@@ -308,11 +323,14 @@ if (SUMMARY_FILE) {
 
     const statusBadge = overallFailed
         ? badge('✕  Tests failed', `${totals.failed} failure${totals.failed === 1 ? '' : 's'} · ${totals.passRate.toFixed(1)}% pass rate`, C.red, { labelColor: C.purplePrimary })
-        : badge('✓  All tests passed', `Build is green · ${totals.passRate.toFixed(1)}% pass rate`, C.teal, { labelColor: C.purplePrimary });
+        : overallIncomplete
+          ? badge('⚠  Incomplete run', `${missingReports} shard report${missingReports === 1 ? '' : 's'} missing · totals under-count the suite`, C.amber, { labelColor: C.purplePrimary })
+          : badge('✓  All tests passed', `Build is green · ${totals.passRate.toFixed(1)}% pass rate`, C.teal, { labelColor: C.purplePrimary });
 
     const suiteStatusBadge = (s) => {
-        if (!s)            return badge('No data', '—', C.gray);
-        if (s.failed > 0)  return badge('Failed', `${s.failed} failure${s.failed === 1 ? '' : 's'}`, C.red);
+        if (!s)                    return badge('No data', '—', C.gray);
+        if (s.failed > 0)          return badge('Failed', `${s.failed} failure${s.failed === 1 ? '' : 's'}`, C.red);
+        if (s.missingReports > 0)  return badge('Incomplete', `${s.mergedReports} of ${s.expectedReports} shards reported`, C.amber);
         return badge('Passed', `${s.passRate.toFixed(1)}% pass rate`, C.green);
     };
 

--- a/tests/pw/utils/gitTestSummary.ts
+++ b/tests/pw/utils/gitTestSummary.ts
@@ -47,6 +47,7 @@ const fmtPct = value => (value === null || value === undefined ? '—' : `${num(
 const verdictBadge = result => {
     if (!result) return '⚪️ No data';
     if (result.failed > 0) return '🔴 Failed';
+    if (num(result.missing_reports) > 0) return '🟠 Incomplete';
     return '🟢 Passed';
 };
 
@@ -115,16 +116,36 @@ const buildOverallBanner = (core, results) => {
             acc.passed += num(r.passed);
             acc.failed += num(r.failed);
             acc.skipped += num(r.skipped);
+            acc.missing += num(r.missing_reports);
             return acc;
         },
-        { total: 0, passed: 0, failed: 0, skipped: 0 },
+        { total: 0, passed: 0, failed: 0, skipped: 0, missing: 0 },
     );
 
-    const status = totals.failed > 0 ? '🔴 **Failed**' : '🟢 **Passed**';
+    const status = totals.failed > 0 ? '🔴 **Failed**' : totals.missing > 0 ? '🟠 **Incomplete**' : '🟢 **Passed**';
     const ran = totals.passed + totals.failed;
     const rate = ran === 0 ? '—' : `${((totals.passed / ran) * 100).toFixed(1)}%`;
 
-    core.summary.addRaw(`> ${status} &nbsp;·&nbsp; **${totals.passed.toLocaleString()} / ${totals.total.toLocaleString()}** tests passed &nbsp;·&nbsp; pass rate **${rate}**`).addEOL().addEOL();
+    // Spell the arithmetic out (total = passed + failed + skipped; pass rate is
+    // over the tests that ran) so the numbers reconcile at a glance.
+    core.summary
+        .addRaw(
+            `> ${status} &nbsp;·&nbsp; **${totals.passed.toLocaleString()} / ${totals.total.toLocaleString()}** tests passed (${totals.failed.toLocaleString()} failed, ${totals.skipped.toLocaleString()} skipped) &nbsp;·&nbsp; pass rate **${rate}** of the ${ran.toLocaleString()} tests run`,
+        )
+        .addEOL()
+        .addEOL();
+
+    // A shard that dies before uploading its results would otherwise just
+    // shrink the totals silently — call it out instead of reporting green.
+    results.forEach(r => {
+        if (!r || num(r.missing_reports) === 0) return;
+        core.summary
+            .addRaw(
+                `> ⚠️ **${r.suite_name || 'Suite'} results are incomplete:** only ${num(r.merged_reports)} of ${num(r.expected_reports)} shard reports were uploaded — a shard job died before finishing (e.g. environment start failure), so the totals above under-count the suite. Check the failed jobs on this run.`,
+            )
+            .addEOL()
+            .addEOL();
+    });
 };
 
 const buildSuiteTable = (core, rows) => {

--- a/tests/pw/utils/mergeCoverageSummary.ts
+++ b/tests/pw/utils/mergeCoverageSummary.ts
@@ -74,8 +74,12 @@ const findReports = (dir: string): void => {
         if (isDirectory) {
             findReports(fullPath); // Recurse into all directories
         } else if (file === 'coverage.json') {
-            // Push the file path if it matches REPORT_TYPE
-            if (fullPath.includes(`${path.sep}${REPORT_TYPE}${path.sep}`)) {
+            // Only consume coverage from this suite's own shard artifacts
+            // (all-reports/test-artifact-<REPORT_TYPE>*). See the matching
+            // guard in mergeSummaryReport.ts — the api job's setup run writes
+            // files under playwright-report/e2e/ into test-artifact-api, which
+            // a bare path-segment match would wrongly merge into e2e results.
+            if (fullPath.includes(`test-artifact-${REPORT_TYPE}`) && fullPath.includes(`${path.sep}${REPORT_TYPE}${path.sep}`)) {
                 console.log(`Matched file: ${fullPath}`);
                 reportPaths.push(fullPath);
             }

--- a/tests/pw/utils/mergeSummaryReport.ts
+++ b/tests/pw/utils/mergeSummaryReport.ts
@@ -104,8 +104,16 @@ const findReports = (dir: string): void => {
         if (isDirectory) {
             findReports(fullPath); // Recurse into all directories
         } else if (file === 'results.json') {
-            // Push the file path if it matches REPORT_TYPE
-            if (fullPath.includes(`${path.sep}${REPORT_TYPE}${path.sep}`)) {
+            // Only consume summaries from this suite's own shard artifacts
+            // (all-reports/test-artifact-<REPORT_TYPE>*). Matching any path that
+            // contains the report type is not enough: every job (including the
+            // api job) runs the site/auth/env setup projects via
+            // playwright.config.ts, whose summary reporter writes to
+            // playwright-report/e2e/summary-report/results.json. The e2e shard
+            // run overwrites that file, but the api job never does — so its
+            // setup-run summary ships inside test-artifact-api and used to be
+            // merged as a 13th e2e shard, inflating the merged totals.
+            if (fullPath.includes(`test-artifact-${REPORT_TYPE}`) && fullPath.includes(`${path.sep}${REPORT_TYPE}${path.sep}`)) {
                 console.log(`Matched file: ${fullPath}`);
                 reportPaths.push(fullPath);
             }

--- a/tests/pw/utils/mergeSummaryReport.ts
+++ b/tests/pw/utils/mergeSummaryReport.ts
@@ -16,6 +16,9 @@ interface TestReport {
     suite_duration: number;
     suite_duration_formatted?: string;
     all_suite_durations: number[];
+    merged_reports?: number;
+    expected_reports?: number | null;
+    missing_reports?: number;
     tests: string[];
     passed_tests: string[];
     failed_tests: string[];
@@ -128,8 +131,40 @@ if (reportPaths.length === 0) {
     process.exit(1);
 }
 
+// Detect shards that never reported. Every shard writes
+// playwright/shard-features.json (with shardTotal) BEFORE its tests start,
+// and results.json only AFTER they finish — so when a shard job dies early
+// (e.g. wp-env never starts), the surviving manifests still tell us how many
+// reports to expect. Without this check a dead shard silently shrinks the
+// merged totals while the report stays green.
+const findExpectedShards = (dir: string): number => {
+    let expected = 0;
+    const files = fs.readdirSync(dir);
+    files.forEach(file => {
+        const fullPath = path.join(dir, file);
+        if (fs.statSync(fullPath).isDirectory()) {
+            expected = Math.max(expected, findExpectedShards(fullPath));
+        } else if (file === 'shard-features.json' && fullPath.includes(`test-artifact-${REPORT_TYPE}`)) {
+            try {
+                const manifest = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+                expected = Math.max(expected, Number(manifest.shardTotal) || 0);
+            } catch (e) {
+                console.warn(`Could not parse ${fullPath}: ${e.message}`);
+            }
+        }
+    });
+    return expected;
+};
+const expectedReports = findExpectedShards(reportsFolder) || Number(process.env.EXPECTED_SHARDS) || 0;
+
 // Merge reports
 const mergedReport = mergeReports(reportPaths);
+mergedReport.merged_reports = reportPaths.length;
+mergedReport.expected_reports = expectedReports > 0 ? expectedReports : null;
+mergedReport.missing_reports = expectedReports > 0 ? Math.max(0, expectedReports - reportPaths.length) : 0;
+if (mergedReport.missing_reports > 0) {
+    console.warn(`WARNING: only ${reportPaths.length} of ${expectedReports} ${REPORT_TYPE} shard reports found — merged totals under-count the suite.`);
+}
 
 // Save the merged report
 const outputPath = './all-reports/merged-summary.json';


### PR DESCRIPTION
The api job runs docker:setup through playwright.config.ts, whose summary reporter writes a 76-test setup-run summary (75 passed + 1 skipped) to playwright-report/e2e/summary-report/results.json. In e2e shard jobs the real test run overwrites that file, but the api job never does, so test-artifact-api shipped it and mergeSummaryReport.ts (which matched any results.json with /e2e/ in its path) merged it as a 13th e2e shard. This inflated the merged report by exactly those 76 tests, e.g. run 27250752607 reported 2,139 e2e tests while the suite at that commit has 2,063.

- mergeSummaryReport.ts / mergeCoverageSummary.ts: only consume reports from the suite's own test-artifact-<REPORT_TYPE>* artifact directories
- e2e_api_tests.yml: exclude playwright-report/e2e/** from the api job artifact, which also keeps its setup-run blob report out of the merged HTML report

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes #


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

*Title*

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test reports and coverage merging now exclude setup/infrastructure artifacts, correctly detect missing shard uploads, and surface “Incomplete” status with descriptive warnings.
* **Chores**
  * CI reliability improved by pre-seeding and caching test images with retry logic.
  * Playwright-related dev/runtime packages updated to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->