### PR TITLE
fix(security): escape product name/category in admin vendor-detail ProductCard (stored XSS)

### DIFF
--- a/src/admin/dashboard/pages/vendors-single/components/ProductCard.tsx
+++ b/src/admin/dashboard/pages/vendors-single/components/ProductCard.tsx
@@ -1,4 +1,5 @@
 import { truncate } from '@dokan/utilities';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 interface Product {
@@ -23,27 +24,18 @@ const ProductCard = ( { product }: ProductCardProps ) => (
             loading="lazy"
         />
         <div className="flex-1 min-w-0 space-y-1.5">
-            <h4
-                className="text-gray-900 truncate text-base font-medium mt-1"
-                dangerouslySetInnerHTML={ {
-                    __html: truncate( product.name, 30 ),
-                } }
-            />
+            {/* decodeEntities restores the display text (e.g. &amp; -> &) while JSX still escapes any markup, so vendor-controlled names render correctly without XSS. */}
+            <h4 className="text-gray-900 truncate text-base font-medium mt-1">
+                { truncate( decodeEntities( product.name ), 30 ) }
+            </h4>
             <div className="flex items-center gap-4">
-                <p
-                    className="text-sm border-r text-[#828282] pr-4"
-                    dangerouslySetInnerHTML={ {
-                        __html: truncate( product.category, 20 ),
-                    } }
-                />
+                <p className="text-sm border-r text-[#828282] pr-4">
+                    { truncate( decodeEntities( product.category ), 20 ) }
+                </p>
                 <div className="flex gap-3">
-                    <div
-                        className="font-bold text-gray-900 text-xl"
-                        dangerouslySetInnerHTML={ {
-                            // @ts-ignore
-                            __html: product.sold,
-                        } }
-                    />
+                    <div className="font-bold text-gray-900 text-xl">
+                        { product.sold }
+                    </div>
                     <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-[#EFEAFF] text-[#7047EB]">
                         { __( 'Sold', 'dokan-lite' ) }
                     </span>


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the lint tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

This PR fixes L5 from the Dokan security audit (getdokan/plugin-internal-tasks#1994): latent stored XSS: admin vendor-detail ProductCard renders product name/category via dangerouslySetInnerHTML (currently KSES-mitigated).

#### The problem

The admin vendor-detail ProductCard renders vendor-controlled product data via React's dangerouslySetInnerHTML instead of as escaped JSX text. product.name (lines 28-30) and product.category (lines 35-37) are strings from products a vendor fully controls; a name/category containing markup (e.g. an img tag with an onerror handler) is injected raw into the admin dashboard DOM = stored XSS in an admin context. product.sold (lines 42-45) also uses dangerouslySetInnerHTML with an @ts-ignore; numeric so not currently exploitable but the same unsafe pattern. Latent/KSES-mitigated because the REST payload may currently be sanitized server-side, but the client enforces no trust boundary of its own. React auto-escaping is the correct self-contained fix.

#### The fix

Removes dangerouslySetInnerHTML for product.name; React escapes the string, closing the stored-XSS vector while keeping 30-char truncation. Removes dangerouslySetInnerHTML for product.category; React escapes the string, keeping 20-char truncation. Removes the last dangerouslySetInnerHTML and its @ts-ignore; numeric sold renders as escaped JSX, eliminating the unsafe pattern from this component.

**Implementation scope**

- Edit only src/admin/dashboard/pages/vendors-single/components/ProductCard.tsx — replace the three dangerouslySetInnerHTML usages (name h4, category p, sold div) with escaped JSX text children.
- No changes to the Product interface, the truncate utility, or the REST payload — only render escaping changes.
- Rebuild admin dashboard assets (npm run build) so the compiled bundle reflects the change.
- No server-side/PHP changes required; purely a client-side output-encoding fix.

### How to test the changes in this Pull Request:

**Security — the vulnerability is now closed.**

_Before_ (reproduces the issue on `develop`):

Attack blocked: as a vendor, create a product whose name is an img tag with an onerror alert and a category name containing a script tag, then as admin open the vendor-single detail page rendering ProductCard; confirm the literal text is shown and no script/onerror fires (pre-fix the payload executes).

_After_ (this PR): the attack is rejected; the legitimate flow and admin access are unaffected.

**Regression — verify each of these still holds:**

- Legit flow: a normal product with plain name/category and numeric sold count still renders, truncated to 30/20 chars, with benign ampersand/angle-bracket characters shown literally.
- Admin/no-regression: confirm the numeric sold count still shows the correct value after removing dangerouslySetInnerHTML, and card layout/styling is unchanged.
- Build check: run tsc/npm build to confirm removing the @ts-ignore on product.sold surfaces no type error (sold is typed number, so rendering it as a JSX child type-checks).

### Changelog entry

**Title:** Fix escape product name/category in admin vendor-detail ProductCard

Fixed a cross-site scripting security issue: latent stored XSS: admin vendor-detail ProductCard renders product name/category via dangerouslySetInnerHTML (currently KSES-mitigated).

### Related Pull Request(s)

* Security audit: getdokan/plugin-internal-tasks#1994 (finding(s) **L5**)

* Closes getdokan/plugin-internal-tasks#2077


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product card rendering to safely display product name, category, and sold count as text.
  * Correctly shows encoded characters like `&amp;` in product details without exposing raw markup.
  * Reduced the risk of unintended HTML injection in vendor product listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->