### PR TITLE
fix: secure admin settings GET endpoint & reset commission default

### DIFF
--- a/includes/REST/AdminSettingsController.php
+++ b/includes/REST/AdminSettingsController.php
@@ -66,7 +66,7 @@ class AdminSettingsController extends DokanBaseAdminController {
                 [
                     'methods'             => WP_REST_Server::READABLE,
                     'callback'            => [ $this, 'get_items' ],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => [ $this, 'check_permission' ],
                 ],
                 'schema' => [ $this, 'get_public_item_schema' ],
             ]

--- a/src/components/commission/utils.ts
+++ b/src/components/commission/utils.ts
@@ -1,6 +1,6 @@
 import { Category, CommissionValues, SettingsElement } from './types';
 
-export const defaultCommission = { percentage: '0', flat: '2500' };
+export const defaultCommission = { percentage: '0', flat: '0' };
 
 // Selector functions
 export const getSettingInChildren = (


### PR DESCRIPTION
## Summary


#### Closes: https://github.com/getdokan/plugin-internal-tasks/issues/2003
#### Related PR: https://github.com/getdokan/dokan-pro/pull/5824

Two review fixes for the new flat-array admin settings, branched from and targeting `refactor/simplify-settings-to-flat-array`.

### 🔴 Security — unauthenticated GET leaked all admin secrets
`GET /dokan/v1/admin/settings` used `permission_callback => '__return_true'`. The handler returns the fully value-populated schema, which includes secrets (Google Maps key, AI API keys, live-chat app secret, payment credentials). Any logged-out visitor could read them.

**Fix:** use `[ $this, 'check_permission' ]` (the same `manage_woocommerce` gate the PUT route already uses).

**Repro:** as admin, save a settings page containing an API key → open an incognito window → `GET /wp-json/dokan/v1/admin/settings` → before this fix the JSON loads with secrets in plain text.

### 🟠 Commission default seeded to 2500
`defaultCommission` in `src/components/commission/utils.ts` had `flat: '2500'`, seeding a large default flat commission for the "All Categories" row on fresh installs.

**Fix:** restore `flat: '0'`.

## Test plan
- [ ] Logged-out `GET /dokan/v1/admin/settings` returns 401/403
- [ ] Admin `GET` still returns the schema with values
- [ ] Fresh install: category commission "All Categories" flat fee shows `0`
- [ ] Requires `npm run build` for the commission change to reflect in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)