### PR TITLE
Preserve query args when building vendor dashboard analytics URLs (WPML parameter mode)

### DIFF
--- a/includes/Admin/AdminBar.php
+++ b/includes/Admin/AdminBar.php
@@ -145,7 +145,7 @@ class AdminBar {
                 'parent' => 'site-name',
                 'id'     => 'view-dashboard',
                 'title'  => __( 'Visit Vendor Dashboard', 'dokan-lite' ),
-                'href'   => get_permalink( $vendor_dashboard ) . ( ReportUtil::is_analytics_enabled() ? '?path=%2Fanalytics%2FOverview' : '' ),
+                'href'   => ReportUtil::is_analytics_enabled() ? add_query_arg( 'path', '/analytics/Overview', get_permalink( $vendor_dashboard ) ) : get_permalink( $vendor_dashboard ),
             ];
         }
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -859,7 +859,7 @@ class Assets {
                 'routes'          => $this->get_vue_frontend_routes(),
                 'urls'            => [
                     'assetsUrl'    => DOKAN_PLUGIN_ASSEST,
-                    'dashboardUrl' => dokan_get_navigation_url() . ( ReportUtil::is_analytics_enabled() ? '?path=%2Fanalytics%2FOverview' : '' ),
+                    'dashboardUrl' => ReportUtil::is_analytics_enabled() ? add_query_arg( 'path', '/analytics/Overview', dokan_get_navigation_url() ) : dokan_get_navigation_url(),
                     'storeUrl'     => dokan_get_store_url( dokan_get_current_user_id() ),
                     'ordersUrl'        => dokan_get_navigation_url( 'orders' ),
                     'legacyOrdersUrl'  => dokan_add_subpage_to_url( rtrim( get_permalink( (int) dokan_get_option( 'dashboard', 'dokan_pages', 0 ) ), '/' ) . '/', 'orders/' ),

--- a/includes/functions-dashboard-navigation.php
+++ b/includes/functions-dashboard-navigation.php
@@ -38,7 +38,7 @@ function dokan_get_dashboard_nav(): array {
         'dashboard' => [
             'title'      => __( 'Dashboard', 'dokan-lite' ),
             'icon'       => '<i class="fas fa-tachometer-alt"></i>',
-            'url'        => dokan_get_navigation_url() . ( ReportUtil::is_analytics_enabled() ? '?path=%2Fanalytics%2FOverview' : '' ),
+            'url'        => ReportUtil::is_analytics_enabled() ? add_query_arg( 'path', '/analytics/Overview', dokan_get_navigation_url() ) : dokan_get_navigation_url(),
             'pos'        => 10,
             'icon_name'  => 'House',
             'permission' => 'dokan_view_overview_menu',

--- a/src/vendor-dashboard/reports/helper.ts
+++ b/src/vendor-dashboard/reports/helper.ts
@@ -1,6 +1,7 @@
 import { dokanConfig } from './dokan-config';
 import { getHistory } from '@woocommerce/navigation';
 import { applyFilters } from '@wordpress/hooks';
+import { addQueryArgs } from '@wordpress/url';
 
 declare const vendorAnalyticsDokanConfig: {
     seller_id: number;
@@ -70,7 +71,15 @@ export const shouldBlockNavigation = () => {
         );
 
     if ( isAnalyticsExcluded && matchingRedirectRule ) {
-        document.location.href = matchingRedirectRule.redirect;
+        // Preserve the current query args (e.g. WPML's ?lang= in parameter-based mode),
+        // except `path` — the redirect target's own path must win.
+        const { path, ...currentParams } = Object.fromEntries(
+            new URLSearchParams( document.location.search )
+        );
+        document.location.href = addQueryArgs(
+            matchingRedirectRule.redirect,
+            currentParams
+        );
     }
 
     return applyFilters( BLOCK_NAVIGATION_FILTER, isAnalyticsExcluded );


### PR DESCRIPTION
### Closes

* Closes getdokan/plugin-internal-tasks#2186

### Problem

The vendor dashboard / analytics URLs are built by **string-concatenating** a literal `?path=%2Fanalytics%2F…` onto the base dashboard URL:

```php
dokan_get_navigation_url() . ( ReportUtil::is_analytics_enabled() ? '?path=%2Fanalytics%2FOverview' : '' )
```

When the base URL already carries a query string, this creates a malformed double-`?`. The concrete trigger is **WPML "language as a parameter"** mode, where a secondary-language permalink ends with `?lang=bn`:

```
base   : https://example.com/dashboard-bn/?lang=bn
result : https://example.com/dashboard-bn/?lang=bn?path=%2Fanalytics%2FOverview   ← double "?"
```

The browser then parses `lang` as `bn?path=/analytics/Overview` (garbage), so the language is lost and the dashboard reverts to the **default language**. Reported for the vendor dashboard: *switching to a non-default language in parameter mode bounces back to English.*

Directory- and domain-based modes are unaffected because their language marker lives in the path/host, not the query — which is exactly why this only reproduces in parameter mode.

### Fix

Use `add_query_arg()` in the three PHP URL builders so the parameter is appended with `&` when a query already exists (and `?` otherwise):

- `includes/functions-dashboard-navigation.php` — Dashboard nav menu item
- `includes/Assets.php` — `dashboardUrl` script config
- `includes/Admin/AdminBar.php` — admin-bar "Visit Vendor Dashboard" link

And in the client-side analytics redirect (`src/vendor-dashboard/reports/helper.ts`), carry over the current query args (except `path`, which the target route owns) instead of discarding the whole query string:

```ts
const { path, ...currentParams } = Object.fromEntries(
    new URLSearchParams( document.location.search )
);
document.location.href = addQueryArgs( matchingRedirectRule.redirect, currentParams );
```

### Behavior

| Base URL | Before | After |
| --- | --- | --- |
| no query (dir/domain mode) | `…/dashboard/?path=%2Fanalytics%2FOverview` | `…/dashboard/?path=/analytics/Overview` (equivalent) |
| `?lang=bn` (parameter mode) | `…/?lang=bn?path=…` ❌ lang lost | `…/?path=/analytics/Overview&lang=bn` ✅ lang preserved |

Note: `add_query_arg()` no longer pre-encodes the `/` in the value (`%2F` → `/`); both forms are accepted by the WC-admin router and by `helper.ts` (which `decodeURIComponent`s before matching).

### Testing

Verified live with WPML active across the full matrix — 2 Vendor Dashboard Styles × 2 Vendor Product Editors × 3 URL modes (directory / domain / parameter):

- Parameter mode, second language: dashboard now lands on `…/dashboard-bn/?path=/analytics/Overview&lang=bn` and **stays** in the selected language (previously reverted to English).
- Directory / domain modes: unchanged.
- Default language: unchanged in all modes.
- Legacy UI regression: Products/editor still resolve to the legacy pages.

Requires an asset rebuild (`npm run build`) for the `helper.ts` change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard and admin-bar links so analytics pages open correctly without broken or duplicated URL encoding.
  * Redirects now preserve relevant query parameters, helping users keep their current context when navigation is blocked.
  * Vendor dashboard links now build more consistently whether analytics is enabled or not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
