### PR TITLE
fix: Enforce per-product ownership on v3 products batch endpoint.

### DIFF
--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -68,13 +68,30 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             return new WP_Error( 'dokan_rest_cannot_edit', __( 'You do not have permission to edit products.', 'dokan-lite' ), [ 'status' => 403 ] );
         }
 
-        $product_id = $request->get_param( 'id' );
-
-        if ( $product_id && ! dokan_is_product_author( $product_id ) ) {
+        if ( ! $this->check_ownership( $request ) ) {
             return new WP_Error( 'dokan_rest_cannot_view', __( 'You do not have permission to view/edit this product.', 'dokan-lite' ), [ 'status' => 403 ] );
         }
 
         return true;
+    }
+
+    /**
+     * Whether the current user owns the product targeted by the request.
+     *
+     * Centralizes the per-product authorship gate shared by the update and delete
+     * permission checks. A request without an `id` has no product to own, so it
+     * passes here and the capability check stays the gate.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     *
+     * @return bool
+     */
+    protected function check_ownership( $request ): bool {
+        $product_id = $request->get_param( 'id' );
+
+        return ! $product_id || dokan_is_product_author( $product_id );
     }
 
     /**
@@ -128,9 +145,7 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             return new WP_Error( 'dokan_rest_cannot_delete', __( 'You do not have permission to delete products.', 'dokan-lite' ), [ 'status' => 403 ] );
         }
 
-        $product_id = $request->get_param( 'id' );
-
-        if ( $product_id && ! dokan_is_product_author( $product_id ) ) {
+        if ( ! $this->check_ownership( $request ) ) {
             return new WP_Error( 'dokan_rest_cannot_delete', __( 'You do not have permission to delete this product.', 'dokan-lite' ), [ 'status' => 403 ] );
         }
 

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -95,6 +95,49 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
     }
 
     /**
+     * Check ownership before a batched product update.
+     *
+     * WooCommerce's WC_REST_Controller::batch_items() calls this once per "update"
+     * item, so this — not the route-level batch_items_permissions_check() — is where
+     * a vendor is stopped from editing another vendor's product.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     *
+     * @return true|WP_Error
+     */
+    public function update_item_permissions_check( $request ) {
+        return $this->check_permission( $request );
+    }
+
+    /**
+     * Check ownership before a batched product delete.
+     *
+     * Mirrors update_item_permissions_check(); the batch route is the only delete
+     * path the v3 controller exposes, so the ownership gate must live here.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Full details about the request.
+     *
+     * @return true|WP_Error
+     */
+    public function delete_item_permissions_check( $request ) {
+        if ( ! current_user_can( 'dokan_delete_product' ) ) {
+            return new WP_Error( 'dokan_rest_cannot_delete', __( 'You do not have permission to delete products.', 'dokan-lite' ), [ 'status' => 403 ] );
+        }
+
+        $product_id = $request->get_param( 'id' );
+
+        if ( $product_id && ! dokan_is_product_author( $product_id ) ) {
+            return new WP_Error( 'dokan_rest_cannot_delete', __( 'You do not have permission to delete this product.', 'dokan-lite' ), [ 'status' => 403 ] );
+        }
+
+        return true;
+    }
+
+    /**
      * Bulk create, update and delete items.
      *
      * Resolves each item's payload through PayloadResolver before delegating

--- a/tests/php/src/REST/ProductControllerV3BatchAuthorizationTest.php
+++ b/tests/php/src/REST/ProductControllerV3BatchAuthorizationTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\REST\ProductControllerV3;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Authorization tests for the v3 products batch endpoint.
+ *
+ * Validates the IDOR fix from getdokan/dokan-pro#5818 / getdokan/dokan#3288:
+ * a vendor must not be able to update or delete another vendor's product through
+ * the dokan/v3/products/batch route, while own-product batch operations keep
+ * working.
+ *
+ * @group dokan-product-controller-v3
+ * @group dokan-authorization
+ *
+ * @covers \WeDevs\Dokan\REST\ProductControllerV3::update_item_permissions_check
+ * @covers \WeDevs\Dokan\REST\ProductControllerV3::delete_item_permissions_check
+ * @covers \WeDevs\Dokan\REST\ProductControllerV3::batch_items_permissions_check
+ */
+class ProductControllerV3BatchAuthorizationTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v3';
+
+    /**
+     * Product owned by seller_id1 (vendor A).
+     *
+     * @var int
+     */
+    protected int $product_a;
+
+    /**
+     * Product owned by seller_id2 (vendor B).
+     *
+     * @var int
+     */
+    protected int $product_b;
+
+    /**
+     * Setup test environment.
+     *
+     * @return void
+     */
+    public function set_up() {
+        parent::set_up();
+
+        // Ensure the v3 controller routes are registered against this server.
+        $controller = new ProductControllerV3();
+        $controller->register_routes();
+
+        $this->product_a = $this->factory()->product
+            ->set_seller_id( $this->seller_id1 )
+            ->create(
+                [
+					'name' => 'Vendor A Product',
+					'regular_price' => '10',
+				]
+            );
+
+        $this->product_b = $this->factory()->product
+            ->set_seller_id( $this->seller_id2 )
+            ->create(
+                [
+					'name' => 'Vendor B Product',
+					'regular_price' => '20',
+				]
+            );
+    }
+
+    /**
+     * Dispatch a JSON batch request, mirroring a real REST client.
+     *
+     * @param array $body Batch body (create/update/delete arrays).
+     *
+     * @return WP_REST_Response
+     */
+    protected function batch_request( array $body ): WP_REST_Response {
+        $request = new WP_REST_Request( 'POST', '/dokan/v3/products/batch' );
+        $request->add_header( 'Content-Type', 'application/json' );
+        $request->set_body( wp_json_encode( $body ) );
+
+        return $this->server->dispatch( $request );
+    }
+
+    /**
+     * Vendor A cannot update Vendor B's product through batch update.
+     *
+     * @return void
+     */
+    public function test_vendor_cannot_batch_update_another_vendors_product(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->batch_request(
+            [
+                'update' => [
+                    [
+						'id' => $this->product_b,
+						'regular_price' => '1.00',
+					],
+                ],
+            ]
+        );
+
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey( 'update', $data, 'Batch response should contain an update section.' );
+        $this->assertArrayHasKey( 'error', $data['update'][0], 'Cross-vendor update item must carry an error.' );
+        $this->assertSame( 403, $data['update'][0]['error']['data']['status'], 'Cross-vendor update must be rejected with 403.' );
+
+        // The target product must remain untouched.
+        $product_b = wc_get_product( $this->product_b );
+        $this->assertSame( '20', $product_b->get_regular_price(), 'Vendor B product price must be unchanged.' );
+    }
+
+    /**
+     * Vendor A cannot delete Vendor B's product through batch delete.
+     *
+     * @return void
+     */
+    public function test_vendor_cannot_batch_delete_another_vendors_product(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->batch_request(
+            [
+                'delete' => [ $this->product_b ],
+            ]
+        );
+
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey( 'delete', $data, 'Batch response should contain a delete section.' );
+        $this->assertArrayHasKey( 'error', $data['delete'][0], 'Cross-vendor delete item must carry an error.' );
+        $this->assertSame( 403, $data['delete'][0]['error']['data']['status'], 'Cross-vendor delete must be rejected with 403.' );
+
+        // The target product must still exist.
+        $this->assertInstanceOf( \WC_Product::class, wc_get_product( $this->product_b ), 'Vendor B product must still exist.' );
+        $this->assertSame( 'publish', get_post_status( $this->product_b ), 'Vendor B product must not be trashed/deleted.' );
+    }
+
+    /**
+     * Vendor A can still update their OWN product (no regression).
+     *
+     * @return void
+     */
+    public function test_vendor_can_batch_update_own_product(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->batch_request(
+            [
+                'update' => [
+                    [
+						'id' => $this->product_a,
+						'regular_price' => '9.99',
+					],
+                ],
+            ]
+        );
+
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey( 'update', $data );
+        $this->assertArrayNotHasKey( 'error', $data['update'][0], 'Own-product update must not error: ' . wp_json_encode( $data['update'][0]['error'] ?? null ) );
+        $this->assertSame( $this->product_a, $data['update'][0]['id'], 'Updated item id should match own product.' );
+
+        $product_a = wc_get_product( $this->product_a );
+        $this->assertSame( '9.99', $product_a->get_regular_price(), 'Own product price should be updated.' );
+    }
+
+    /**
+     * Vendor A can still delete their OWN product (no regression).
+     *
+     * @return void
+     */
+    public function test_vendor_can_batch_delete_own_product(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->batch_request(
+            [
+                'delete' => [ $this->product_a ],
+            ]
+        );
+
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey( 'delete', $data );
+        $this->assertArrayNotHasKey( 'error', $data['delete'][0], 'Own-product delete must not error: ' . wp_json_encode( $data['delete'][0]['error'] ?? null ) );
+    }
+
+    /**
+     * The batch update path must enforce the SAME ownership gate as the
+     * single-item update route — this is the asymmetry the fix closes.
+     *
+     * Vendor A attacking Vendor B's product must be rejected identically
+     * whether it goes through PUT /products/{id} or the batch route.
+     *
+     * @return void
+     */
+    public function test_batch_update_matches_single_item_route_for_cross_vendor(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        // Single-item route (the route that already had the ownership gate).
+        $single = new WP_REST_Request( 'PUT', "/dokan/v3/products/{$this->product_b}" );
+        $single->add_header( 'Content-Type', 'application/json' );
+        $single->set_body( wp_json_encode( [ 'regular_price' => '1.00' ] ) );
+        $single_response = $this->server->dispatch( $single );
+
+        $this->assertSame( 403, $single_response->get_status(), 'Single-item route must reject cross-vendor update.' );
+        $this->assertSame( 'dokan_rest_cannot_view', $single_response->get_data()['code'], 'Single-item route error code baseline.' );
+
+        // Batch route must now produce the SAME ownership rejection per item.
+        $batch_response = $this->batch_request(
+            [
+                'update' => [
+                    [
+						'id' => $this->product_b,
+						'regular_price' => '1.00',
+					],
+                ],
+            ]
+        );
+
+        $item = $batch_response->get_data()['update'][0];
+        $this->assertArrayHasKey( 'error', $item, 'Batch route must reject cross-vendor update.' );
+        $this->assertSame(
+            $single_response->get_data()['code'],
+            $item['error']['code'],
+            'Batch route must return the same ownership error as the single-item route (asymmetry closed).'
+        );
+        $this->assertSame( 403, $item['error']['data']['status'] );
+    }
+
+    /**
+     * Decisive IDOR test: even when the attacker's role carries WooCommerce's
+     * `edit_others_products` / `delete_others_products` meta-capabilities — so
+     * WooCommerce's own inherited per-item checks would ALLOW the cross-vendor
+     * write — Dokan's explicit ownership gate must still block it.
+     *
+     * This is the scenario where the missing gate was actually exploitable
+     * (elevated vendor roles / custom caps); on pre-fix code the update below
+     * succeeds, on fixed code it is rejected with Dokan's ownership error.
+     *
+     * @return void
+     */
+    public function test_batch_blocked_even_with_edit_others_capability(): void {
+        $attacker = get_user_by( 'id', $this->seller_id1 );
+        $attacker->add_cap( 'edit_others_products' );
+        $attacker->add_cap( 'edit_published_products' );
+        $attacker->add_cap( 'delete_others_products' );
+        $attacker->add_cap( 'delete_published_products' );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        // Cross-vendor UPDATE must still be blocked by Dokan's ownership gate.
+        $update = $this->batch_request(
+            [
+                'update' => [
+                    [
+						'id' => $this->product_b,
+						'regular_price' => '0.01',
+					],
+                ],
+            ]
+        );
+
+        $update_item = $update->get_data()['update'][0];
+        $this->assertArrayHasKey( 'error', $update_item, 'Even with edit_others_products, cross-vendor update must be blocked.' );
+        $this->assertSame( 'dokan_rest_cannot_view', $update_item['error']['code'], 'Dokan ownership gate (not WC meta-cap) must do the blocking.' );
+        $this->assertSame( 403, $update_item['error']['data']['status'] );
+        $this->assertSame( '20', wc_get_product( $this->product_b )->get_regular_price(), 'Victim product price must be unchanged.' );
+
+        // Cross-vendor DELETE must still be blocked by Dokan's ownership gate.
+        $delete = $this->batch_request(
+            [
+                'delete' => [ $this->product_b ],
+            ]
+        );
+
+        $delete_item = $delete->get_data()['delete'][0];
+        $this->assertArrayHasKey( 'error', $delete_item, 'Even with delete_others_products, cross-vendor delete must be blocked.' );
+        $this->assertSame( 'dokan_rest_cannot_delete', $delete_item['error']['code'], 'Dokan ownership gate must block the delete.' );
+        $this->assertSame( 403, $delete_item['error']['data']['status'] );
+        $this->assertSame( 'publish', get_post_status( $this->product_b ), 'Victim product must still exist.' );
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [ ] My code is tested — no automated test in this PR (see **Test scope**); manual REST steps provided
* [ ] My code passes the PHPCS tests — not run locally (dev deps absent); CI PHPCS will verify
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

**Problem** — automated WordPress.org security scan (`dokan-lite 5.0.6`), tracked as `getdokan/dokan-pro#5818`.

The `dokan/v3/products/batch` REST route authorized callers with a **capability-only** check — `batch_items_permissions_check()` → `current_user_can( 'dokan_edit_product' )` — whereas the single-item update route (`/products/(?P<id>)`) *also* verifies **ownership** via `check_permission()` → `dokan_is_product_author()`. The scanner flagged this asymmetry as a broken-authorization / IDOR risk: an authenticated vendor could submit **another vendor's** product ID in a batch `update`/`delete`.

**Root cause** — `batch_items()` delegates to `WC_REST_Controller::batch_items()`, which processes each item by calling the controller's *per-item* permission methods (`update_item_permissions_check()` / `delete_item_permissions_check()`). The v3 controller did not override them, so the batch path never ran Dokan's `dokan_is_product_author()` ownership gate that the single-item route enforces.

**How it's resolved** — add the two per-item overrides that WooCommerce's batch loop invokes:

| Method (new) | Gate applied per item |
|---|---|
| `update_item_permissions_check()` | delegates to existing `check_permission()` → `dokan_edit_product` **+ `dokan_is_product_author()`** |
| `delete_item_permissions_check()` | `dokan_delete_product` **+ `dokan_is_product_author()`** |

The route-level `batch_items_permissions_check()` is intentionally kept as the coarse capability "door" (with a clarifying comment); per-product ownership is now enforced **per item**, matching the single-item route. The `create` array is unchanged — new products are authored by the current vendor. Note the v3 controller exposes product deletion **only** through the batch route, so `delete_item_permissions_check()` is the sole ownership gate for deletes.

> Severity context: in a **default** Dokan install the cross-vendor write was already blocked, because WooCommerce's inherited per-item checks map to the `edit_others_products` / `delete_others_products` meta-capabilities that the `seller` role does not hold (and Dokan adds no product-level `map_meta_cap` override). This change makes the ownership boundary **explicit and self-contained** instead of relying on that WooCommerce internal — i.e. defense-in-depth + consistency + WordPress.org review compliance.

### Related Pull Request(s)

* N/A

### Closes

* https://github.com/getdokan/dokan-pro/issues/5818

### How to test the changes in this Pull Request:

**Setup:** two vendors **A** and **B**. Vendor **B** owns product `#PB`; vendor **A** owns product `#PA`. Authenticate to the REST API as **Vendor A**.

1. **Cross-vendor batch update → rejected**
   `POST /wp-json/dokan/v3/products/batch` body `{ "update": [ { "id": PB, "regular_price": "1.00" } ] }`
   → item returns **403** (`dokan_rest_cannot_view`); product `#PB` is **unchanged**.
2. **Cross-vendor batch delete → rejected**
   `POST /wp-json/dokan/v3/products/batch` body `{ "delete": [ PB ] }`
   → **403** (`dokan_rest_cannot_delete`); product `#PB` **still exists**.
3. **Own-product batch update → still works (no regression)**
   `{ "update": [ { "id": PA, "regular_price": "9.99" } ] }` → success; `#PA` updated.
4. **Own-product batch create/delete → still works** — batch `create` assigns Vendor A as author; batch `delete` of `#PA` succeeds.

### Test scope

* **Affected methods:** `ProductControllerV3::update_item_permissions_check()` *(new)*, `ProductControllerV3::delete_item_permissions_check()` *(new)*, `batch_items_permissions_check()` *(comment only)*.
* **Existing automated tests:** **none** — `tests/php/` has no coverage for `ProductControllerV3` / `dokan/v3/products` / the batch permission methods (verified by grep). Nothing to update or fix.
* **New automated tests:** **not included** in this PR (kept out per scope). Recommended follow-up — a PHPUnit case asserting: (a) Vendor A batch `update`/`delete` of Vendor B's product → `WP_Error` 403, and (b) Vendor A on own product → success. Happy to add on request.
* **Verified locally:** `php -l` clean. PHPCS could not run locally (dev dependencies not installed); the additions mirror the file's existing committed permission methods and Lite's CI PHPCS (changed-files) will confirm.

### Changelog entry

**Title:** Enforce per-product ownership on the v3 products batch REST endpoint

**Before:** `dokan/v3/products/batch` checked only the `dokan_edit_product` capability, while the single-item route also verified product ownership — so a vendor's batched `update`/`delete` items were not individually checked against `dokan_is_product_author()`.

**After:** every batched `update`/`delete` item is gated by ownership (`dokan_is_product_author()`; delete also requires `dokan_delete_product`), matching the single-item route and preventing cross-vendor product modification/deletion through the batch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for batch product update and delete requests with clear ownership enforcement.
  * Blocked cross-vendor batch updates/deletes from modifying prices or deleting other vendors’ products.
  * Improved permission error handling with HTTP 403 responses and consistent authorization error codes.
* **Tests**
  * Added PHPUnit coverage for batch update/delete authorization, including cross-vendor rejection, same-vendor success, and parity with single-item route errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->