### PR TITLE
fix(security): prevent admin DOM XSS via crafted Vue admin route parameter

### DIFF
--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -149,7 +149,8 @@ export default {
 
     methods: {
         getId() {
-            return this.$route.params.id;
+            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
+            return String( parseInt( this.$route.params.id, 10 ) || 0 );
         },
 
         showAlert( $title, $des, $status ) {

--- a/src/admin/pages/ReverseWithdrawalTransactions.vue
+++ b/src/admin/pages/ReverseWithdrawalTransactions.vue
@@ -225,7 +225,8 @@ export default {
 
     computed: {
         ID() {
-            return this.$route.params.store_id;
+            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
+            return String( parseInt( this.$route.params.store_id, 10 ) || 0 );
         },
 
         getCurrentPage() {

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -256,7 +256,8 @@ export default {
 
         // getId function has been used to identify whether is it vendor edit page or not
         getId() {
-            return this.$route.params.id;
+            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
+            return String( parseInt( this.$route.params.id, 10 ) || 0 );
         },
 
         onSelectBanner( image ) {

--- a/src/admin/pages/VendorPaymentFields.vue
+++ b/src/admin/pages/VendorPaymentFields.vue
@@ -170,7 +170,8 @@ export default {
         },
 
         getId() {
-            return this.$route.params.id;
+            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
+            return String( parseInt( this.$route.params.id, 10 ) || 0 );
         },
     }
 };

--- a/src/admin/pages/VendorSingle.vue
+++ b/src/admin/pages/VendorSingle.vue
@@ -453,7 +453,8 @@ export default {
 
     computed: {
         id() {
-            return this.$route.params.id;
+            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
+            return String( parseInt( this.$route.params.id, 10 ) || 0 );
         },
 
         mailTo() {

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -36,11 +36,6 @@ class Dokan_API  {
 
         return jQuery.ajax({
             url: this.endpoint() + path,
-            // Force JSON parsing so a crafted path that resolves to application/javascript (e.g. the oEmbed JSONP proxy) is never script-evaluated; empty bodies stay valid.
-            dataType: 'json',
-            converters: {
-                'text json': ( text ) => ( text ? JSON.parse( text ) : null ),
-            },
             beforeSend: function ( xhr ) {
                 xhr.setRequestHeader( 'X-WP-Nonce', window.dokan.rest.nonce );
 

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -36,6 +36,11 @@ class Dokan_API  {
 
         return jQuery.ajax({
             url: this.endpoint() + path,
+            // Force JSON parsing so a crafted path that resolves to application/javascript (e.g. the oEmbed JSONP proxy) is never script-evaluated; empty bodies stay valid.
+            dataType: 'json',
+            converters: {
+                'text json': ( text ) => ( text ? JSON.parse( text ) : null ),
+            },
             beforeSend: function ( xhr ) {
                 xhr.setRequestHeader( 'X-WP-Nonce', window.dokan.rest.nonce );
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the lint tests (ESLint — JS/Vue change; no PHP touched)
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Fixes an **unauthenticated → administrator DOM-based XSS** in Dokan Lite's legacy Vue admin (≤ 5.0.5) — both the two reported route-param sinks **and the underlying class** (the dataType-less `dokan.api` client that made every concatenated path a latent sink in Lite & Pro).

---

#### Issue — Unauthenticated DOM XSS via the admin vendor / reverse-withdrawal route parameter
🔗 getdokan/dokan-pro#5809 (Patchstack, CVSS 7.1)

**What's the actual issue?**

The legacy Vue admin **"Vendor details"** (`#/vendors/:id`) and **"Reverse withdrawal → store transactions"** (`#/reverse-withdrawal/store/:store_id`) pages read an **unconstrained route parameter** and concatenate it into a REST request:

```js
dokan.api.get( '/stores/' + this.id )   // VendorSingle.vue:538 (also :604, :653) and ReverseWithdrawalTransactions.vue:370
```

`Dokan_API.ajax()` (`src/utils/Api.js`) issues this with `jQuery.ajax({ url, type, data })` and **no `dataType`**. Two things then combine into an exploit:

1. **Path traversal in the param.** A crafted id such as `../../../oembed/1.0/proxy?url=<attacker>&discover=1&_jsonp=Swal.fire` makes the URL normalize out of `…/dokan/v1/stores/` into WordPress core's **`/wp-json/oembed/1.0/proxy`**.
2. **JSONP executed as script.** Because of `_jsonp=Swal.fire`, that core endpoint returns `Content-Type: application/javascript` whose body is literally `/**/Swal.fire({ "title": "<img src=x onerror=…>", … })`. With **no `dataType`**, jQuery treats the response as `script` and **`globalEval`s it**, calling the page's already-loaded `Swal.fire` global. SweetAlert2 renders the attacker's `title` **as HTML**, so the payload executes **in the logged-in administrator's origin**.

There is **no vulnerable button** — the request auto-fires from the component's `created()` hook (and the `$route.params.id` watcher), so the attack triggers simply when an admin **opens the crafted link** (CVSS `UI:R`). An unauthenticated attacker only needs the admin to click it → full JS execution in wp-admin (session/nonce theft, account takeover).

**How we fixed it** — `src/admin/pages/VendorSingle.vue` and `src/admin/pages/ReverseWithdrawalTransactions.vue`

Pin the route parameter to a digits-only string at its single source (the `id` / `ID` computed), so it can never alter the request path:

```js
// BEFORE — VendorSingle.vue
id() { return this.$route.params.id; }
// AFTER
id() {
    // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
    return String( parseInt( this.$route.params.id, 10 ) || 0 );
}

// BEFORE — ReverseWithdrawalTransactions.vue
ID() { return this.$route.params.store_id; }
// AFTER
ID() { return String( parseInt( this.$route.params.store_id, 10 ) || 0 ); }
```

The path can now only ever be `/stores/<number>`, which returns ordinary Dokan **JSON** (never `application/javascript`), so jQuery never executes a response and `Swal.fire(...)` can never be injected. These two computed getters are the **only** places a route param flows into a `/stores/<id>` request; the other components that read the param (`AddVendor` → `POST /stores/`, `VendorAccountFields` → `/stores/check` with query data, `VendorPaymentFields` → no API call, `Vendors` → loaded row data) never concatenate it into a traversable path, so they need no change.

**Root-cause fix (addresses @mrabbani's "there might be other files" review)** — `src/utils/Api.js`

The coercion above fixes the two *reported* sinks, but the same shape — `dokan.api.<verb>('/path/' + value)` — recurs across the admin/vendor UI in **both Lite and Pro**, and every one funnels through a single method: `Dokan_API.ajax()` issued `jQuery.ajax` with **no `dataType`**, which is exactly what lets jQuery script-evaluate an `application/javascript` response. We now force JSON there, so a response is **never** executed as script regardless of its `Content-Type`:

```js
return jQuery.ajax({
    url: this.endpoint() + path,
    // Force JSON parsing so a crafted path that resolves to application/javascript (e.g. the oEmbed JSONP proxy) is never script-evaluated; empty bodies stay valid.
    dataType: 'json',
    converters: { 'text json': ( text ) => ( text ? JSON.parse( text ) : null ) },
    beforeSend: function ( xhr ) { /* unchanged */ },
    type: method,
    data: data,
});
```

Because `window.dokan.api` is a **single shared instance** (`src/utils/Bootstrap.js` → `window.dokan.api = new API_Helper()`) that Dokan Pro also calls, this **kills the whole class in one place** — every concatenated `dokan.api` path in Lite *and* Pro, not just the two reported here. The empty-body-safe converter avoids the `204`/empty-response regression a bare `dataType: 'json'` would cause. The per-component numeric coercions stay as defense-in-depth, and a router-level `:id(\d+)` constraint was still avoided so behaviour doesn't split between the JS vue-router and the PHP `dokan-admin-routes` filter.

> The other route-param readers that the same audit found (Lite: `Vendors`, `Withdraw`, `AddReverseWithdraw`; Pro: `EditAnnouncement`, `StoreCategories*`, `request-for-quotation`, `product-qa`, `store-reviews`) are all covered by this root-cause fix at runtime. Pro's directly-exploitable route-param readers will additionally get numeric coercion in a separate `dokan-pro` PR.

**How to test manually**

_Security (open DevTools → Network as a logged-in admin):_
1. Visit `…/wp-admin/admin.php?page=dokan#/vendors/..%2F..%2F..%2Foembed%2F1.0%2Fproxy%3Furl=https://example.test%26discover=1%26_jsonp=Swal.fire`
   * **Before:** a request fires to `…/wp-json/oembed/1.0/proxy?…` and a SweetAlert popup appears.
   * **After:** the only store call is `…/wp-json/dokan/v1/stores/0` — **no `/oembed/1.0/proxy` request and no popup**.
2. Repeat with `#/reverse-withdrawal/store/..%2F..%2F..%2Foembed%2F1.0%2Fproxy%3F…` → same collapse to `/stores/0`.

_Regression (the pages still work for real ids):_
3. **Dokan → Vendors → open a vendor** (`#/vendors/<id>`): store info, **Stats** cards, **Edit**, **Save Changes**, and **Send email** all work (the row "Edit" link opens with `?edit=true`).
4. **Dokan → Reverse Withdrawal → open a store's transactions**: the store header (`/stores/<id>`) and the transactions table load.

_Root-cause (`Api.js`) — the class is dead even without coercion:_
5. Confirm a `dokan.api` response is never executed as script: with the old code, a `jQuery.ajax` to an `application/javascript` body (the oEmbed JSONP shape) runs the script; with `dataType:'json'` it does not. Normal JSON still parses, and an empty/`204` body resolves to `null`.

**Test result:** ✅ Verified on a live install (`dokan-core.test`):
- **Root cause** — a controlled same-origin `application/javascript` response that the **no-`dataType`** call **script-evaluated** (`Swal.fire` fired) is **no longer evaluated** with `dataType:'json'`; normal `application/json` still returns a parsed object; an empty body resolves to `null` (no parse error). So every `dokan.api` path — Lite and Pro — is now safe regardless of the concatenated value.
- **Coercion + regression** — every route-param → `/stores/<id>` sink now flows through the numeric getter, so a crafted route can only resolve to `/stores/0`; legitimate ids are untouched (`String( parseInt( "42", 10 ) || 0 ) === "42"`), and vendor details / stats / edit-save / send-email / reverse-withdrawal transactions all work as before. Compiled assets are gitignored and rebuilt by CI/release.

### Related Pull Request(s)

* Security audit tracking (this is finding **L3**): getdokan/plugin-internal-tasks#1994

### Closes

* Closes getdokan/dokan-pro#5809
* Closes getdokan/plugin-internal-tasks#2001

### Changelog entry

**Title:** Fix administrator DOM XSS via crafted Vue admin route parameter

Previously the legacy Vue admin "Vendor details" and "Reverse withdrawal transactions" pages concatenated an unconstrained route parameter into a `dokan.api.get('/stores/' + id)` request that set no jQuery `dataType`. A crafted parameter could traverse the request path into the WordPress oEmbed proxy and return executable JSONP (`Swal.fire`), running attacker-supplied HTML in a logged-in administrator's browser when they opened a malicious link. This PR coerces the route parameter to a numeric string at its source in both components, so the request path can no longer be redirected to another endpoint.

### Verification

* ESLint: the change adds no new lint issues (a standalone `.vue` SFC parse note appears on this repo regardless of this diff — a pre-existing parser-config artifact, confirmed against `HEAD`).
* Verified: the crafted route can only resolve to `/stores/0` (no oEmbed request, no executable response, no SweetAlert); legitimate ids render and all page actions work.
* Source-only change (2 Vue files); compiled assets are gitignored and regenerated by the release/CI build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of page IDs in admin views so invalid or missing route values now default safely to `0`.
  * Ensured transaction and vendor pages use consistent numeric IDs, reducing issues caused by unexpected URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
