### PR TITLE
refactor: render captcha provider cards as labels, drop per-provider toggle

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2512,13 +2512,14 @@ class SettingsSchema {
 					],
                 ],
             ],
-            // Provider card — collapsible switch (icon header + toggle). The
-            // toggle bridges to the legacy `recaptcha_enable_status` flag;
-            // credential fields nest below.
+            // Provider header — display-only label (logo + title + description,
+            // no toggle button). `default => 'on'` + legacy_key keep the legacy
+            // `recaptcha_enable_status` flag enabled; credential fields render in
+            // the group below.
             [
                 'id'            => 'recaptcha_validation_label',
                 'type'          => 'field',
-                'variant'       => 'collapsible_switch',
+                'variant'       => 'base_field_label',
                 'section_id'    => 'captcha_section',
                 'title'         => esc_html__( 'Google reCAPTCHA v3 Validation', 'dokan-lite' ),
                 'description'   => sprintf(
@@ -2653,12 +2654,13 @@ class SettingsSchema {
                 ],
             ],
 
-            // Provider card — Cloudflare Turnstile. Shown when that provider is
-            // selected; credential fields bridge to the legacy `turnstile_*` keys.
+            // Provider header — display-only label (no toggle button), shown when
+            // Turnstile is the selected provider. `default => 'on'` + legacy_key keep
+            // `turnstile_enable_status` enabled; credential fields render below.
             [
                 'id'            => 'turnstile_validation_label',
                 'type'          => 'field',
-                'variant'       => 'collapsible_switch',
+                'variant'       => 'base_field_label',
                 'section_id'    => 'captcha_section',
                 'title'         => esc_html__( 'Cloudflare Turnstile Validation', 'dokan-lite' ),
                 'description'   => sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress' coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

The **Google reCAPTCHA v3** and **Cloudflare Turnstile** provider cards in the new captcha settings (**Dokan → Settings → Moderation → Captcha**) rendered a `collapsible_switch` with a per-provider enable toggle. That toggle is redundant with the **Captcha Service** master switch and the **Captcha Provider** dropdown, so this PR renders both cards as `base_field_label` display-only headers (logo + title + description) — removing the toggle button.

- Both provider cards: `variant` `collapsible_switch` → `base_field_label`.
- Cards keep `default => 'on'` and their `legacy_key`, so the legacy `recaptcha_enable_status` / `turnstile_enable_status` flags stay enabled.
- Credential fields (Site Key / Secret Key) keep their existing fieldgroup gating (captcha enabled + provider selected) and now render directly below the header, without the per-provider toggle in between.

No functional change to whether captcha runs: `Manager::is_captcha_enabled()` already prefers the master `captcha_enable_status` flag and only falls back to the per-provider flag (default `on`).

> **Note:** verified locally with `php -l`, `composer phpcs` (clean), and a code review of the dependency/validator/save paths. The full PHPUnit suite (incl. `SettingsSchemaTest`) was not run locally (no Docker/wp-env here) — CI will exercise it. `base_field_label` is an existing variant already used elsewhere in the schema, so no JS rebuild is required.

### Closes

* Closes #

### How to test the changes in this Pull Request:

1. Go to **Dokan → Settings → Moderation → Captcha** (`admin.php?page=dokan#/settings`).
2. Enable **Captcha Service** and set **Captcha Provider** to *Google reCAPTCHA v3*.
3. The **Google reCAPTCHA v3 Validation** card now shows as a header (logo + title + description) with **no toggle button**; the **Site Key** / **Secret Key** fields appear below it.
4. Switch **Captcha Provider** to *Cloudflare Turnstile* — same behaviour for its card.
5. With valid keys, confirm captcha still validates on a supported form (e.g. the contact-seller form).

### Changelog entry

*Remove the redundant per-provider toggle from the captcha provider cards*

Previously the reCAPTCHA v3 and Cloudflare Turnstile cards in the captcha settings each had their own enable toggle, duplicating the master **Captcha Service** switch and the **Captcha Provider** dropdown. Those cards now render as display-only headers, with the Site Key / Secret Key fields shown directly beneath. Captcha enablement is governed by the master switch; the legacy per-provider flags remain `on` by default, so captcha behaviour is unchanged.

### Before Changes

The "Google reCAPTCHA v3 Validation" / "Cloudflare Turnstile Validation" cards showed a per-provider enable toggle on the right.

### After Changes

The cards render as display-only headers (no toggle); the Site Key / Secret Key fields appear directly below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
