### PR TITLE
fix(security): prevent cross-vendor product-attribute editing via REST (IDOR)

### DIFF
--- a/includes/REST/ProductAttributeController.php
+++ b/includes/REST/ProductAttributeController.php
@@ -176,6 +176,15 @@ class ProductAttributeController extends WC_REST_Product_Attributes_V1_Controlle
      * @return WP_Error|bool
      */
     public function update_product_attribute_permissions_check( $request ) {
+        // A vendor may only edit attributes on their own products; admins/shop managers are exempt.
+        if ( ! current_user_can( 'manage_woocommerce' ) && ! dokan_is_product_author( absint( $request['id'] ) ) ) {
+            return new WP_Error(
+                'dokan_rest_cannot_edit',
+                __( 'Sorry, you are not allowed to edit this product.', 'dokan-lite' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
         return current_user_can( 'dokan_edit_product' );
     }
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code is tested
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Fixes a **cross-vendor IDOR** on the product-attribute edit / set-default REST routes: any authenticated vendor could modify the attributes of **any other vendor's product**.

**What's the actual issue?**

The custom routes
`POST /wp-json/dokan/v1/products/attributes/edit-product/<id>` and
`POST /wp-json/dokan/v1/products/attributes/set-default/<id>`
(where `<id>` is a **product** id) are both guarded by `update_product_attribute_permissions_check()`, which returned only:

```php
return current_user_can( 'dokan_edit_product' );
```

`dokan_edit_product` is a primitive capability **every vendor holds**, and the check never looks at the product in the URL. So a vendor could pass **another vendor's product id** and overwrite that product's attributes / default attributes — the callbacks (`update_product_attribute`, `update_product_default_attribute`) load the product purely from the request id with no ownership check.

**How we fixed it** — `includes/REST/ProductAttributeController.php`

Gate the permission check on product ownership, exactly like the rest of Dokan (admins / shop managers exempt):

```php
public function update_product_attribute_permissions_check( $request ) {
    // A vendor may only edit attributes on their own products; admins/shop managers are exempt.
    if ( ! current_user_can( 'manage_woocommerce' ) && ! dokan_is_product_author( absint( $request['id'] ) ) ) {
        return new WP_Error(
            'dokan_rest_cannot_edit',
            __( 'Sorry, you are not allowed to edit this product.', 'dokan-lite' ),
            array( 'status' => rest_authorization_required_code() )
        );
    }

    return current_user_can( 'dokan_edit_product' );
}
```

`dokan_is_product_author()` is Dokan's canonical "current user owns this product" primitive (vendor-staff aware). Both routes share this one permission callback, so both are fixed.

**How to test**

1. As **Vendor A**, open one of **your own** products in the product editor, change an attribute / default attribute and save → it still works (no regression).
2. As **Vendor A**, send a crafted request targeting **Vendor B's** product id:
   ```js
   fetch('/wp-json/dokan/v1/products/attributes/edit-product/<VENDOR_B_PRODUCT_ID>', {
     method:'POST',
     headers:{'Content-Type':'application/json','X-WP-Nonce':window.dokan.rest.nonce},
     credentials:'same-origin',
     body: JSON.stringify({ attributes: [] })
   })
   ```
   * **Before:** `200` — Vendor B's product attributes are modified.
   * **After:** `403 dokan_rest_cannot_edit` — request rejected. Same for `/set-default/<id>`.

**Test result:** ✅ Verified on a live install. As a non-admin vendor: requests to the vendor's **own** product id returned `200` (edit + set-default still work), while the **same requests to another vendor's product id** returned `403 dokan_rest_cannot_edit`. Admins/shop managers are unaffected.

### Related Pull Request(s)

* Security audit tracking (finding **L2**): getdokan/plugin-internal-tasks#1994

### Closes

* Closes getdokan/plugin-internal-tasks#2000

### Changelog entry

**Fix — Cross-vendor product-attribute editing via REST**

The product-attribute edit / set-default REST routes only checked a generic capability, so a vendor could edit another vendor's product attributes by passing a foreign product id. The permission check now verifies product ownership (admins and shop managers are exempt).
