### PR TITLE
fix: load admin dashboard on non-Latin locales (e.g. Persian) via page slug

### DIFF
--- a/includes/Admin/Dashboard/Dashboard.php
+++ b/includes/Admin/Dashboard/Dashboard.php
@@ -552,9 +552,7 @@ class Dashboard implements Hookable {
      * @return void
      */
     public function enqueue_scripts() {
-        $screen = get_current_screen();
-
-        if ( $screen->id !== 'toplevel_page_dokan' && $screen->id !== 'dokan_page_dokan-dashboard' ) {
+        if ( ! $this->is_dokan_admin_page( [ 'dokan', 'dokan-dashboard' ] ) ) {
             return;
         }
 
@@ -578,6 +576,24 @@ class Dashboard implements Hookable {
     }
 
     /**
+     * Check whether the current admin request targets one of the given Dokan pages.
+     *
+     * Matches the locale-stable `page` slug rather than the screen id, whose prefix
+     * is derived from the translatable menu title and breaks on non-Latin locales.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array<string> $page_slugs Admin page slugs to match against.
+     *
+     * @return bool
+     */
+    protected function is_dokan_admin_page( array $page_slugs ): bool {
+        global $plugin_page;
+
+        return is_string( $plugin_page ) && in_array( $plugin_page, $page_slugs, true );
+    }
+
+    /**
      * Runs before admin notices action and hides them.
      *
      * @since 4.1.0
@@ -585,8 +601,7 @@ class Dashboard implements Hookable {
      * @return void
      */
     public function inject_before_notices(): void {
-        $screen = get_current_screen();
-        if ( ! $screen || ( $screen->id !== 'dokan_page_dokan-dashboard' ) ) {
+        if ( ! $this->is_dokan_admin_page( [ 'dokan-dashboard' ] ) ) {
             return;
         }
 
@@ -607,8 +622,7 @@ class Dashboard implements Hookable {
      * @return void
      */
     public function inject_after_notices(): void {
-        $screen = get_current_screen();
-        if ( ! $screen || ( $screen->id !== 'dokan_page_dokan-dashboard' ) ) {
+        if ( ! $this->is_dokan_admin_page( [ 'dokan-dashboard' ] ) ) {
             return;
         }
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

The new React **Admin Dashboard** (`?page=dokan-dashboard`) rendered a permanent **"Loading…"** and never mounted when the site language translated the top-level **Dokan** menu title to a non-Latin string — most visibly **Persian (fa_IR)**.

`Dashboard::enqueue_scripts()` (and `inject_before/after_notices()`) gated on a **hard-coded** screen id `dokan_page_dokan-dashboard`. For a submenu page WordPress derives that prefix from `sanitize_title( <top-level menu title> )`. The title is the translatable `__( 'Dokan', 'dokan-lite' )`, so in Persian it is `دکان` → `sanitize_title()` → `%d8%af%da%a9%d8%a7%d9%86`, making the real screen id `%d8%af…_page_dokan-dashboard`. The `!==` guard then matched nothing → early `return` → **no dashboard scripts were enqueued** → React never mounted. (Arabic works only because the brand stays untranslated, so its prefix stays `dokan`.)

**Fix:** match the locale-independent `page` slug via WordPress's own `$plugin_page` global instead of the translated screen id, through a small helper:

```php
protected function is_dokan_admin_page( array $page_slugs ): bool {
    global $plugin_page;
    return is_string( $plugin_page ) && in_array( $plugin_page, $page_slugs, true );
}
```

- `enqueue_scripts()` → `is_dokan_admin_page( [ 'dokan', 'dokan-dashboard' ] )` (preserves the previous `toplevel_page_dokan` + dashboard scope)
- `inject_before_notices()` / `inject_after_notices()` → `is_dokan_admin_page( [ 'dokan-dashboard' ] )` (scope unchanged)

`$plugin_page` is set by core in `wp-admin/admin.php` (from `$_GET['page']`, `wp_unslash()` + `plugin_basename()`-d) **before** `admin_enqueue_scripts`/`admin_notices` fire, and core itself routes admin pages with it — so it is authoritative and locale-independent. All `'toplevel_page_dokan'` checks elsewhere are already locale-stable (top-level hook uses the menu *slug*, not the title) and are left untouched.

### Related Pull Request(s)

* Pro follow-up (same pattern in `includes/Assets.php` and `modules/seller-badge/includes/Admin/Hooks.php`) — to be filed in `getdokan/dokan-pro`.

### Closes

* Closes getdokan/plugin-internal-tasks#1985
* Ref getdokan/dokan-pro#5342

### How to test the changes in this Pull Request:

1. **Settings → General → Site Language → Persian (فارسی)** (install the language pack if prompted), Save.
2. Visit **WP Admin → Dokan → Dashboard** (`?page=dokan-dashboard`).
   - **Before:** stuck on "Loading…"; `window.dokanAdminDashboard` is `undefined`; the `dokan-admin-dashboard.js` bundle is not on the page.
   - **After:** the dashboard mounts and renders fully (RTL).
3. Confirm **English** and **Arabic** still work, and the legacy `?page=dokan` page is unaffected.

### Changelog entry

*Title*

Fix: Admin dashboard fails to load on non-Latin site languages (e.g. Persian)

Detailed Description of the pull request:
Previously the new admin dashboard showed a permanent "Loading…" when the site language translated the Dokan menu title to a non-Latin string, because the script-enqueue guard compared against a hard-coded screen id whose prefix is derived from that translated title. Now the dashboard detects its page via the locale-independent `page` slug, so it loads correctly in every language.

### Before Changes

Persian site language: `?page=dokan-dashboard` stays on "Loading…"; none of the dashboard bundles are enqueued; the `<body>` screen-id class is `%d8%af…_page_dokan-dashboard` (percent-encoded translated menu title).

### After Changes

Persian site language: the dashboard mounts and renders fully in RTL — header, To-Do cards, Analytics, and Monthly Overview all display correctly.

### PR Self Review Checklist:

* [x] Code follows code style guidelines
* [x] Good naming, self-explanatory
* [x] KISS — minimal, single-purpose helper
* [x] DRY — one helper reused across the three guards
* [x] Readable, no deep nesting
* [x] No performance concerns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for identifying Dokan admin pages, making the system more maintainable and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->