### PR TITLE
fix(security): prevent cross-vendor download-permission granting in grant_access_to_download (IDOR)

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -255,7 +255,13 @@ class Ajax {
 
         foreach ( $product_ids as $product_id ) {
             $product = dokan()->product->get( $product_id );
-            $files   = $product->get_downloads();
+
+            // Only grant downloads for the vendor's own products, never another vendor's files.
+            if ( ! $product || ! dokan_is_product_author( $product_id ) ) {
+                continue;
+            }
+
+            $files = $product->get_downloads();
 
             if ( ! $order->get_billing_email() ) {
                 wp_die();


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code is tested
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Fixes a **cross-vendor IDOR** in the "grant download access" AJAX handler: a vendor could grant a customer download permissions for **another vendor's** downloadable files.

**What's the actual issue?**

`grant_access_to_download()` (`wp_ajax_dokan_grant_access_to_download`) verifies the nonce, the `dokandar` capability, and `dokan_is_seller_has_order( current_user, order_id )` — i.e. it confirms the vendor owns the **order**. It then loops over the **attacker-controlled** `$_POST['product_ids']` and calls `wc_downloadable_file_permission()` for each, **without checking that the vendor owns those products**:

```php
foreach ( $product_ids as $product_id ) {
    $product = dokan()->product->get( $product_id );
    $files   = $product->get_downloads();           // <-- any product id, including another vendor's
    ...
    wc_downloadable_file_permission( $download_id, $product_id, $order );
}
```

So a vendor could send another vendor's downloadable product id and grant their own customer free, working download permissions for that vendor's paid files. (The unchecked `$product` also fataled on an invalid id.)

**How we fixed it** — `includes/Ajax.php`

Skip any product the current vendor does not own before granting:

```php
foreach ( $product_ids as $product_id ) {
    $product = dokan()->product->get( $product_id );

    // Only grant downloads for the vendor's own products, never another vendor's files.
    if ( ! $product || ! dokan_is_product_author( $product_id ) ) {
        continue;
    }

    $files = $product->get_downloads();
    ...
}
```

`dokan_is_product_author()` is Dokan's canonical product-ownership primitive (vendor-staff aware); the same `! $product` guard also removes the pre-existing null-dereference on invalid ids.

**How to test**

1. As a vendor with a **downloadable** product in one of your orders, open that order and use **Grant access** → your own product's download permission is still granted (no regression).
2. As that vendor, replay the request but swap in **another vendor's** downloadable product id in `product_ids` (action `dokan_grant_access_to_download`, valid `grant-access` nonce, your own `order_id`).
   * **Before:** a `woocommerce_downloadable_product_permissions` row is created for the foreign product — the customer can download another vendor's file.
   * **After:** the foreign product is skipped — **no** permission row is created.

**Test result:** ✅ Verified on a live install by replaying the handler's exact (patched) grant loop as a non-admin vendor against one of the vendor's own orders: the vendor's **own** product took the grant path, while a **foreign** vendor's downloadable product was skipped and **zero** download-permission rows were created for it. (This is a legacy admin-ajax handler whose UI only renders for orders that contain the vendor's own downloadable products, so it was exercised through the server-side handler path rather than the browser.)

### Related Pull Request(s)

* Security audit tracking (finding **L4**): getdokan/plugin-internal-tasks#1994

### Closes

* Closes getdokan/plugin-internal-tasks#2002

### Changelog entry

**Fix — Cross-vendor download-permission granting**

The "grant download access" handler only checked order ownership, so a vendor could grant download permissions for another vendor's downloadable products by passing foreign product ids. Each product is now checked for ownership before access is granted.
