### PR TITLE
docs: document @since DOKAN_SINCE placeholder convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Services accessed via `dokan()->service_name` magic getter. Major services:
 - **JS/TS**: ESLint with `@wordpress/scripts` config
 - **CSS**: Stylelint
 - **TypeScript**: Strict mode, ESNext target, React-JSX
+- **`@since` for new code**: use the literal placeholder token `@since DOKAN_SINCE` (and `@deprecated DOKAN_SINCE` / `@version DOKAN_SINCE`) — the release tooling replaces it with the real version at tag time. Never hardcode or guess a version number (e.g. `@since 5.1.0`) for unreleased code.
 
 ## Key Patterns
 


### PR DESCRIPTION
## Summary

Adds a one-line note to the **Coding Standards** section of `CLAUDE.md` documenting that new/unreleased PHP code should use the `@since DOKAN_SINCE` placeholder token (matching the convention already used in dokan-pro), which the release tooling replaces with the real version at tag time.

## Why

dokan-lite currently has no `DOKAN_SINCE` usages and only literal `@since X.Y.Z` values, which invites guessing a version number for unreleased code. Documenting the placeholder convention prevents hardcoded/guessed versions (e.g. `@since 5.1.0`) in future contributions.

## Changes

- `CLAUDE.md`: add a Coding Standards bullet for `@since DOKAN_SINCE` (and `@deprecated`/`@version` variants).

Docs-only; no code or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for release metadata formatting in the coding standards.
  * New unreleased code should use the `@since DOKAN_SINCE`, `@deprecated DOKAN_SINCE`, and `@version DOKAN_SINCE` placeholders instead of hardcoded version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->