### PR TITLE
chore(dev-env): make .wp-env.json local and add git-worktree tooling

### DIFF
--- a/.claude/skills/dokan-wp-env-worktrees/SKILL.md
+++ b/.claude/skills/dokan-wp-env-worktrees/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: dokan-wp-env-worktrees
+description: Configure and run wp-env across git worktrees with isolated or shared databases, and pair dokan-lite + dokan-pro worktrees for coordinated cross-repo changes — including creating a paired worktree straight from a GitHub PR link (auto-resolving the companion PR). Use when setting up wp-env in a new worktree, creating a worktree from a PR, hitting port conflicts running two environments at once, mounting dokan-pro as a dependency, or reusing a seeded database across checkouts.
+---
+
+# wp-env across git worktrees
+
+How Dokan's `wp-env` environment behaves when the plugin is checked out into
+multiple git worktrees, and how to make each worktree's database **isolated**
+(the default) or **shared** (deliberate).
+
+## How wp-env keys an instance (the one fact that explains everything)
+
+From `@wordpress/env` (`lib/config/load-config.js`):
+
+```js
+cacheDirectoryPath = path.resolve( getCacheDirectory(), md5( configFilePath ) )
+```
+
+- **Instance identity = `md5( absolute path of .wp-env.json )`**, stored under
+  `~/.wp-env/<md5>/` (or `$WP_ENV_HOME/<md5>/`).
+- The Docker Compose project name is that directory, so the database volumes are
+  named `<md5>_mysql` and `<md5>_mysql-test`.
+
+Because every worktree lives at a **different absolute path**, each one hashes to
+a different `<md5>` and therefore gets its **own containers and its own MySQL
+volumes automatically**. Isolation is the default — you do not configure it.
+
+```bash
+docker volume ls | grep mysql     # one <md5>_mysql pair per worktree/checkout
+ls ~/.wp-env                       # one <md5> dir per worktree/checkout
+```
+
+`WP_ENV_HOME` only changes the parent folder; the per-path `<md5>` leaf is
+unchanged, so it does **not** make worktrees share a database.
+
+## The only real conflict: ports
+
+Two worktrees are isolated on disk but both default to `port: 8888` /
+`testsPort: 8889`. Starting a second while the first runs fails with a port
+clash. Give each worktree unique ports.
+
+Config precedence (later wins): `.wp-env.json` → `.wp-env.override.json`.
+Keep the live config **local/per-worktree** — only `.wp-env.json.example` is
+committed. Both `.wp-env.json` and `.wp-env.override.json` are gitignored.
+
+### New worktree setup
+
+```bash
+cp .wp-env.json.example .wp-env.json      # or edit an existing local copy
+```
+
+Then set ports unique to the worktree. Put ports in `.wp-env.override.json` so
+the base `.wp-env.json` (plugin mounts) stays uniform across worktrees:
+
+```jsonc
+// .wp-env.override.json  (gitignored, per-worktree)
+{
+  "port": 8890,
+  "testsPort": 8891,
+  "mysqlPort": 33306,      // only if you connect to MySQL directly
+  "phpmyadminPort": 9091   // only if you enable phpMyAdmin
+}
+```
+
+Convention that avoids collisions: pick a per-worktree base `B` (8888, 8890,
+8892, …) and use `port=B`, `testsPort=B+1`. `mysqlPort` may be left out —
+wp-env assigns a random free port when it is `null`.
+
+## Dependencies (dokan-pro, WooCommerce, add-ons)
+
+wp-env has **no dependency concept** — every entry in `plugins[]` is just mounted
+and activated. Dokan Pro requires Dokan Lite requires WooCommerce, so all three
+must be listed explicitly, ideally in dependency order:
+
+```jsonc
+"plugins": [
+  "https://downloads.wordpress.org/plugin/woocommerce.zip",
+  ".",              // THIS worktree's dokan-lite
+  "../dokan-pro"    // sibling dependency
+]
+```
+
+Two gotchas that bite in worktrees:
+
+1. **Providing a `plugins` array drops the implicit `.`.** wp-env only
+   auto-mounts the current directory in *zero-config* mode
+   (`shouldInferType: ! hasUserConfig` in `parse-config.js`). The moment a
+   `.wp-env.json` exists, you must list `.` yourself. A config that lists
+   `../dokan-pro` but forgets `.` activates Pro **without** Lite → broken env.
+
+2. **Relative sources resolve against the current working directory, not the
+   config file.** `parse-source-string.js` does `path.resolve( sourceString )`,
+   so `../dokan-pro` is relative to wherever you run `npm run env:start`
+   (the worktree root). This works only when the worktree sits under
+   `wp-content/plugins/` next to `dokan-pro`. For a worktree created elsewhere
+   (`git worktree add ~/wt/foo`), `../dokan-pro` won't resolve — use an
+   **absolute path** in that worktree's local config.
+
+**Sharing a dependency across worktrees:** point every lite worktree at the
+**same** dokan-pro checkout (relative if co-located, absolute otherwise). You do
+not need a parallel dokan-pro worktree — *unless* a lite branch needs matching
+pro changes, in which case point that worktree's `.wp-env.override.json` at a
+matching pro worktree by absolute path.
+
+## Coordinated lite + pro changes (paired worktrees)
+
+dokan-lite and dokan-pro are **separate git repos** that are often changed
+together (a feature/bug that spans both). dokan-pro has no wp-env of its own —
+**lite always drives the environment and mounts pro via `../dokan-pro`**. A
+single shared `../dokan-pro` can only be on one branch at a time, so for a
+coordinated change you pair worktrees.
+
+**Convention:** use the **same branch name** in both repos, and place the two
+worktrees side by side under one per-feature folder so `../dokan-pro` resolves to
+the matching pro branch:
+
+```
+~/dokan-wt/feat-x/
+├── dokan-lite/   ← worktree of lite @ feat-x   (runs wp-env, port 8890)
+└── dokan-pro/    ← worktree of pro  @ feat-x   (mounted via ../dokan-pro)
+```
+
+New path → new `md5` → own isolated DB automatically; just bump ports.
+
+### From a PR link (recommended — resolves the companion PR automatically)
+
+`worktree-from-pr.sh` takes **either** the lite PR **or** the pro PR, reads its
+body for the companion ("Related PR" / "Companion Pro PR" link to the other
+repo), and checks out the matching branch in **both** repos as paired worktrees.
+Falls back to the same branch name in the other repo if the body has no link,
+and to a lite-only env (pro mounted from the shared main checkout) if there is
+no companion at all.
+
+```bash
+.claude/skills/dokan-wp-env-worktrees/worktree-from-pr.sh https://github.com/getdokan/dokan/pull/3141
+# accepts:  3141  (bare number ⇒ lite repo)  |  getdokan/dokan-pro#5538  |  full URL
+# optional 2nd arg = port, e.g. ... /pull/3141 8892
+```
+
+It resolves branch + base per repo via `gh`, fast-forwards each worktree to the
+PR head, and writes `.wp-env.json` + `.wp-env.override.json` (ports). Requires an
+authenticated `gh` and `jq`. Run it from inside the dokan-lite main checkout.
+
+### From a branch name (when the branch already exists / no PR yet)
+
+```bash
+.claude/skills/dokan-wp-env-worktrees/create-paired-worktree.sh feat-x develop 8890
+```
+
+Both scripts only *create + configure* the worktrees. They deliberately do **not**
+install or build — do that with the bootstrap sequence below.
+
+## Bootstrap a paired worktree (install + build)
+
+> **Name the lite worktree folder `dokan`, not `dokan-lite`.** wp-env mounts a
+> local plugin at `/var/www/html/wp-content/plugins/<folder-basename>`, and
+> Dokan's `npm run phpunit` hardcodes `--env-cwd=wp-content/plugins/dokan`. A
+> folder named `dokan-lite` mounts at `.../plugins/dokan-lite`, so
+> `npm run phpunit` (and the Mode 2b seed paths below) break. The helper scripts
+> currently create `dokan-lite/` — rename to `dokan/` or adjust `--env-cwd`.
+
+A fresh worktree has no `node_modules`, `vendor`, or built `assets/` (worktrees
+don't share them with the main checkout). Run this order:
+
+```bash
+WT=~/dokan-wt/feat-x
+
+# 1. LITE first, fully (composer → npm → build)
+cd "$WT/dokan-lite" && composer install && npm ci && npm run build
+
+# 2. THEN pro
+cd "$WT/dokan-pro" && composer install && npm ci && npm run build
+
+# 3. Start the env from the LITE worktree
+cd "$WT/dokan-lite" && npx wp-env start          # http://localhost:8890
+```
+
+Why the order matters:
+
+- **Lite before pro.** dokan-pro's `webpack.config.js` requires
+  `../dokan-lite/webpack-dependency-mapping.js`, which `require('lodash')` from
+  **dokan-lite's** `node_modules`. Build pro before lite is installed and it dies
+  with `[webpack-cli] Cannot find module 'lodash'`.
+- `composer install` pulls ~90 packages (Google/Stripe/Mangopay SDKs, Mozart) —
+  no auth needed for the public deps. This part works reliably.
+
+> ⚠️ **UNRESOLVED BLOCKER — `npm ci`/`npm install` fails in a worktree.**
+> lite's `package.json` has a private git dep
+> `"@getdokan/dokan-ui": "github:getdokan/dokan-ui#dokan-plugin"` (cloned over
+> SSH). In a linked git worktree, both `npm ci` and `npm install` fail
+> **reproducibly** with:
+> ```
+> npm error code 128
+> npm error command git ... clone --mirror -q ssh://git@github.com/getdokan/dokan-ui.git .../_cacache/tmp/git-clone…/.git
+> npm error fatal: destination path '.../git-clone…/.git' already exists and is not an empty directory.
+> ```
+> It looks like npm cloning the same git dep twice concurrently into one temp path.
+>
+> **Verified this is NOT auth/network:** a raw
+> `git clone --mirror ssh://git@github.com/getdokan/dokan-ui.git <dir>/.git`
+> succeeds, and `ssh -T git@github.com` greets you.
+>
+> **Tried and did NOT help** (2026-07-07, npm 11.17.0 / node 22.22.0):
+> `rm -rf ~/.npm/_cacache/tmp/git-clone*`, a fresh `--cache <dir>`, a warmed
+> cache, `npm install` instead of `npm ci`, and `npm ci --maxsockets=1`.
+> Pro's own `npm ci` sometimes succeeds (it runs second and reuses leftover
+> cache state), which is misleading — lite, running first against a cold state,
+> always fails.
+>
+> **Untested leads / candidate workarounds** (confirm before trusting):
+> - Does `npm ci` work in a **non-worktree** checkout of the same branch? If so,
+>   the bug is git-worktree-specific → install there and copy `node_modules` in.
+> - Try an older npm (`npm i -g npm@10`) — the concurrent-git-clone races differ
+>   by npm major.
+> - Pre-seed `node_modules/@getdokan/dokan-ui` from a checkout where it installed.
+
+Other notes:
+- **Lite-only change:** skip the pro worktree and point at the shared main pro
+  checkout (absolute path in `.wp-env.override.json`). The shared pro is on one
+  branch at a time, which is fine when you aren't touching it.
+- If lite and pro versions are enforced (pro checks a minimum lite version),
+  dev branches report dev versions and pass — no special handling needed.
+
+## Mode 1 — Isolated database (default, recommended)
+
+Each worktree = its own fresh WordPress + MySQL. Use for parallel branches that
+must not see each other's data.
+
+```bash
+npm run env:start          # provisions this worktree's own DB
+npm run phpunit            # runs against this worktree's own test DB
+npm run env:stop
+```
+
+Nothing extra to configure beyond unique ports. The cost is re-provisioning
+(WP install, WooCommerce, sample data) per worktree.
+
+## Mode 2 — Shared / reusable database
+
+wp-env cannot live-share one MySQL volume across two paths (the volume name is
+derived from the config path). "Sharing" therefore means one of:
+
+### 2a. One owner instance, code swapped by remount (true single DB)
+
+Run the environment from **one** checkout only and point its `plugins` /
+`mappings` at whichever worktree's code you want live. Other worktrees do not
+run their own env; their tooling targets the owner's port. Simple, but only one
+code tree is active at a time.
+
+### 2b. Clone a seeded DB into a new worktree (recommended for "reuse the setup")
+
+Provision once, then snapshot and restore into each new worktree's own
+(isolated) instance. You get fast provisioning **and** independence. The dump
+path must be inside a **bind-mounted** dir so both `cli` and `tests-cli`
+containers (and the host) can see it — the plugin mount works. Replace `dokan`
+below with your actual lite worktree folder name if it differs.
+
+```bash
+P=/var/www/html/wp-content/plugins/dokan        # = the lite mount (folder basename)
+
+# In the seeded/owner worktree — export both DBs:
+npx wp-env run cli -- wp db export "$P/.wp-env-seed.sql"
+npx wp-env run tests-cli -- wp db export "$P/.wp-env-seed-tests.sql"
+
+# In a fresh worktree after `npm run env:start` — import them:
+npx wp-env run cli -- wp db import "$P/.wp-env-seed.sql"
+npx wp-env run cli -- wp search-replace 'http://localhost:8888' 'http://localhost:8890' --all-tables
+npx wp-env run tests-cli -- wp db import "$P/.wp-env-seed-tests.sql"
+```
+
+Adjust the `search-replace` URLs to the source and target `port`. Add
+`.wp-env-seed*.sql` to `.gitignore` if you keep dumps in the tree.
+
+## Gotchas
+
+- **Config changes need a `wp-env start` to take effect.** Plugin mounts live in
+  the generated `docker-compose.yml`, which is only rewritten on `start`. Adding
+  `.` (or any plugin) to a config while the env is already running does nothing
+  until you `npx wp-env start` again. Symptom: a plugin listed in `plugins[]`
+  (e.g. dokan-lite via `.`) is missing from wp-admin, so a dependent (dokan-pro)
+  refuses to activate with "required plugins are missing or inactive".
+- **Default theme:** wp-env has no active-theme option; set it with an
+  `afterStart` lifecycle script. Twenty Twenty-Five ships with WP core (6.7+), so
+  it only needs activating:
+  ```jsonc
+  "lifecycleScripts": {
+    "afterStart": "npx wp-env run cli wp theme activate twentytwentyfive && npx wp-env run tests-cli wp theme activate twentytwentyfive"
+  }
+  ```
+- Editing `~/.wp-env/<md5>/docker-compose.yml` by hand does not stick — wp-env
+  regenerates it on every `start`. Configure via `.wp-env.json` /
+  `.wp-env.override.json` instead.
+- `npx wp-env destroy` removes **only the current worktree's** `<md5>` instance
+  and volumes, not the others.
+- Orphaned volumes from deleted worktrees: `docker volume ls | grep mysql`
+  lists every `<md5>_mysql`; prune the ones whose `~/.wp-env/<md5>` worktree is
+  gone.
+- `phpunit` scripts use `--env-cwd=wp-content/plugins/dokan`, so container paths
+  are under `/var/www/html/wp-content/plugins/dokan/`.

--- a/.claude/skills/dokan-wp-env-worktrees/create-paired-worktree.sh
+++ b/.claude/skills/dokan-wp-env-worktrees/create-paired-worktree.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Create a paired dokan-lite + dokan-pro worktree for a coordinated feature that
+# touches both repos. The two worktrees are placed side by side so the lite
+# worktree's "../dokan-pro" mount resolves to the matching pro branch, and the
+# new path gets its own isolated wp-env database automatically.
+#
+# Usage:
+#   create-paired-worktree.sh <branch> [base-branch] [port]
+#
+# Env overrides:
+#   DOKAN_WT_HOME   parent dir for worktrees (default: ~/dokan-wt)
+#   PRO_BASE        base branch for a NEW pro branch  (default: develop)
+#
+# Run from anywhere inside the dokan-lite main checkout.
+set -euo pipefail
+
+BRANCH="${1:?usage: create-paired-worktree.sh <branch> [base-branch] [port]}"
+BASE="${2:-develop}"
+PORT="${3:-8890}"
+TESTS_PORT=$(( PORT + 1 ))
+
+# Resolve the two main checkouts. dokan-pro is expected next to dokan-lite.
+LITE_MAIN="$( git rev-parse --show-toplevel )"
+PLUGINS_DIR="$( dirname "$LITE_MAIN" )"
+PRO_MAIN="$PLUGINS_DIR/dokan-pro"
+[ -d "$PRO_MAIN/.git" ] || { echo "dokan-pro not found at $PRO_MAIN"; exit 1; }
+
+SLUG="${BRANCH//\//-}"
+DEST="${DOKAN_WT_HOME:-$HOME/dokan-wt}/$SLUG"
+mkdir -p "$DEST"
+
+add_worktree() { # <repo> <path> <branch> <base>
+  local repo="$1" path="$2" branch="$3" base="$4"
+  if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$repo" worktree add "$path" "$branch"
+  else
+    git -C "$repo" worktree add -b "$branch" "$path" "$base"
+  fi
+}
+
+add_worktree "$LITE_MAIN" "$DEST/dokan-lite" "$BRANCH" "$BASE"
+add_worktree "$PRO_MAIN"  "$DEST/dokan-pro"  "$BRANCH" "${PRO_BASE:-develop}"
+
+cat > "$DEST/dokan-lite/.wp-env.json" <<JSON
+{
+  "core": null,
+  "phpVersion": "7.4",
+  "plugins": [
+    "https://downloads.wordpress.org/plugin/woocommerce.zip",
+    ".",
+    "../dokan-pro"
+  ],
+  "lifecycleScripts": {
+    "afterStart": "npx wp-env run cli wp theme activate twentytwentyfive && npx wp-env run tests-cli wp theme activate twentytwentyfive"
+  }
+}
+JSON
+
+cat > "$DEST/dokan-lite/.wp-env.override.json" <<JSON
+{ "port": $PORT, "testsPort": $TESTS_PORT }
+JSON
+
+cat <<EOF
+
+Paired worktree ready: $DEST
+  lite: $DEST/dokan-lite  ($BRANCH)   ← runs wp-env on port $PORT
+  pro:  $DEST/dokan-pro   ($BRANCH)   ← mounted via ../dokan-pro
+
+Next (build LITE first — pro's webpack.config.js requires ../dokan-lite/node_modules):
+  cd "$DEST/dokan-lite" && composer install && npm ci && npm run build
+  cd "$DEST/dokan-pro"  && composer install && npm ci && npm run build
+  cd "$DEST/dokan-lite" && npx wp-env start           # http://localhost:$PORT
+  # If npm ci fails on the @getdokan/dokan-ui git clone
+  # (code 128 / "destination path ... already exists"):  rm -rf ~/.npm/_cacache/tmp/git-clone*  and retry.
+
+Tear down when merged:
+  git -C "$LITE_MAIN" worktree remove "$DEST/dokan-lite"
+  git -C "$PRO_MAIN"  worktree remove "$DEST/dokan-pro"
+  (cd "$DEST/dokan-lite" && npx wp-env destroy)        # drop its DB volumes
+EOF

--- a/.claude/skills/dokan-wp-env-worktrees/worktree-from-pr.sh
+++ b/.claude/skills/dokan-wp-env-worktrees/worktree-from-pr.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Create paired dokan-lite + dokan-pro worktrees straight from a GitHub PR link.
+#
+# Give it EITHER the lite PR or the pro PR — it reads that PR's body, finds the
+# companion PR (the "Related PR" / "Companion Pro PR" link to the other repo),
+# and checks out the matching branch in both repos as side-by-side worktrees so
+# "../dokan-pro" resolves correctly and the DB is isolated. Falls back to the
+# same branch name in the other repo if the body has no companion link.
+#
+# Usage:
+#   worktree-from-pr.sh <pr-url | pr-number | owner/repo#number> [port]
+#
+# Examples:
+#   worktree-from-pr.sh https://github.com/getdokan/dokan/pull/3141
+#   worktree-from-pr.sh 3141                 # bare number ⇒ lite repo
+#   worktree-from-pr.sh getdokan/dokan-pro#5538 8892
+#
+# Env overrides:
+#   DOKAN_WT_HOME   parent dir for worktrees (default: ~/dokan-wt)
+#
+# Requires: gh (authenticated), jq. Run from inside the dokan-lite main checkout.
+set -euo pipefail
+
+LITE_REPO="getdokan/dokan"
+PRO_REPO="getdokan/dokan-pro"
+
+INPUT="${1:?usage: worktree-from-pr.sh <pr-url|number|owner/repo#number> [port]}"
+PORT="${2:-8890}"
+TESTS_PORT=$(( PORT + 1 ))
+
+command -v gh >/dev/null || { echo "gh CLI required"; exit 1; }
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+# --- parse input into <repo> + <number> ---
+repo="" num=""
+if [[ "$INPUT" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  repo="${BASH_REMATCH[1]}"; num="${BASH_REMATCH[2]}"
+elif [[ "$INPUT" =~ ^([^#]+/[^#]+)#([0-9]+)$ ]]; then
+  repo="${BASH_REMATCH[1]}"; num="${BASH_REMATCH[2]}"
+elif [[ "$INPUT" =~ ^[0-9]+$ ]]; then
+  repo="$LITE_REPO"; num="$INPUT"
+else
+  echo "Cannot parse PR reference: $INPUT"; exit 1
+fi
+
+# --- fetch this PR ---
+meta="$( gh pr view "$num" --repo "$repo" --json headRefName,baseRefName,body )"
+this_branch="$( jq -r .headRefName <<<"$meta" )"
+this_base="$( jq -r .baseRefName <<<"$meta" )"
+body="$( jq -r .body <<<"$meta" )"
+
+if [[ "$repo" == "$PRO_REPO" ]]; then
+  this_side="pro";  other_repo="$LITE_REPO"
+else
+  this_side="lite"; other_repo="$PRO_REPO"
+fi
+
+# --- find the companion PR number in the body (URL or owner/repo#N form) ---
+other_num="$( grep -oiE "(${other_repo}/pull/|${other_repo}#)[0-9]+" <<<"$body" \
+              | grep -oE '[0-9]+' | head -1 || true )"
+
+other_branch=""
+if [[ -n "$other_num" ]]; then
+  other_branch="$( gh pr view "$other_num" --repo "$other_repo" --json headRefName -q .headRefName )"
+  echo "Companion PR: $other_repo#$other_num  (branch: $other_branch)"
+elif git ls-remote --exit-code --heads "https://github.com/${other_repo}.git" "$this_branch" >/dev/null 2>&1; then
+  other_branch="$this_branch"
+  echo "No companion PR in body; matched same branch name in $other_repo."
+else
+  echo "No companion PR and no matching branch in $other_repo — creating a lite-only env."
+fi
+
+# --- map to lite/pro branch names ---
+if [[ "$this_side" == "lite" ]]; then
+  lite_branch="$this_branch"; pro_branch="$other_branch"
+else
+  pro_branch="$this_branch";  lite_branch="$other_branch"
+fi
+
+# --- resolve main checkouts (dokan-pro expected next to dokan-lite) ---
+LITE_MAIN="$( git rev-parse --show-toplevel )"
+PLUGINS_DIR="$( dirname "$LITE_MAIN" )"
+PRO_MAIN="$PLUGINS_DIR/dokan-pro"
+
+SLUG="${this_branch//\//-}"
+DEST="${DOKAN_WT_HOME:-$HOME/dokan-wt}/$SLUG"
+mkdir -p "$DEST"
+
+# add_worktree <repo-main> <path> <branch> [base]
+add_worktree() {
+  local main="$1" path="$2" br="$3" base="${4:-develop}"
+  git -C "$main" fetch --quiet origin "$br" 2>/dev/null || true
+  if git -C "$main" show-ref --verify --quiet "refs/heads/$br"; then
+    git -C "$main" worktree add "$path" "$br"
+    git -C "$path" merge --ff-only "origin/$br" 2>/dev/null || true   # match PR head (no-op if ahead)
+  elif git -C "$main" show-ref --verify --quiet "refs/remotes/origin/$br"; then
+    git -C "$main" worktree add -b "$br" "$path" "origin/$br"
+  else
+    git -C "$main" worktree add -b "$br" "$path" "$base"
+  fi
+}
+
+[[ -n "$lite_branch" ]] && add_worktree "$LITE_MAIN" "$DEST/dokan-lite" "$lite_branch" "$this_base"
+
+if [[ -n "$pro_branch" && -d "$PRO_MAIN/.git" ]]; then
+  add_worktree "$PRO_MAIN" "$DEST/dokan-pro" "$pro_branch" develop
+  PRO_MOUNT="../dokan-pro"
+else
+  PRO_MOUNT="$PRO_MAIN"   # lite-only: mount the shared main pro checkout by absolute path
+fi
+
+cat > "$DEST/dokan-lite/.wp-env.json" <<JSON
+{
+  "core": null,
+  "phpVersion": "7.4",
+  "plugins": [
+    "https://downloads.wordpress.org/plugin/woocommerce.zip",
+    ".",
+    "${PRO_MOUNT}"
+  ],
+  "lifecycleScripts": {
+    "afterStart": "npx wp-env run cli wp theme activate twentytwentyfive && npx wp-env run tests-cli wp theme activate twentytwentyfive"
+  }
+}
+JSON
+
+cat > "$DEST/dokan-lite/.wp-env.override.json" <<JSON
+{ "port": $PORT, "testsPort": $TESTS_PORT }
+JSON
+
+cat <<EOF
+
+Worktree ready: $DEST
+  lite: $DEST/dokan-lite  (${lite_branch:-<none>})   ← runs wp-env on port $PORT
+  pro:  ${pro_branch:+$DEST/dokan-pro  ($pro_branch)}${pro_branch:-mounted from $PRO_MAIN (shared main checkout)}
+
+Next (build LITE first — pro's webpack.config.js requires ../dokan-lite/node_modules):
+  cd "$DEST/dokan-lite" && composer install && npm ci && npm run build
+  ${pro_branch:+cd "$DEST/dokan-pro"  && composer install && npm ci && npm run build}
+  cd "$DEST/dokan-lite" && npx wp-env start           # http://localhost:$PORT
+  # If npm ci fails on the @getdokan/dokan-ui git clone
+  # (code 128 / "destination path ... already exists"):  rm -rf ~/.npm/_cacache/tmp/git-clone*  and retry.
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ config.json
 /lib/classes/
 .env
 
+# wp-env: live config is per-machine / per-worktree. Commit .wp-env.json.example only.
+.wp-env.json
+.wp-env.override.json
+
 # Composer
 /vendor/
 phpcs-report.txt

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,0 @@
-{
-  "core": null,
-  "phpVersion": "7.4",
-  "plugins": [
-	".",
-	"https://downloads.wordpress.org/plugin/woocommerce.zip"
-  ]
-}

--- a/.wp-env.json.example
+++ b/.wp-env.json.example
@@ -1,0 +1,14 @@
+{
+  "core": null,
+  "phpVersion": "7.4",
+  "plugins": [
+	  ".",
+	  "https://downloads.wordpress.org/plugin/woocommerce.zip",
+    "../dokan-pro"
+  ],
+  "port": 8888,
+  "testsPort": 8889,
+  "lifecycleScripts": {
+    "afterStart": "npx wp-env run cli wp theme activate twentytwentyfive && npx wp-env run tests-cli wp theme activate twentytwentyfive"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ The `.claude/skills/` directory contains procedural HOW-TO instructions:
 - **`dokan-git`** — Git and GitHub operations: branching, PR templates, CI checks
 - **`dokan-qa-automation`** — Playwright E2E and REST API test conventions under `tests/pw/`: page objects, tags, ApiUtils, schemas, CI compatibility
 - **`dokan-run-test-suite`** — Run the Playwright suite (local or CI). **Invoke when the team asks to "run the suite", trigger CI, or debug a failed run.**
+- **`dokan-wp-env-worktrees`** — Configure `wp-env` across git worktrees with isolated (default) or shared databases; resolve port conflicts when running two environments at once.
 
 ## Build & Development Commands
 
@@ -38,10 +39,17 @@ npm run phpunit            # Run PHPUnit tests (via wp-env)
 npm run phpunit:coverage   # PHPUnit with coverage
 npm run test:phpunit       # Start env, run tests, stop env
 
-# Environment
+# Environment (first run: create your local wp-env config)
+cp .wp-env.json.example .wp-env.json   # one-time; .wp-env.json is gitignored (per-machine)
 npm run env:start          # Start wp-env
 npm run env:stop           # Stop wp-env
 ```
+
+> `.wp-env.json` is **not** committed — it is per-machine/per-worktree (local
+> ports, plugin mounts, dependency paths). Copy `.wp-env.json.example` to
+> `.wp-env.json` and adjust it locally. See the `dokan-wp-env-worktrees` skill
+> for worktree-specific setup. For overrides that shouldn't touch the base
+> config, use `.wp-env.override.json` (also gitignored).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Makes the wp-env config **per-machine/per-worktree** and adds tooling + docs for running Dokan across git worktrees.

- **`.wp-env.json` is no longer committed** — it holds local ports, plugin mounts, and dependency paths that differ per machine/worktree. It (and `.wp-env.override.json`) are now gitignored.
- **`.wp-env.json.example` is committed** as the template — mounts WooCommerce + `.` (dokan-lite) + `../dokan-pro`, sets default ports, and activates Twenty Twenty-Five via an `afterStart` lifecycle script.
- **First-run instruction** added to `CLAUDE.md`: `cp .wp-env.json.example .wp-env.json`.
- **New `dokan-wp-env-worktrees` skill** (`.claude/skills/`) documenting how wp-env isolates DBs per worktree, port handling, dependency mounting (lite+pro), paired worktrees for coordinated cross-repo changes, and the install/build order — plus two helper scripts:
  - `create-paired-worktree.sh <branch> [base] [port]`
  - `worktree-from-pr.sh <pr-url|number|owner/repo#N> [port]` (auto-resolves the companion Pro PR from the body)

## Why

Every git worktree lives at a different path, so wp-env already gives each its own database automatically — the only real friction is ports and the committed config fighting local edits. Making `.wp-env.json` local removes that friction; the example keeps onboarding one command.

## Migration for existing clones

`.wp-env.json` is now gitignored. After pulling:

```bash
cp .wp-env.json.example .wp-env.json   # then adjust ports/mounts locally
```

Your existing local `.wp-env.json` keeps working — it just stops being tracked.

## Notes

- Docs-only + dev-env config; no plugin runtime code changes.
- The skill's SKILL.md documents a known, still-unresolved `npm ci` blocker on the private `@getdokan/dokan-ui` git dependency inside worktrees (honestly recorded, not claimed fixed).

## Test plan

- [ ] Fresh clone: `cp .wp-env.json.example .wp-env.json && npm run env:start` brings up WooCommerce + Dokan Lite + Dokan Pro (if `../dokan-pro` present) with Twenty Twenty-Five active.
- [ ] `git status` no longer shows `.wp-env.json` after local edits.
- [ ] `.wp-env.override.json` overrides ports without editing the base config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scripts to create paired WordPress worktrees for Dokan Lite and Pro from either a branch or a PR reference.
  * Added a sample WordPress environment configuration for local setup with custom ports and theme activation.

* **Documentation**
  * Expanded setup guidance for using `wp-env` across multiple worktrees, including port conflicts, plugin ordering, and shared vs. isolated databases.
  * Updated onboarding notes to explain first-time local configuration and the new worktree workflow.

* **Chores**
  * Ignored generated WordPress environment config files in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->