### PR TITLE
fix(security): prevent cross-vendor order status change via orders bulk-actions endpoint (IDOR)

### DIFF
--- a/includes/REST/OrderControllerV2.php
+++ b/includes/REST/OrderControllerV2.php
@@ -414,8 +414,21 @@ class OrderControllerV2 extends OrderController {
      * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
      */
     public function process_orders_bulk_action( $requests ) {
+        $order_ids = $requests->get_param( 'order_ids' );
+
+        // A vendor may only bulk-update their own orders; foreign order ids are dropped (admins/shop managers are exempt).
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            $vendor_id = dokan_get_current_user_id();
+            $order_ids = array_filter(
+                $order_ids,
+                function ( $order_id ) use ( $vendor_id ) {
+                    return dokan_is_seller_has_order( $vendor_id, $order_id );
+                }
+            );
+        }
+
         $data = [
-            'bulk_orders' => $requests->get_param( 'order_ids' ),
+            'bulk_orders' => $order_ids,
             'status'      => $requests->get_param( 'status' ),
         ];
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code is tested
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Fixes a **cross-vendor IDOR** on the vendor orders **bulk-actions** REST endpoint: any authenticated vendor could change the status of **any other vendor's order**.

**What's the actual issue?**

`POST /wp-json/dokan/v2/orders/bulk-actions` (and the inherited `dokan/v3` route) is guarded only by `update_order_permissions_check()`, which checks the generic `dokan_manage_order` capability and the global "order status change" setting — it **never verifies that the submitted order ids belong to the requesting vendor**. The callback then forwards the raw `order_ids` straight into `dokan_apply_bulk_order_status_change()`, which calls `$order->update_status()` on each id.

So a vendor could send another vendor's order ids in the `order_ids` array and flip their statuses (e.g. mark a competitor's pending orders as `completed`/`processing`), bypassing the per-order ownership check that the single-order endpoints already enforce.

**How we fixed it** — `includes/REST/OrderControllerV2.php`

Before dispatching the status change, drop any order the current vendor does not own. Admins / shop managers (`manage_woocommerce`) are exempt and keep acting on every order, exactly like the single-order endpoints:

```php
$order_ids = $requests->get_param( 'order_ids' );

// A vendor may only bulk-update their own orders; foreign order ids are dropped (admins/shop managers are exempt).
if ( ! current_user_can( 'manage_woocommerce' ) ) {
    $vendor_id = dokan_get_current_user_id();
    $order_ids = array_filter(
        $order_ids,
        function ( $order_id ) use ( $vendor_id ) {
            return dokan_is_seller_has_order( $vendor_id, $order_id );
        }
    );
}
```

This reuses Dokan's canonical ownership helper (`dokan_is_seller_has_order()`), and `OrderControllerV3` inherits the method so the `dokan/v3` route is covered by the same change.

**How to test**

1. As **Vendor A**, open **Dashboard → Orders**, select a few of your own orders, pick a Bulk Action (e.g. *Change status to Processing*) and **Apply** → it still works (no regression).
2. As **Vendor A**, send a crafted request with **Vendor B's** order id:
   ```js
   fetch('/wp-json/dokan/v2/orders/bulk-actions', {
     method:'POST',
     headers:{'Content-Type':'application/json','X-WP-Nonce':window.dokan.rest.nonce},
     credentials:'same-origin',
     body: JSON.stringify({ order_ids:[<VENDOR_B_ORDER_ID>], status:'completed' })
   })
   ```
   * **Before:** Vendor B's order is changed to `completed`.
   * **After:** Vendor B's order status is **unchanged**.

**Test result:** ✅ Verified on a live install. As a non-admin vendor: the vendor's own order changed status normally, while a foreign order (owned by another seller) stayed in its original status after the crafted request. Admins/shop managers remain unaffected.

### Related Pull Request(s)

* Security audit tracking (finding **L1**): getdokan/plugin-internal-tasks#1994

### Closes

* Closes getdokan/plugin-internal-tasks#1999

### Changelog entry

**Fix — Cross-vendor order status change via the orders bulk-actions REST endpoint**

The vendor orders bulk-actions endpoint changed order statuses from a vendor-supplied list of ids without checking ownership, so a vendor could change another vendor's order statuses. Order ids are now filtered to the requesting vendor's own orders (admins and shop managers are exempt).
