### PR TITLE
fix(settings): schema validator allow-list + unique captcha credential group IDs

### DIFF
--- a/includes/Admin/Settings/Schema/SchemaValidator.php
+++ b/includes/Admin/Settings/Schema/SchemaValidator.php
@@ -183,6 +183,13 @@ class SchemaValidator {
         'single_product_preview',
         'textarea',
         'withdraw_schedule',
+        'collapsible_switch',
+        'biweekly_week_pair',
+        'quarter_anchor_month',
+        'color_customizer',
+        'delivery_days',
+        'google_auth',
+        'verification_methods',
     ];
 
     /**
@@ -217,7 +224,10 @@ class SchemaValidator {
     public function validate( array $elements ): array {
         // Skip validation if disabled via constant.
         if ( defined( 'DOKAN_DISABLE_SCHEMA_VALIDATION' ) && DOKAN_DISABLE_SCHEMA_VALIDATION ) {
-            return [ 'errors' => [], 'warnings' => [] ];
+            return [
+				'errors' => [],
+				'warnings' => [],
+			];
         }
 
         /**
@@ -232,7 +242,10 @@ class SchemaValidator {
          * @param array $elements The schema elements about to be validated.
          */
         if ( apply_filters( 'dokan_admin_settings_schema_skip_validation', false, $elements ) ) {
-            return [ 'errors' => [], 'warnings' => [] ];
+            return [
+				'errors' => [],
+				'warnings' => [],
+			];
         }
 
         $this->errors   = [];

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -550,7 +550,8 @@ class SettingsSchema {
                 'type'        => 'subpage',
                 'page_id'     => 'transaction',
                 'title'       => esc_html__( 'Fees', 'dokan-lite' ),
-                'description' => esc_html__( 'Configure how different types of fees are distributed between vendors and admin', 'dokan-lite' ),                'priority'    => 100,
+                'description' => esc_html__( 'Configure how different types of fees are distributed between vendors and admin', 'dokan-lite' ),
+				'priority' => 100,
             ],
             [
                 'id'         => 'fees',
@@ -807,7 +808,8 @@ class SettingsSchema {
                 'type'        => 'subpage',
                 'page_id'     => 'transaction',
                 'title'       => esc_html__( 'Withdraw', 'dokan-lite' ),
-                'description' => esc_html__( 'Set up available withdrawal methods and transaction conditions for vendors.', 'dokan-lite' ),                'priority'    => 300,
+                'description' => esc_html__( 'Set up available withdrawal methods and transaction conditions for vendors.', 'dokan-lite' ),
+				'priority' => 300,
                 'doc_link'    => 'https://dokan.co/docs/wordpress/withdraw/',
             ],
             [
@@ -2571,11 +2573,52 @@ class SettingsSchema {
 					],
                 ],
             ],
+            // Group container for the card's credential fields. A dedicated
+            // `fieldgroup` (not the switch field itself) so `field_group_id`
+            // resolves to a real group element; the switch stays `type: field`
+            // to keep its legacy_key bridging and single-option storage. Carries
+            // the provider show/hide dependencies so credentials hide unless
+            // reCAPTCHA v3 is the selected provider.
+            [
+                'id'           => 'recaptcha_credentials_group',
+                'type'         => 'fieldgroup',
+                'section_id'   => 'captcha_section',
+                'dependencies' => [
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'google_recaptcha_v3',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'google_recaptcha_v3',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                ],
+            ],
             [
                 'id'             => 'recaptcha_admin_notice',
                 'type'           => 'field',
                 'variant'        => 'info',
-                'field_group_id' => 'recaptcha_validation_label',
+                'field_group_id' => 'recaptcha_credentials_group',
                 'show_icon'      => true,
                 'title'          => esc_html__( 'You can get your Site Key and Secret Key from your reCAPTCHA admin console.', 'dokan-lite' ),
                 'link_title'     => esc_html__( 'Admin Console', 'dokan-lite' ),
@@ -2585,7 +2628,7 @@ class SettingsSchema {
                 'id'             => 'recaptcha_site_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
-                'field_group_id' => 'recaptcha_validation_label',
+                'field_group_id' => 'recaptcha_credentials_group',
                 'title'          => esc_html__( 'Site Key', 'dokan-lite' ),
                 'placeholder'    => esc_html__( 'Site Key', 'dokan-lite' ),
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 site key.', 'dokan-lite' ),
@@ -2599,7 +2642,7 @@ class SettingsSchema {
                 'id'             => 'recaptcha_secret_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
-                'field_group_id' => 'recaptcha_validation_label',
+                'field_group_id' => 'recaptcha_credentials_group',
                 'title'          => esc_html__( 'Secret Key', 'dokan-lite' ),
                 'placeholder'    => esc_html__( 'Secret Key', 'dokan-lite' ),
                 'tooltip'        => esc_html__( 'Insert Google reCAPTCHA v3 secret key.', 'dokan-lite' ),
@@ -2670,11 +2713,52 @@ class SettingsSchema {
 					],
                 ],
             ],
+            // Group container for the card's credential fields. A dedicated
+            // `fieldgroup` (not the switch field itself) so `field_group_id`
+            // resolves to a real group element; the switch stays `type: field`
+            // to keep its legacy_key bridging and single-option storage. Carries
+            // the provider show/hide dependencies so credentials hide unless
+            // Turnstile is the selected provider.
+            [
+                'id'           => 'turnstile_credentials_group',
+                'type'         => 'fieldgroup',
+                'section_id'   => 'captcha_section',
+                'dependencies' => [
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_enable_status',
+						'value' => 'on',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'cloudflare_turnstile',
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+                    [
+						'key' => 'captcha_provider',
+						'value' => 'cloudflare_turnstile',
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+                ],
+            ],
             [
                 'id'             => 'turnstile_admin_notice',
                 'type'           => 'field',
                 'variant'        => 'info',
-                'field_group_id' => 'turnstile_validation_label',
+                'field_group_id' => 'turnstile_credentials_group',
                 'show_icon'      => true,
                 'title'          => esc_html__( 'You can get your Site Key and Secret Key from your Cloudflare Turnstile dashboard.', 'dokan-lite' ),
                 'link_title'     => esc_html__( 'Turnstile Dashboard', 'dokan-lite' ),
@@ -2684,7 +2768,7 @@ class SettingsSchema {
                 'id'             => 'turnstile_site_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
-                'field_group_id' => 'turnstile_validation_label',
+                'field_group_id' => 'turnstile_credentials_group',
                 'title'          => esc_html__( 'Site Key', 'dokan-lite' ),
                 'placeholder'    => esc_html__( 'Site Key', 'dokan-lite' ),
                 'tooltip'        => esc_html__( 'Insert Cloudflare Turnstile site key.', 'dokan-lite' ),
@@ -2698,7 +2782,7 @@ class SettingsSchema {
                 'id'             => 'turnstile_secret_key',
                 'type'           => 'field',
                 'variant'        => 'show_hide',
-                'field_group_id' => 'turnstile_validation_label',
+                'field_group_id' => 'turnstile_credentials_group',
                 'title'          => esc_html__( 'Secret Key', 'dokan-lite' ),
                 'placeholder'    => esc_html__( 'Secret Key', 'dokan-lite' ),
                 'tooltip'        => esc_html__( 'Insert Cloudflare Turnstile secret key.', 'dokan-lite' ),


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Two fixes in the flat-array settings schema layer:

1. **Schema validator allow-list** — `SchemaValidator` rejected several field variants/types that the schema legitimately uses, causing false validation errors. Added the missing entries to the allowed list: `collapsible_switch`, `biweekly_week_pair`, `quarter_anchor_month`, `color_customizer`, `delivery_days`, `google_auth`, `verification_methods`.

2. **Unique field-group IDs for captcha credentials** — The reCAPTCHA and Turnstile credential fields (admin notice, site key, secret key) were parented to `*_validation_label`, which is not a real `fieldgroup` element. Introduced dedicated `fieldgroup` containers (`recaptcha_credentials_group`, `turnstile_credentials_group`) so `field_group_id` resolves to an actual group, and moved the provider show/hide dependencies onto those groups (credentials stay hidden unless the matching provider is selected). The enable switch stays `type: field` to preserve its `legacy_key` bridging and single-option storage.

Also fixed two malformed schema entries where `priority` was concatenated onto the same line as `description`.

### Related Pull Request(s)

* N/A

### Closes

* Closes #

### How to test the changes in this Pull Request:

1. Load the admin settings schema with validation enabled (no `DOKAN_DISABLE_SCHEMA_VALIDATION`).
2. Confirm no validation errors are raised for fields using the newly allow-listed variants/types.
3. Open **Settings → Moderation → Captcha**.
4. Enable captcha, select **reCAPTCHA v3** — only the reCAPTCHA credential fields show; select **Cloudflare Turnstile** — only the Turnstile credential fields show.
5. Save and confirm the keys persist (legacy bridge intact).

### Changelog entry

*Fix schema validator allow-list and unique captcha credential field-group IDs*

Previously the schema validator flagged several valid field variants/types as errors, and the reCAPTCHA/Turnstile credential fields were parented to non-existent group IDs. This PR adds the missing variants/types to the validator allow-list and wraps each provider's credential fields in a dedicated `fieldgroup` with the correct provider show/hide dependencies.

### Before Changes

Validator raised false errors for valid field types; captcha credential fields referenced non-existent group IDs.

### After Changes

Validator passes for all used field types; captcha credentials live under dedicated groups that show/hide by selected provider.

### PR Self Review Checklist:

* [x] Code follows code style guidelines
* [x] Good naming
* [x] KISS
* [x] DRY
* [x] Readable
* [x] No performance issues
