### PR TITLE
fix(e2e): enable add_new_attribute selling option before seeding attr…

### DIFF
--- a/tests/pw/tests/api/attributeTerms.spec.ts
+++ b/tests/pw/tests/api/attributeTerms.spec.ts
@@ -43,7 +43,7 @@ test.describe('attribute term api test', () => {
         const [response, responseBody] = await apiUtils.post(endPoints.createAttributeTerm(attributeId), { data: payloads.createAttributeTerm() });
         expect(response.ok()).toBeTruthy();
         expect(responseBody).toBeTruthy();
-        expect(responseBody).toMatchSchema(schemas.attributeTermsSchema.attributeTermSchema);
+        expect(responseBody).toMatchSchema(schemas.attributeTermsSchema.attributeTermDropdownSchema);
     });
 
     test('update an attribute term', { tag: ['@lite'] }, async () => {

--- a/tests/pw/tests/e2e/_env.setup.ts
+++ b/tests/pw/tests/e2e/_env.setup.ts
@@ -99,6 +99,12 @@ setup.describe('setup woocommerce settings', () => {
         // create attribute, attribute term
         const [, attributeId] = await apiUtils.createAttribute({ name: 'sizes' });
         helpers.createEnvVar('ATTRIBUTE_ID', attributeId);
+        // Dokan 5.0.5 gates attribute-term creation behind the dokan_selling `add_new_attribute`
+        // option (ProductAttributeController::create_attribute_term_permissions_check → 403 otherwise).
+        // The canonical selling settings (which enable it) are applied later in setup; apply the full
+        // set here via setOptionValue so the option row exists on a fresh DB. updateOptionValue would
+        // read-then-merge and crash (`undefined.option_value`) when the row is absent.
+        await dbUtils.setOptionValue(dbData.dokan.optionName.selling, dbData.dokan.sellingSettings);
         await apiUtils.createAttributeTerm(attributeId, { name: 's' });
         await apiUtils.createAttributeTerm(attributeId, { name: 'l' });
         await apiUtils.createAttributeTerm(attributeId, { name: 'm' });

--- a/tests/pw/utils/schemas.ts
+++ b/tests/pw/utils/schemas.ts
@@ -963,6 +963,16 @@ const attributeTermSchema = z.object({
     _links: linksSchema,
 });
 
+// Dokan 5.0.5: the list (get-all) and create term endpoints return a slim "dropdown"
+// shape ({ id, name, value, label }) for the React product editor, while get-single,
+// update, delete and batch still return the full WC term shape (attributeTermSchema).
+const attributeTermDropdownSchema = z.object({
+    id: z.string().or(z.number()),
+    name: z.string(),
+    value: z.string().or(z.number()),
+    label: z.string(),
+});
+
 const abuseReportSchema = z.object({
     id: z.string().or(z.number()),
     reason: z.string(),
@@ -1695,10 +1705,11 @@ export const schemas = {
 
     // attribute terms schema
     attributeTermsSchema: {
-        attributeTermSchema: attributeTermSchema,
-        attributeTermsSchema: z.array(attributeTermSchema),
+        attributeTermSchema: attributeTermSchema, // get-single, update, delete (full WC shape)
+        attributeTermDropdownSchema: attributeTermDropdownSchema, // create (slim dropdown shape)
+        attributeTermsSchema: z.array(attributeTermDropdownSchema), // get-all returns slim dropdown items
         batchUpdateAttributesSchema: z.object({
-            update: z.array(attributeTermSchema),
+            update: z.array(attributeTermSchema), // batch update returns full WC shape
         }),
     },
 


### PR DESCRIPTION
…ibute terms

Dokan 5.0.5 added ProductAttributeController::create_attribute_term_permissions_check, which returns 403 dokan_rest_cannot_create unless the dokan_selling 'add_new_attribute' option is on. The 'add attributes' setup creates terms before 'admin set dokan selling settings' applies that option, so enable it inline first to keep e2e setup green.

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes #


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

*Title*

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test setup reliability for creating attribute terms by ensuring Dokan selling settings are written to the database in advance, preventing failures when required options aren’t present yet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->