### PR TITLE
feat(components): add shared WeeklyTimeSlots to @dokan/components

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,0 +1,31 @@
+import { Switch as _PluginUISwitch } from '@wedevs/plugin-ui';
+
+// Legacy alias for the old `DokanSwitch` component. The underlying plugin-ui
+// `Switch` is a Radix primitive that exposes `onCheckedChange(value: boolean)`.
+// Old call sites (e.g. dokan-pro's delivery-time module) pass
+// `onChange(value: boolean)`. This adapter forwards both names so neither API
+// change breaks consumers.
+type DokanSwitchProps = {
+    checked?: boolean;
+    onChange?: ( value: boolean ) => void;
+    onCheckedChange?: ( value: boolean ) => void;
+    [ key: string ]: unknown;
+};
+
+export const DokanSwitch = ( {
+    onChange,
+    onCheckedChange,
+    checked = false,
+    ...rest
+}: DokanSwitchProps ) => {
+    const handler = onCheckedChange ?? onChange;
+    return (
+        <_PluginUISwitch
+            checked={ checked }
+            onCheckedChange={ handler }
+            { ...rest }
+        />
+    );
+};
+
+export default DokanSwitch;

--- a/src/components/WeeklyTimeSlots/TimeDropdown.tsx
+++ b/src/components/WeeklyTimeSlots/TimeDropdown.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Clock, ChevronDown } from 'lucide-react';
+import { twMerge } from 'tailwind-merge';
+import {
+    DEFAULT_STEP_MINUTES,
+    FULL_DAY,
+    MINUTES_PER_DAY,
+    formatTimeForDisplay,
+    minutesToCanonical,
+    minutesToDisplay,
+    timeToMinutes,
+} from './utils';
+
+export type TimeDropdownProps = {
+    value?: string;
+    onChange?: ( newValue: string ) => void;
+    placeholder?: string;
+    is12Hour?: boolean;
+    hasError?: boolean;
+    // Offer the "Full Day" preset (opening dropdowns only — a closing can never be "Full Day").
+    includeFullDay?: boolean;
+    step?: number;
+};
+
+type TimeOption = { key: string; label: string; minutes: number | null };
+
+// Preset dropdown (legacy jQuery-timepicker UX): "Full Day" + step increments. Stores the
+// canonical `g:i a` key (or FULL_DAY sentinel); labels re-localize per render via dateI18n.
+const TimeDropdown = ( {
+    value = '',
+    onChange,
+    placeholder = '',
+    is12Hour = true,
+    hasError = false,
+    includeFullDay = false,
+    step = DEFAULT_STEP_MINUTES,
+}: TimeDropdownProps ) => {
+    const [ open, setOpen ] = useState( false );
+    const wrapRef = useRef< HTMLDivElement | null >( null );
+    const listRef = useRef< HTMLUListElement | null >( null );
+
+    const options = useMemo( () => {
+        const opts: TimeOption[] = [];
+        if ( includeFullDay ) {
+            opts.push( {
+                key: FULL_DAY,
+                label: __( 'Full Day', 'dokan-lite' ),
+                minutes: null,
+            } );
+        }
+        for ( let m = 0; m < MINUTES_PER_DAY; m += step ) {
+            opts.push( {
+                key: minutesToCanonical( m ),
+                label: minutesToDisplay( m, is12Hour ),
+                minutes: m,
+            } );
+        }
+        return opts;
+    }, [ includeFullDay, is12Hour, step ] );
+
+    // Match by minutes so stored values with other casing/padding ("09:00 AM") still highlight.
+    const valueMinutes = timeToMinutes( value );
+    const isSelected = ( option: TimeOption ): boolean =>
+        option.key === value ||
+        ( valueMinutes !== null && option.minutes === valueMinutes );
+
+    const displayLabel =
+        value === FULL_DAY
+            ? __( 'Full Day', 'dokan-lite' )
+            : value && formatTimeForDisplay( value, is12Hour );
+
+    useEffect( () => {
+        if ( ! open ) {
+            return;
+        }
+        const handler = ( event: MouseEvent ) => {
+            if (
+                wrapRef.current &&
+                ! wrapRef.current.contains( event.target as Node )
+            ) {
+                setOpen( false );
+            }
+        };
+        document.addEventListener( 'mousedown', handler );
+        const selected = listRef.current?.querySelector(
+            '[aria-selected="true"]'
+        ) as HTMLElement | null;
+        selected?.scrollIntoView?.( { block: 'center' } );
+        return () => document.removeEventListener( 'mousedown', handler );
+    }, [ open ] );
+
+    const selectOption = ( option: TimeOption ) => {
+        onChange?.( option.key );
+        setOpen( false );
+    };
+
+    return (
+        <div ref={ wrapRef } className="relative inline-block">
+            <button
+                type="button"
+                onClick={ () => setOpen( ( isOpen ) => ! isOpen ) }
+                className={ twMerge(
+                    'flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-sm shadow-sm min-w-[155px] focus:outline-none focus:ring-2 focus:ring-[#7047EB]',
+                    hasError
+                        ? 'border-red-500 ring-1 ring-red-500'
+                        : 'border-gray-300'
+                ) }
+            >
+                <Clock size={ 16 } className="text-gray-400" />
+                <span
+                    className={ twMerge(
+                        'flex-1 text-left text-[#25252D]',
+                        ! displayLabel && 'text-gray-400'
+                    ) }
+                >
+                    { displayLabel || placeholder }
+                </span>
+                <ChevronDown size={ 14 } className="text-gray-400" />
+            </button>
+            { open && (
+                <ul
+                    ref={ listRef }
+                    className="absolute z-50 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-gray-300 bg-white py-1 shadow-lg"
+                    role="listbox"
+                >
+                    { options.map( ( option ) => {
+                        const selected = isSelected( option );
+                        return (
+                            /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
+                            <li
+                                key={ option.key }
+                                role="option"
+                                aria-selected={ selected }
+                                onClick={ () => selectOption( option ) }
+                                className={ twMerge(
+                                    'cursor-pointer px-3 py-2 text-sm hover:bg-gray-100',
+                                    selected && 'bg-gray-100 font-medium',
+                                    option.key === FULL_DAY &&
+                                        'border-b border-gray-200'
+                                ) }
+                            >
+                                { option.label }
+                            </li>
+                        );
+                    } ) }
+                </ul>
+            ) }
+        </div>
+    );
+};
+
+export default TimeDropdown;

--- a/src/components/WeeklyTimeSlots/index.tsx
+++ b/src/components/WeeklyTimeSlots/index.tsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import DokanButton from '../Button';
+import { DokanSwitch } from '../Switch';
+import { twMerge } from 'tailwind-merge';
+import { Minus, Plus, Trash } from 'lucide-react';
+import TimeDropdown from './TimeDropdown';
+import { createMultipleValidator, createSingleValidator } from './validators';
+import {
+    DEFAULT_STEP_MINUTES,
+    FULL_DAY,
+    MINUTES_PER_DAY,
+    defaultSeedSlot,
+    minutesToCanonical,
+    timeToMinutes,
+} from './utils';
+import type {
+    TimeSlot,
+    WeeklyDay,
+    WeeklyTimeSlotsProps,
+    WeeklyValue,
+} from './types';
+
+// Generic weekly schedule editor: `multiple` switches between one range/day (admin) and
+// N ranges with add/remove (vendor). Validation and messages are overridable via props.
+const WeeklyTimeSlots = ( {
+    value,
+    days,
+    multiple = false,
+    is12Hour = true,
+    allowFullDay = true,
+    step = DEFAULT_STEP_MINUTES,
+    openingPlaceholder,
+    closingPlaceholder,
+    validate,
+    messages,
+    validateOnMount = false,
+    seedSlot,
+    onChange,
+}: WeeklyTimeSlotsProps ) => {
+    const validator = useMemo(
+        () =>
+            validate ??
+            ( multiple
+                ? createMultipleValidator( messages )
+                : createSingleValidator( messages ) ),
+        [ validate, multiple, messages ]
+    );
+
+    // Derived from the controlled value, so errors never go stale on external updates.
+    const errors = useMemo(
+        () => validator( value, days ),
+        [ validator, value, days ]
+    );
+
+    // A day's errors only show once it's been touched (or on mount when validateOnMount).
+    const [ touched, setTouched ] = useState< Record< string, boolean > >(
+        () =>
+            validateOnMount
+                ? Object.fromEntries(
+                      Object.keys( days ).map( ( k ) => [ k, true ] )
+                  )
+                : {}
+    );
+
+    const seed = seedSlot ?? ( () => defaultSeedSlot( step, multiple ) );
+    const opensAt = openingPlaceholder ?? __( 'Opens at', 'dokan-lite' );
+    const closesAt = closingPlaceholder ?? __( 'Closed at', 'dokan-lite' );
+
+    const commit = ( dayKey: string, nextDay: WeeklyDay, isTouched = true ) => {
+        const nextValue: WeeklyValue = { ...value, [ dayKey ]: nextDay };
+        if ( isTouched ) {
+            setTouched( ( prev ) => ( { ...prev, [ dayKey ]: true } ) );
+        }
+        onChange( nextValue, validator( nextValue, days ) );
+    };
+
+    const handleToggle = ( dayKey: string, isActive: boolean ) => {
+        const day = value[ dayKey ] ?? { status: false, slots: [] };
+        let slots = day.slots;
+        if ( isActive ) {
+            if ( slots.length === 0 ) {
+                slots = [ seed() ];
+            } else if ( ! multiple ) {
+                // Keep existing times when re-enabling; only fill the gaps.
+                const seeded = seed();
+                slots = [
+                    {
+                        opening_time:
+                            slots[ 0 ].opening_time || seeded.opening_time,
+                        closing_time:
+                            slots[ 0 ].closing_time || seeded.closing_time,
+                    },
+                ];
+            }
+        }
+        commit( dayKey, { status: isActive, slots }, isActive );
+    };
+
+    const handleTimeChange = (
+        dayKey: string,
+        slotIndex: number,
+        field: 'opening_time' | 'closing_time',
+        newValue: string
+    ) => {
+        const day = value[ dayKey ];
+        if ( ! day ) {
+            return;
+        }
+        let nextSlots: TimeSlot[];
+        if ( field === 'opening_time' && newValue === FULL_DAY ) {
+            // Legacy parity: "Full Day" collapses the day to one all-day range (no closing time).
+            nextSlots = [ { opening_time: FULL_DAY, closing_time: '' } ];
+        } else {
+            nextSlots = day.slots.map( ( slot, index ) => {
+                if ( index !== slotIndex ) {
+                    return slot;
+                }
+                const next: TimeSlot = { ...slot, [ field ]: newValue };
+                // Leaving "Full Day": seed a closing one step after the new opening so the pair is valid.
+                if (
+                    field === 'opening_time' &&
+                    slot.opening_time === FULL_DAY &&
+                    newValue !== FULL_DAY
+                ) {
+                    const opening = timeToMinutes( newValue );
+                    next.closing_time =
+                        opening !== null && opening + step < MINUTES_PER_DAY
+                            ? minutesToCanonical( opening + step )
+                            : '';
+                }
+                return next;
+            } );
+        }
+        commit( dayKey, { ...day, slots: nextSlots } );
+    };
+
+    const handleAddSlot = ( dayKey: string ) => {
+        const day = value[ dayKey ];
+        if ( ! day ) {
+            return;
+        }
+        commit( dayKey, { ...day, slots: [ ...day.slots, seed() ] } );
+    };
+
+    const handleRemoveSlot = ( dayKey: string, slotIndex: number ) => {
+        const day = value[ dayKey ];
+        if ( ! day ) {
+            return;
+        }
+        const slots = day.slots.filter( ( _, index ) => index !== slotIndex );
+        // Vendor-legacy parity: removing the last range turns the day off.
+        commit( dayKey, {
+            status: slots.length > 0 ? day.status : false,
+            slots,
+        } );
+    };
+
+    const renderSlotRow = (
+        dayKey: string,
+        day: WeeklyDay,
+        slot: TimeSlot,
+        index: number
+    ) => {
+        const slotError = touched[ dayKey ]
+            ? errors[ dayKey ]?.[ index ]
+            : undefined;
+        const isFullDaySlot = slot.opening_time === FULL_DAY;
+        return (
+            <div
+                key={ index }
+                className={ twMerge(
+                    'flex items-center gap-4',
+                    slotError && 'dokan-weekly-slot-error'
+                ) }
+            >
+                <TimeDropdown
+                    value={ slot.opening_time }
+                    placeholder={ opensAt }
+                    onChange={ ( v ) =>
+                        handleTimeChange( dayKey, index, 'opening_time', v )
+                    }
+                    is12Hour={ is12Hour }
+                    hasError={ Boolean( slotError?.opening ) }
+                    // "Full Day" is a single-range concept; offering it per row in multiple
+                    // mode would wipe the day's other ranges on selection.
+                    includeFullDay={ allowFullDay && ! multiple }
+                    step={ step }
+                />
+                { ! isFullDaySlot && (
+                    <>
+                        <Minus size={ 20 } color={ '#828282' } />
+                        <TimeDropdown
+                            value={ slot.closing_time }
+                            placeholder={ closesAt }
+                            onChange={ ( v ) =>
+                                handleTimeChange(
+                                    dayKey,
+                                    index,
+                                    'closing_time',
+                                    v
+                                )
+                            }
+                            is12Hour={ is12Hour }
+                            hasError={ Boolean( slotError?.closing ) }
+                            includeFullDay={ false }
+                            step={ step }
+                        />
+                    </>
+                ) }
+                { multiple && (
+                    <div className="flex gap-2 ml-2">
+                        <DokanButton
+                            variant="tertiary"
+                            className="p-2! text-gray-500! hover:text-red-500! hover:bg-red-50! h-8 w-8"
+                            onClick={ () => handleRemoveSlot( dayKey, index ) }
+                        >
+                            <Trash />
+                        </DokanButton>
+                        { ! isFullDaySlot && index === day.slots.length - 1 && (
+                            <DokanButton
+                                variant="tertiary"
+                                className="p-2! text-gray-500! h-8 w-8"
+                                onClick={ () => handleAddSlot( dayKey ) }
+                            >
+                                <Plus />
+                            </DokanButton>
+                        ) }
+                    </div>
+                ) }
+            </div>
+        );
+    };
+
+    const renderDayMessages = ( dayMessages: string[] ) =>
+        dayMessages.map( ( message ) => (
+            <p key={ message } className="mt-1 text-sm text-[#E7000B]">
+                { message }
+            </p>
+        ) );
+
+    const renderDayRow = ( dayKey: string ) => {
+        const day = value[ dayKey ] ?? { status: false, slots: [] };
+        // De-duplicated day messages, rendered under the row.
+        const dayMessages = touched[ dayKey ]
+            ? Array.from(
+                  new Set(
+                      Object.values( errors[ dayKey ] ?? {} ).map(
+                          ( slotError ) => slotError.message
+                      )
+                  )
+              )
+            : [];
+
+        return (
+            <div
+                key={ dayKey }
+                className="border-b border-gray-200 last:border-b-0 bg-white"
+            >
+                { /* Desktop Layout */ }
+                <div className="hidden sm:block!">
+                    <div className="flex items-center py-4 px-6 min-h-20">
+                        { /* Day name */ }
+                        <div className="w-2/4 shrink-0 self-start mt-2">
+                            <span className="text-sm font-medium text-[#25252D]">
+                                { days[ dayKey ] }
+                            </span>
+                            { renderDayMessages( dayMessages ) }
+                        </div>
+
+                        <div className="flex-1 flex items-center justify-end">
+                            { /* Time slots or status */ }
+                            <div className="flex-1 flex items-center justify-end">
+                                { day.status && day.slots.length > 0 && (
+                                    <div className="dokan-weekly-slots space-y-2">
+                                        { day.slots.map( ( slot, index ) =>
+                                            renderSlotRow(
+                                                dayKey,
+                                                day,
+                                                slot,
+                                                index
+                                            )
+                                        ) }
+                                    </div>
+                                ) }
+                            </div>
+
+                            { /* Switch - with proper spacing */ }
+                            <div className="ml-10 shrink-0">
+                                <DokanSwitch
+                                    checked={ day.status }
+                                    onChange={ ( val: boolean ) =>
+                                        handleToggle( dayKey, val )
+                                    }
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                { /* Mobile Layout */ }
+                <div
+                    className={ twMerge(
+                        'sm:hidden! px-6 py-4 min-h-20 w-full',
+                        ! day.status && 'flex items-center'
+                    ) }
+                >
+                    { /* Day name + Switch row */ }
+                    <div className="flex items-center justify-between w-full">
+                        <div>
+                            <span className="text-sm font-semibold text-[#25252D]">
+                                { days[ dayKey ] }
+                            </span>
+                            { renderDayMessages( dayMessages ) }
+                        </div>
+                        <DokanSwitch
+                            checked={ day.status }
+                            onChange={ ( val: boolean ) =>
+                                handleToggle( dayKey, val )
+                            }
+                        />
+                    </div>
+
+                    { /* Time picker rows - only when active */ }
+                    { day.status && day.slots.length > 0 && (
+                        <div className="mt-4 space-y-2">
+                            { day.slots.map( ( slot, index ) =>
+                                renderSlotRow( dayKey, day, slot, index )
+                            ) }
+                        </div>
+                    ) }
+                </div>
+            </div>
+        );
+    };
+
+    // Render in `days` key order (honours WP "Week Starts On"), not the value's key order.
+    return (
+        <div className="overflow-hidden">
+            { Object.keys( days ).map( renderDayRow ) }
+        </div>
+    );
+};
+
+export default WeeklyTimeSlots;
+export { default as TimeDropdown } from './TimeDropdown';
+export {
+    FULL_DAY,
+    defaultSeedSlot,
+    timeToMinutes,
+    minutesToCanonical,
+} from './utils';
+export {
+    createSingleValidator,
+    createMultipleValidator,
+    hasWeeklyErrors,
+} from './validators';
+export * from './types';

--- a/src/components/WeeklyTimeSlots/types.ts
+++ b/src/components/WeeklyTimeSlots/types.ts
@@ -1,0 +1,65 @@
+// One opening/closing range: canonical `g:i a`, the FULL_DAY sentinel (opening only), or ''.
+export type TimeSlot = {
+    opening_time: string;
+    closing_time: string;
+};
+
+export type WeeklyDay = {
+    status: boolean;
+    slots: TimeSlot[];
+};
+
+// Keyed by day (monday…sunday). Render order comes from `days`, not this map.
+export type WeeklyValue = Record< string, WeeklyDay >;
+
+export type SlotError = {
+    // Red-border the opening picker.
+    opening?: boolean;
+    // Red-border the closing picker.
+    closing?: boolean;
+    // Translated, day-labeled message rendered under the day row.
+    message: string;
+};
+
+export type WeeklyErrors = Record< string, Record< number, SlotError > >;
+
+export type WeeklyValidator = (
+    value: WeeklyValue,
+    dayLabels: Record< string, string >
+) => WeeklyErrors;
+
+// Message-only overrides — keep the default logic, swap the strings.
+export type WeeklyMessages = {
+    required?: ( dayLabel: string ) => string;
+    order?: ( dayLabel: string ) => string;
+    overlap?: ( dayLabel: string ) => string;
+};
+
+export type WeeklyTimeSlotsProps = {
+    // Controlled value — the parent owns state.
+    value: WeeklyValue;
+    // Translated day labels; KEY ORDER IS RENDER ORDER (honours start_of_week).
+    days: Record< string, string >;
+    // false (default): one range per day. true: N ranges with add/remove.
+    multiple?: boolean;
+    // Display-only; storage is always canonical `g:i a`.
+    is12Hour?: boolean;
+    // Offer the "Full Day" preset in opening dropdowns. Default true.
+    allowFullDay?: boolean;
+    // Preset increment in minutes. Default 30 (legacy jQuery-timepicker step).
+    step?: number;
+    openingPlaceholder?: string;
+    closingPlaceholder?: string;
+    // Full logic override; a mode-appropriate default is used when omitted.
+    validate?: WeeklyValidator;
+    // Message-only override for the default validators.
+    messages?: WeeklyMessages;
+    // Validate on mount so pre-existing bad data shows immediately (vendor gates save on it).
+    // Default false = admin: errors appear after interaction.
+    validateOnMount?: boolean;
+    // Slot used when enabling a day / adding a range.
+    seedSlot?: () => TimeSlot;
+    // Emits the next value AND its error map on every change. Admin ignores the errors
+    // (server validation_func gates); the vendor consumer gates Save on hasWeeklyErrors().
+    onChange: ( value: WeeklyValue, errors: WeeklyErrors ) => void;
+};

--- a/src/components/WeeklyTimeSlots/utils.ts
+++ b/src/components/WeeklyTimeSlots/utils.ts
@@ -1,0 +1,96 @@
+import { dateI18n } from '@wordpress/date';
+import type { TimeSlot } from './types';
+
+// "Full Day" sentinel; mirrors DeliveryDaysScheduleTransformer::FULL_DAY_SENTINEL.
+export const FULL_DAY = '__full_day__';
+export const MINUTES_PER_DAY = 24 * 60;
+export const DEFAULT_STEP_MINUTES = 30;
+
+const pad = ( n: number ): string => String( n ).padStart( 2, '0' );
+
+// Parse "9:00 am" / "09:00 AM" / "13:30" to minutes since midnight; null when unparseable.
+export const timeToMinutes = ( timeString: string ): number | null => {
+    if ( ! timeString || timeString === FULL_DAY ) {
+        return null;
+    }
+    const match = timeString
+        .trim()
+        .match( /^(\d{1,2}):(\d{2})(?:\s*(am|pm))?$/i );
+    if ( ! match ) {
+        return null;
+    }
+    let hours = Number( match[ 1 ] );
+    const minutes = Number( match[ 2 ] );
+    const meridiem = match[ 3 ]?.toLowerCase();
+    if ( meridiem === 'am' && hours === 12 ) {
+        hours = 0;
+    } else if ( meridiem === 'pm' && hours !== 12 ) {
+        hours += 12;
+    }
+    if ( hours > 23 || minutes > 59 ) {
+        return null;
+    }
+    return hours * 60 + minutes;
+};
+
+// Canonical `g:i a` storage (never varies by display format) — the shape Settings.php
+// normalizes and the transformer's full-day match expect.
+export const minutesToCanonical = ( totalMinutes: number ): string => {
+    const normalized =
+        ( ( totalMinutes % MINUTES_PER_DAY ) + MINUTES_PER_DAY ) %
+        MINUTES_PER_DAY;
+    const hours24 = Math.floor( normalized / 60 );
+    const meridiem = hours24 >= 12 ? 'pm' : 'am';
+    const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+    return `${ hours12 }:${ pad( normalized % 60 ) } ${ meridiem }`;
+};
+
+// Localized time-of-day label. Build the instant in UTC and format in UTC (gmt=true) so the
+// wall-clock time survives any browser/site timezone gap; dateI18n still localizes the meridiem.
+export const minutesToDisplay = (
+    totalMinutes: number,
+    is12Hour: boolean
+): string => {
+    const date = new Date(
+        Date.UTC(
+            2000,
+            0,
+            1,
+            Math.floor( totalMinutes / 60 ),
+            totalMinutes % 60
+        )
+    );
+    return dateI18n( is12Hour ? 'g:i A' : 'H:i', date, true );
+};
+
+// Localize any parseable stored value (even off the preset grid); raw fallback otherwise.
+export const formatTimeForDisplay = (
+    value: string,
+    is12Hour: boolean
+): string => {
+    const minutes = timeToMinutes( value );
+    return minutes === null ? value : minutesToDisplay( minutes, is12Hour );
+};
+
+// Default slot on enable / add. Single mode snaps "now" down to the step grid (so it lands
+// on a preset), closing one step later, clamped from midnight. Multiple mode returns blanks.
+export const defaultSeedSlot = (
+    step: number,
+    multiple: boolean
+): TimeSlot => {
+    if ( multiple ) {
+        return { opening_time: '', closing_time: '' };
+    }
+    const now = new Date();
+    let opening =
+        Math.floor( ( now.getHours() * 60 + now.getMinutes() ) / step ) * step;
+    let closing = opening + step;
+    if ( closing >= MINUTES_PER_DAY ) {
+        closing = MINUTES_PER_DAY - step;
+        opening = closing - step;
+    }
+    return {
+        opening_time: minutesToCanonical( opening ),
+        closing_time: minutesToCanonical( closing ),
+    };
+};

--- a/src/components/WeeklyTimeSlots/validators.ts
+++ b/src/components/WeeklyTimeSlots/validators.ts
@@ -1,0 +1,146 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { FULL_DAY, timeToMinutes } from './utils';
+import type {
+    SlotError,
+    WeeklyErrors,
+    WeeklyMessages,
+    WeeklyValidator,
+} from './types';
+
+const defaultMessages: Required< WeeklyMessages > = {
+    required: ( dayLabel: string ) =>
+        sprintf(
+            // translators: %s is the day name, e.g. Monday.
+            __( '%s delivery time can not be empty', 'dokan-lite' ),
+            dayLabel
+        ),
+    order: ( dayLabel: string ) =>
+        sprintf(
+            // translators: %s is the day name, e.g. Monday.
+            __(
+                '%s closing time must be greater than opening time',
+                'dokan-lite'
+            ),
+            dayLabel
+        ),
+    overlap: ( dayLabel: string ) =>
+        sprintf(
+            // translators: %s is the day name, e.g. Monday.
+            __(
+                '%s opening time must not be earlier than the previous closing time',
+                'dokan-lite'
+            ),
+            dayLabel
+        ),
+};
+
+// Per-slot rule: FULL_DAY passes; otherwise both times are required and closing must be
+// strictly after opening. Unparseable legacy values defer to the server gate.
+const validateSlot = (
+    opening: string,
+    closing: string,
+    messages: Required< WeeklyMessages >,
+    dayLabel: string
+): SlotError | null => {
+    if ( opening === FULL_DAY ) {
+        return null;
+    }
+    if ( ! opening || ! closing ) {
+        return {
+            opening: ! opening,
+            closing: ! closing,
+            message: messages.required( dayLabel ),
+        };
+    }
+    const openingMinutes = timeToMinutes( opening );
+    const closingMinutes = timeToMinutes( closing );
+    if ( openingMinutes === null || closingMinutes === null ) {
+        return null;
+    }
+    if ( closingMinutes <= openingMinutes ) {
+        return {
+            opening: true,
+            closing: true,
+            message: messages.order( dayLabel ),
+        };
+    }
+    return null;
+};
+
+// Admin rules: one range per enabled day.
+export const createSingleValidator = (
+    overrides: WeeklyMessages = {}
+): WeeklyValidator => {
+    const messages = { ...defaultMessages, ...overrides };
+    return ( value, dayLabels ) => {
+        const errors: WeeklyErrors = {};
+        Object.entries( value ).forEach( ( [ dayKey, day ] ) => {
+            if ( ! day?.status || ! day.slots?.length ) {
+                return;
+            }
+            const slotError = validateSlot(
+                day.slots[ 0 ].opening_time,
+                day.slots[ 0 ].closing_time,
+                messages,
+                dayLabels[ dayKey ] ?? dayKey
+            );
+            if ( slotError ) {
+                errors[ dayKey ] = { 0: slotError };
+            }
+        } );
+        return errors;
+    };
+};
+
+// Multi-slot rule: every range required + ordered, and range N must not start before range N-1 ends.
+export const createMultipleValidator = (
+    overrides: WeeklyMessages = {}
+): WeeklyValidator => {
+    const messages = { ...defaultMessages, ...overrides };
+    return ( value, dayLabels ) => {
+        const errors: WeeklyErrors = {};
+        Object.entries( value ).forEach( ( [ dayKey, day ] ) => {
+            if ( ! day?.status || ! day.slots?.length ) {
+                return;
+            }
+            const dayLabel = dayLabels[ dayKey ] ?? dayKey;
+            const dayErrors: Record< number, SlotError > = {};
+            day.slots.forEach( ( slot, index ) => {
+                const slotError = validateSlot(
+                    slot.opening_time,
+                    slot.closing_time,
+                    messages,
+                    dayLabel
+                );
+                if ( slotError ) {
+                    dayErrors[ index ] = slotError;
+                    return;
+                }
+                if ( index === 0 || slot.opening_time === FULL_DAY ) {
+                    return;
+                }
+                const opening = timeToMinutes( slot.opening_time );
+                const prevClosing = timeToMinutes(
+                    day.slots[ index - 1 ].closing_time
+                );
+                if (
+                    opening !== null &&
+                    prevClosing !== null &&
+                    opening < prevClosing
+                ) {
+                    dayErrors[ index ] = {
+                        opening: true,
+                        message: messages.overlap( dayLabel ),
+                    };
+                }
+            } );
+            if ( Object.keys( dayErrors ).length > 0 ) {
+                errors[ dayKey ] = dayErrors;
+            }
+        } );
+        return errors;
+    };
+};
+
+export const hasWeeklyErrors = ( errors: WeeklyErrors ): boolean =>
+    Object.keys( errors ).length > 0;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -8,37 +8,7 @@ export {
 export { default as AdminDataViews } from './dataviews/AdminDataViewTable';
 export { DataViews, Switch, LabeledSwitch } from '@wedevs/plugin-ui';
 
-import { Switch as _PluginUISwitch } from '@wedevs/plugin-ui';
-
-/**
- * Legacy alias for the old `DokanSwitch` component. The underlying
- * plugin-ui `Switch` is a Radix primitive that exposes
- * `onCheckedChange(value: boolean)`. Old call sites (e.g., dokan-pro's
- * delivery-time module) pass `onChange(value: boolean)`. This adapter
- * forwards both names so neither API change breaks consumers.
- */
-type DokanSwitchProps = {
-    checked?: boolean;
-    onChange?: ( value: boolean ) => void;
-    onCheckedChange?: ( value: boolean ) => void;
-    [ key: string ]: unknown;
-};
-
-export const DokanSwitch = ( {
-    onChange,
-    onCheckedChange,
-    checked = false,
-    ...rest
-}: DokanSwitchProps ) => {
-    const handler = onCheckedChange ?? onChange;
-    return (
-        <_PluginUISwitch
-            checked={ checked }
-            onCheckedChange={ handler }
-            { ...rest }
-        />
-    );
-};
+export { DokanSwitch } from './Switch';
 export { default as DokanModal } from './modals/DokanModal';
 export { default as SortableList } from './sortable-list';
 export { default as ListEmpty } from './dataviews/ListEmpty';
@@ -95,6 +65,30 @@ export {
 export { default as VendorAsyncSelect } from './VendorAsyncSelect';
 export { default as VisitStore } from './VisitStore';
 export { default as WpDatePicker } from './WpDatePicker';
+
+// Weekly time-slot schedule editor (single/multiple modes). Shared by Lite's
+// store open-close and Pro's delivery-time weekly schedule.
+export { default as WeeklyTimeSlots } from './WeeklyTimeSlots';
+export {
+    TimeDropdown,
+    FULL_DAY,
+    defaultSeedSlot,
+    timeToMinutes,
+    minutesToCanonical,
+    createSingleValidator,
+    createMultipleValidator,
+    hasWeeklyErrors,
+} from './WeeklyTimeSlots';
+export type {
+    TimeSlot,
+    WeeklyDay,
+    WeeklyValue,
+    SlotError,
+    WeeklyErrors,
+    WeeklyValidator,
+    WeeklyMessages,
+    WeeklyTimeSlotsProps,
+} from './WeeklyTimeSlots';
 
 // Commission Components
 export * from './commission';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a shared **`WeeklyTimeSlots`** component to the Dokan components library (`@dokan/components`) — a reusable weekly time-slot schedule editor so both **Lite** (store open/close time) and **Pro** (delivery-time weekly schedule) can share one implementation instead of each maintaining its own.

- **`src/components/WeeklyTimeSlots/`** — generic editor with `single` (one range/day) and `multiple` (N ranges/day with add/remove) modes, pluggable validation (`validate`/`messages` overrides; per-mode defaults) and a `TimeDropdown` preset picker ("Full Day" + step increments).
- Stores canonical `g:i a` values; display localizes via `dateI18n`, so it honours the WP 12/24-hour setting and translated meridiem (e.g. Bangla AM/PM).
- **`src/components/Switch.tsx`** — extracts the existing inline `DokanSwitch` from the barrel into its own file so `WeeklyTimeSlots` can consume it without a circular import. The barrel re-exports it, so `import { DokanSwitch } from '@dokan/components'` is unchanged for all existing consumers.

Exports added to the barrel: `WeeklyTimeSlots`, `TimeDropdown`, `FULL_DAY`, `createSingleValidator`, `createMultipleValidator`, `hasWeeklyErrors`, `defaultSeedSlot`, `timeToMinutes`, `minutesToCanonical`, and the related types.

### Related Pull Request(s)

* Dokan Pro: getdokan/dokan-pro#5909 (consumes this component in the admin Delivery Days field)
* Base branch: `refactor/simplify-settings-to-flat-array`

### How to test the changes in this Pull Request:

This PR ships the shared component; its first consumer is the Pro Delivery Days field (see the linked Pro PR for the end-to-end test). Sanity check here:

1. `npm run build` builds cleanly; `assets/js/components.js` (the `dokan.components` global) includes `WeeklyTimeSlots`.
2. Existing `DokanSwitch` consumers (e.g. any switch across the admin) still render and toggle — the barrel export is unchanged.

### Changelog entry

*Add shared WeeklyTimeSlots component to @dokan/components*

**Before:** Weekly time-slot editing (store open/close, delivery-time) had no shared React component; each feature rolled its own.

**After:** A reusable single/multiple weekly time-slot editor is exported from `@dokan/components` with pluggable validation and full WP 12/24-hour + translation support, ready for Lite and Pro to share.
