### PR TITLE
refactor(weekly-time-slots): localized digits + auto-flip dropdown placement

### DIFF
--- a/src/components/WeeklyTimeSlots/TimeDropdown.tsx
+++ b/src/components/WeeklyTimeSlots/TimeDropdown.tsx
@@ -21,12 +21,32 @@ export type TimeDropdownProps = {
     // Offer the "Full Day" preset (opening dropdowns only — a closing can never be "Full Day").
     includeFullDay?: boolean;
     step?: number;
+    // Render as a static, non-editable field (e.g. the "Full Day" closing placeholder).
+    readOnly?: boolean;
 };
 
 type TimeOption = { key: string; label: string; minutes: number | null };
 
-// Preset dropdown (legacy jQuery-timepicker UX): "Full Day" + step increments. Stores the
-// canonical `g:i a` key (or FULL_DAY sentinel); labels re-localize per render via dateI18n.
+const LIST_MAX_HEIGHT = 288;
+
+// Visible clip window: the viewport intersected with every scroll/overflow ancestor (e.g. the
+// admin settings card), so the in-flow list can flip up / shrink to fit instead of being cut off.
+const getClipWindow = ( el: HTMLElement ): { top: number; bottom: number } => {
+    let top = 0;
+    let bottom = window.innerHeight;
+    let node = el.parentElement;
+    while ( node ) {
+        if ( getComputedStyle( node ).overflowY !== 'visible' ) {
+            const rect = node.getBoundingClientRect();
+            top = Math.max( top, rect.top );
+            bottom = Math.min( bottom, rect.bottom );
+        }
+        node = node.parentElement;
+    }
+    return { top, bottom };
+};
+
+// Writable time combobox: type a custom time (parsed on commit) or pick a preset; the in-flow list keeps the app's scoped Tailwind styling.
 const TimeDropdown = ( {
     value = '',
     onChange,
@@ -35,19 +55,34 @@ const TimeDropdown = ( {
     hasError = false,
     includeFullDay = false,
     step = DEFAULT_STEP_MINUTES,
+    readOnly = false,
 }: TimeDropdownProps ) => {
     const [ open, setOpen ] = useState( false );
+    // The list opens downward by default; it flips up / shrinks to stay inside the clip window.
+    const [ placement, setPlacement ] = useState( {
+        up: false,
+        maxHeight: LIST_MAX_HEIGHT,
+    } );
     const wrapRef = useRef< HTMLDivElement | null >( null );
     const listRef = useRef< HTMLUListElement | null >( null );
+    const inputRef = useRef< HTMLInputElement | null >( null );
+
+    const fullDayLabel = __( 'Full Day', 'dokan-lite' );
+
+    // The text a stored value shows as: Full Day sentinel, localized time, or ''.
+    const valueToText = ( raw: string ): string => {
+        if ( raw === FULL_DAY ) {
+            return fullDayLabel;
+        }
+        return raw ? formatTimeForDisplay( raw, is12Hour ) : '';
+    };
+
+    const [ inputText, setInputText ] = useState( () => valueToText( value ) );
 
     const options = useMemo( () => {
         const opts: TimeOption[] = [];
         if ( includeFullDay ) {
-            opts.push( {
-                key: FULL_DAY,
-                label: __( 'Full Day', 'dokan-lite' ),
-                minutes: null,
-            } );
+            opts.push( { key: FULL_DAY, label: fullDayLabel, minutes: null } );
         }
         for ( let m = 0; m < MINUTES_PER_DAY; m += step ) {
             opts.push( {
@@ -59,26 +94,75 @@ const TimeDropdown = ( {
         return opts;
     }, [ includeFullDay, is12Hour, step ] );
 
-    // Match by minutes so stored values with other casing/padding ("09:00 AM") still highlight.
+    // Match by minutes so stored values with other casing/padding still highlight.
     const valueMinutes = timeToMinutes( value );
     const isSelected = ( option: TimeOption ): boolean =>
         option.key === value ||
         ( valueMinutes !== null && option.minutes === valueMinutes );
 
-    const displayLabel =
-        value === FULL_DAY
-            ? __( 'Full Day', 'dokan-lite' )
-            : value && formatTimeForDisplay( value, is12Hour );
+    // Keep the field text in sync with the stored value whenever we're not editing.
+    useEffect( () => {
+        if ( ! open ) {
+            setInputText( valueToText( value ) );
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ value, is12Hour, open ] );
 
+    // Commit the live input value (via ref, so the outside-click listener isn't stale) as a custom time or Full Day; invalid input is ignored.
+    const commitText = () => {
+        const text = ( inputRef.current?.value ?? inputText ).trim();
+        if ( ! text ) {
+            onChange?.( '' );
+            return;
+        }
+        if (
+            includeFullDay &&
+            text.toLowerCase() === fullDayLabel.toLowerCase()
+        ) {
+            onChange?.( FULL_DAY );
+            return;
+        }
+        const minutes = timeToMinutes( text );
+        if ( minutes !== null ) {
+            onChange?.( minutesToCanonical( minutes ) );
+        }
+        // else: keep the stored value; the sync effect restores its text.
+    };
+
+    const selectOption = ( option: TimeOption ) => {
+        onChange?.( option.key );
+        setInputText( option.label );
+        setOpen( false );
+    };
+
+    // Commit the typed text and close when clicking away; scroll the current value into view on open.
     useEffect( () => {
         if ( ! open ) {
             return;
+        }
+        // Flip up when the space below can't fit the list; cap its height to the room available.
+        const wrap = wrapRef.current;
+        if ( wrap ) {
+            const rect = wrap.getBoundingClientRect();
+            const clip = getClipWindow( wrap );
+            const gap = 4;
+            const below = clip.bottom - rect.bottom - gap;
+            const above = rect.top - clip.top - gap;
+            const up = below < LIST_MAX_HEIGHT && above > below;
+            setPlacement( {
+                up,
+                maxHeight: Math.max(
+                    160,
+                    Math.min( LIST_MAX_HEIGHT, up ? above : below )
+                ),
+            } );
         }
         const handler = ( event: MouseEvent ) => {
             if (
                 wrapRef.current &&
                 ! wrapRef.current.contains( event.target as Node )
             ) {
+                commitText();
                 setOpen( false );
             }
         };
@@ -88,40 +172,70 @@ const TimeDropdown = ( {
         ) as HTMLElement | null;
         selected?.scrollIntoView?.( { block: 'center' } );
         return () => document.removeEventListener( 'mousedown', handler );
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ open ] );
-
-    const selectOption = ( option: TimeOption ) => {
-        onChange?.( option.key );
-        setOpen( false );
-    };
 
     return (
         <div ref={ wrapRef } className="relative inline-block">
-            <button
-                type="button"
-                onClick={ () => setOpen( ( isOpen ) => ! isOpen ) }
+            <div
                 className={ twMerge(
-                    'flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-sm shadow-sm min-w-[155px] focus:outline-none focus:ring-2 focus:ring-[#7047EB]',
+                    'flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-sm shadow-sm min-w-[155px] focus-within:ring-2 focus-within:ring-[#7047EB]',
                     hasError
                         ? 'border-red-500 ring-1 ring-red-500'
-                        : 'border-gray-300'
+                        : 'border-gray-300',
+                    readOnly && 'cursor-not-allowed opacity-50'
                 ) }
             >
-                <Clock size={ 16 } className="text-gray-400" />
-                <span
+                <Clock size={ 16 } className="shrink-0 text-gray-400" />
+                <input
+                    ref={ inputRef }
+                    type="text"
+                    value={ inputText }
+                    placeholder={ placeholder }
+                    readOnly={ readOnly }
+                    onChange={ ( event ) => setInputText( event.target.value ) }
+                    onFocus={ () => ! readOnly && setOpen( true ) }
+                    onClick={ () => ! readOnly && setOpen( true ) }
+                    onKeyDown={ ( event ) => {
+                        if ( event.key === 'Enter' ) {
+                            event.preventDefault();
+                            commitText();
+                            setOpen( false );
+                        } else if ( event.key === 'Escape' ) {
+                            setInputText( valueToText( value ) );
+                            setOpen( false );
+                        }
+                    } }
+                    // Bare field: strip the theme/WP input chrome so it blends into the wrapper.
+                    className="min-w-0 flex-1 appearance-none! m-0! h-auto! min-h-0! border-0! bg-transparent! p-0! text-sm! text-[#25252D] shadow-none! outline-none! focus:outline-none! focus:ring-0! focus:shadow-none! placeholder:text-gray-400"
+                />
+                <ChevronDown
+                    size={ 14 }
                     className={ twMerge(
-                        'flex-1 text-left text-[#25252D]',
-                        ! displayLabel && 'text-gray-400'
+                        'shrink-0 text-gray-400',
+                        ! readOnly && 'cursor-pointer'
                     ) }
-                >
-                    { displayLabel || placeholder }
-                </span>
-                <ChevronDown size={ 14 } className="text-gray-400" />
-            </button>
-            { open && (
+                    onClick={ () => {
+                        if ( readOnly ) {
+                            return;
+                        }
+                        if ( open ) {
+                            setOpen( false );
+                        } else {
+                            inputRef.current?.focus();
+                            setOpen( true );
+                        }
+                    } }
+                />
+            </div>
+            { open && ! readOnly && (
                 <ul
                     ref={ listRef }
-                    className="absolute z-50 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-gray-300 bg-white py-1 shadow-lg"
+                    style={ { maxHeight: placement.maxHeight } }
+                    className={ twMerge(
+                        'absolute z-50 w-full overflow-y-auto rounded-md border border-gray-300 bg-white py-1 shadow-lg',
+                        placement.up ? 'bottom-full mb-1' : 'top-full mt-1'
+                    ) }
                     role="listbox"
                 >
                     { options.map( ( option ) => {
@@ -132,6 +246,10 @@ const TimeDropdown = ( {
                                 key={ option.key }
                                 role="option"
                                 aria-selected={ selected }
+                                // Keep the input focused so its blur doesn't pre-empt the click.
+                                onMouseDown={ ( event ) =>
+                                    event.preventDefault()
+                                }
                                 onClick={ () => selectOption( option ) }
                                 className={ twMerge(
                                     'cursor-pointer px-3 py-2 text-sm hover:bg-gray-100',

--- a/src/components/WeeklyTimeSlots/TimeDropdown.tsx
+++ b/src/components/WeeklyTimeSlots/TimeDropdown.tsx
@@ -23,14 +23,15 @@ export type TimeDropdownProps = {
     step?: number;
     // Render as a static, non-editable field (e.g. the "Full Day" closing placeholder).
     readOnly?: boolean;
+    // Extra classes for the outer wrapper (e.g. responsive width inside a slot row).
+    wrapperClassName?: string;
 };
 
 type TimeOption = { key: string; label: string; minutes: number | null };
 
 const LIST_MAX_HEIGHT = 288;
 
-// Visible clip window: the viewport intersected with every scroll/overflow ancestor (e.g. the
-// admin settings card), so the in-flow list can flip up / shrink to fit instead of being cut off.
+// Visible clip window (viewport ∩ every scroll/overflow ancestor, e.g. the admin settings card) so the in-flow list flips up / shrinks to fit instead of being cut off.
 const getClipWindow = ( el: HTMLElement ): { top: number; bottom: number } => {
     let top = 0;
     let bottom = window.innerHeight;
@@ -56,6 +57,7 @@ const TimeDropdown = ( {
     includeFullDay = false,
     step = DEFAULT_STEP_MINUTES,
     readOnly = false,
+    wrapperClassName = '',
 }: TimeDropdownProps ) => {
     const [ open, setOpen ] = useState( false );
     // The list opens downward by default; it flips up / shrinks to stay inside the clip window.
@@ -176,7 +178,10 @@ const TimeDropdown = ( {
     }, [ open ] );
 
     return (
-        <div ref={ wrapRef } className="relative inline-block">
+        <div
+            ref={ wrapRef }
+            className={ twMerge( 'relative inline-block', wrapperClassName ) }
+        >
             <div
                 className={ twMerge(
                     'flex items-center gap-2 rounded-md border bg-white px-3 py-2 text-sm shadow-sm min-w-[155px] focus-within:ring-2 focus-within:ring-[#7047EB]',

--- a/src/components/WeeklyTimeSlots/index.tsx
+++ b/src/components/WeeklyTimeSlots/index.tsx
@@ -27,6 +27,7 @@ const WeeklyTimeSlots = ( {
     value,
     days,
     multiple = false,
+    spread = true,
     is12Hour = true,
     allowFullDay = true,
     step = DEFAULT_STEP_MINUTES,
@@ -92,6 +93,17 @@ const WeeklyTimeSlots = ( {
                             slots[ 0 ].closing_time || seeded.closing_time,
                     },
                 ];
+            }
+        } else {
+            // Disabling clears the day's error state; if it was in error, reset the
+            // fields too so the read-only overlay never shows invalid times.
+            setTouched( ( prev ) => {
+                const next = { ...prev };
+                delete next[ dayKey ];
+                return next;
+            } );
+            if ( errors[ dayKey ] ) {
+                slots = [ seed() ];
             }
         }
         commit( dayKey, { status: isActive, slots }, isActive );
@@ -182,12 +194,21 @@ const WeeklyTimeSlots = ( {
                     }
                     is12Hour={ is12Hour }
                     hasError={ Boolean( slotError?.opening ) }
-                    // "Full Day" is a single-range concept; offering it per row in multiple
-                    // mode would wipe the day's other ranges on selection.
-                    includeFullDay={ allowFullDay && ! multiple }
+                    // Full Day only ever lives on the opening dropdown; picking it collapses the day.
+                    includeFullDay={ allowFullDay }
                     step={ step }
                 />
-                { ! isFullDaySlot && (
+                { isFullDaySlot ? (
+                    // Full Day spans the day: static, read-only "Full Day" closing (matches admin settings).
+                    <>
+                        <Minus size={ 20 } color={ '#828282' } />
+                        <TimeDropdown
+                            value={ FULL_DAY }
+                            is12Hour={ is12Hour }
+                            readOnly
+                        />
+                    </>
+                ) : (
                     <>
                         <Minus size={ 20 } color={ '#828282' } />
                         <TimeDropdown
@@ -215,15 +236,19 @@ const WeeklyTimeSlots = ( {
                             className="p-2! text-gray-500! hover:text-red-500! hover:bg-red-50! h-8 w-8"
                             onClick={ () => handleRemoveSlot( dayKey, index ) }
                         >
-                            <Trash />
+                            <Trash size={ 16 } className="shrink-0" />
                         </DokanButton>
-                        { ! isFullDaySlot && index === day.slots.length - 1 && (
+                        { index === day.slots.length - 1 && (
                             <DokanButton
                                 variant="tertiary"
-                                className="p-2! text-gray-500! h-8 w-8"
+                                className={ twMerge(
+                                    'p-2! text-gray-500! h-8 w-8',
+                                    // Full Day takes no extra ranges: hide the add button but keep its space so the trash stays aligned.
+                                    isFullDaySlot && 'invisible'
+                                ) }
                                 onClick={ () => handleAddSlot( dayKey ) }
                             >
-                                <Plus />
+                                <Plus size={ 16 } className="shrink-0" />
                             </DokanButton>
                         ) }
                     </div>
@@ -241,7 +266,7 @@ const WeeklyTimeSlots = ( {
 
     const renderDayRow = ( dayKey: string ) => {
         const day = value[ dayKey ] ?? { status: false, slots: [] };
-        // De-duplicated day messages, rendered under the row.
+        // De-duplicated day messages, rendered under the row (disabled days carry none).
         const dayMessages = touched[ dayKey ]
             ? Array.from(
                   new Set(
@@ -252,27 +277,53 @@ const WeeklyTimeSlots = ( {
               )
             : [];
 
+        // A disabled day keeps its pickers visible but dimmed and non-interactive (read-only overlay).
+        const slotsOverlay =
+            ! day.status && 'opacity-50 pointer-events-none select-none';
+        const hasSlots = day.slots.length > 0;
+
         return (
             <div
                 key={ dayKey }
-                className="border-b border-gray-200 last:border-b-0 bg-white"
+                className={ twMerge(
+                    'border-b border-gray-200 last:border-b-0 bg-white',
+                    // Vendor rows round their outer corners to match the bordered box (admin has no box).
+                    ! spread && 'first:rounded-t-md last:rounded-b-md'
+                ) }
             >
                 { /* Desktop Layout */ }
                 <div className="hidden sm:block!">
-                    <div className="flex items-center py-4 px-6 min-h-20">
-                        { /* Day name */ }
-                        <div className="w-2/4 shrink-0 self-start mt-2">
-                            <span className="text-sm font-medium text-[#25252D]">
-                                { days[ dayKey ] }
-                            </span>
-                            { renderDayMessages( dayMessages ) }
-                        </div>
-
-                        <div className="flex-1 flex items-center justify-end">
-                            { /* Time slots or status */ }
-                            <div className="flex-1 flex items-center justify-end">
-                                { day.status && day.slots.length > 0 && (
-                                    <div className="dokan-weekly-slots space-y-2">
+                    { spread ? (
+                        // Admin: day name left, switch + pickers pushed to the right edge.
+                        <div className="flex items-center justify-between gap-4 py-4 px-6 min-h-20">
+                            <div>
+                                <span
+                                    className={ twMerge(
+                                        'text-sm font-medium text-[#25252D]',
+                                        ! day.status && 'opacity-50'
+                                    ) }
+                                >
+                                    { days[ dayKey ] }
+                                </span>
+                                { dayMessages.length > 0 &&
+                                    renderDayMessages( dayMessages ) }
+                            </div>
+                            <div className="flex items-center gap-8 shrink-0">
+                                <div className="shrink-0">
+                                    <DokanSwitch
+                                        checked={ day.status }
+                                        onChange={ ( val: boolean ) =>
+                                            handleToggle( dayKey, val )
+                                        }
+                                    />
+                                </div>
+                                { hasSlots && (
+                                    <div
+                                        className={ twMerge(
+                                            'dokan-weekly-slots space-y-2',
+                                            slotsOverlay
+                                        ) }
+                                    >
                                         { day.slots.map( ( slot, index ) =>
                                             renderSlotRow(
                                                 dayKey,
@@ -284,33 +335,81 @@ const WeeklyTimeSlots = ( {
                                     </div>
                                 ) }
                             </div>
-
-                            { /* Switch - with proper spacing */ }
-                            <div className="ml-10 shrink-0">
-                                <DokanSwitch
-                                    checked={ day.status }
-                                    onChange={ ( val: boolean ) =>
-                                        handleToggle( dayKey, val )
-                                    }
-                                />
+                        </div>
+                    ) : (
+                        // Vendor: single-slot rows center everything; multi-slot rows top-align to the first slot. Message sits tight under the day name (admin style).
+                        <div
+                            className={ twMerge(
+                                'flex justify-between gap-4 py-4 px-6',
+                                day.slots.length > 1
+                                    ? 'items-start'
+                                    : 'items-center'
+                            ) }
+                        >
+                            <div>
+                                <span
+                                    className={ twMerge(
+                                        'text-sm font-medium text-[#25252D]',
+                                        ! day.status && 'opacity-50'
+                                    ) }
+                                >
+                                    { days[ dayKey ] }
+                                </span>
+                                { dayMessages.length > 0 &&
+                                    renderDayMessages( dayMessages ) }
+                            </div>
+                            <div
+                                className={ twMerge(
+                                    'flex gap-8 shrink-0',
+                                    day.slots.length > 1
+                                        ? 'items-start'
+                                        : 'items-center'
+                                ) }
+                            >
+                                <div className="shrink-0 flex items-center min-h-10">
+                                    <DokanSwitch
+                                        checked={ day.status }
+                                        onChange={ ( val: boolean ) =>
+                                            handleToggle( dayKey, val )
+                                        }
+                                    />
+                                </div>
+                                { hasSlots && (
+                                    <div
+                                        className={ twMerge(
+                                            'dokan-weekly-slots space-y-2',
+                                            slotsOverlay
+                                        ) }
+                                    >
+                                        { day.slots.map( ( slot, index ) =>
+                                            renderSlotRow(
+                                                dayKey,
+                                                day,
+                                                slot,
+                                                index
+                                            )
+                                        ) }
+                                    </div>
+                                ) }
                             </div>
                         </div>
-                    </div>
+                    ) }
                 </div>
                 { /* Mobile Layout */ }
-                <div
-                    className={ twMerge(
-                        'sm:hidden! px-6 py-4 min-h-20 w-full',
-                        ! day.status && 'flex items-center'
-                    ) }
-                >
-                    { /* Day name + Switch row */ }
+                <div className="sm:hidden! px-6 py-4 w-full">
+                    { /* Day name (+ validation message) + Switch row */ }
                     <div className="flex items-center justify-between w-full">
                         <div>
-                            <span className="text-sm font-semibold text-[#25252D]">
+                            <span
+                                className={ twMerge(
+                                    'text-sm font-semibold text-[#25252D]',
+                                    ! day.status && 'opacity-50'
+                                ) }
+                            >
                                 { days[ dayKey ] }
                             </span>
-                            { renderDayMessages( dayMessages ) }
+                            { dayMessages.length > 0 &&
+                                renderDayMessages( dayMessages ) }
                         </div>
                         <DokanSwitch
                             checked={ day.status }
@@ -320,9 +419,14 @@ const WeeklyTimeSlots = ( {
                         />
                     </div>
 
-                    { /* Time picker rows - only when active */ }
-                    { day.status && day.slots.length > 0 && (
-                        <div className="mt-4 space-y-2">
+                    { /* Time picker rows — read-only overlay when the day is off */ }
+                    { hasSlots && (
+                        <div
+                            className={ twMerge(
+                                'mt-4 space-y-2',
+                                slotsOverlay
+                            ) }
+                        >
                             { day.slots.map( ( slot, index ) =>
                                 renderSlotRow( dayKey, day, slot, index )
                             ) }
@@ -334,8 +438,9 @@ const WeeklyTimeSlots = ( {
     };
 
     // Render in `days` key order (honours WP "Week Starts On"), not the value's key order.
+    // Admin keeps overflow-hidden; vendor drops it so a bottom-row dropdown isn't clipped.
     return (
-        <div className="overflow-hidden">
+        <div className={ spread ? 'overflow-hidden' : undefined }>
             { Object.keys( days ).map( renderDayRow ) }
         </div>
     );

--- a/src/components/WeeklyTimeSlots/index.tsx
+++ b/src/components/WeeklyTimeSlots/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import DokanButton from '../Button';
 import { DokanSwitch } from '../Switch';
 import { twMerge } from 'tailwind-merge';
 import { Minus, Plus, Trash } from 'lucide-react';
@@ -20,6 +19,31 @@ import type {
     WeeklyTimeSlotsProps,
     WeeklyValue,
 } from './types';
+
+// Per-mode layout classes: vendor (multiple) rows are wide, so they switch side-by-side/stacked on the CONTAINER width (@container root) at @3xl; admin (single) is narrow and uses the viewport `sm` breakpoint. Literal strings so Tailwind emits every variant.
+const LAYOUT = {
+    multiple: {
+        desktopRow: 'hidden @3xl:block!',
+        mobileRow: '@3xl:hidden!',
+        slotRow:
+            'flex flex-col gap-2 @3xl:flex-row @3xl:items-center @3xl:gap-4',
+        fieldWidth: 'w-full @3xl:w-auto',
+        minus: 'hidden shrink-0 @3xl:block',
+        icons: 'flex shrink-0 gap-2 self-end @3xl:ml-2 @3xl:self-auto',
+    },
+    single: {
+        desktopRow: 'hidden sm:block!',
+        mobileRow: 'sm:hidden!',
+        slotRow: 'flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4',
+        fieldWidth: 'w-full sm:w-auto',
+        minus: 'hidden shrink-0 sm:block',
+        icons: 'flex shrink-0 gap-2 self-end sm:ml-2 sm:self-auto',
+    },
+} as const;
+
+// Icon buttons: 32px (a touch shorter than the field), gray border, rounded, no shadow; `!` stops the theme's own button rules from overriding them.
+const iconBtnBase =
+    'flex items-center justify-center shrink-0 box-border! h-8! w-8! min-w-0! rounded-md! border! border-gray-200! bg-white! p-0! transition-colors';
 
 // Generic weekly schedule editor: `multiple` switches between one range/day (admin) and
 // N ranges with add/remove (vendor). Validation and messages are overridable via props.
@@ -67,6 +91,15 @@ const WeeklyTimeSlots = ( {
     const seed = seedSlot ?? ( () => defaultSeedSlot( step, multiple ) );
     const opensAt = openingPlaceholder ?? __( 'Opens at', 'dokan-lite' );
     const closesAt = closingPlaceholder ?? __( 'Closed at', 'dokan-lite' );
+
+    const {
+        desktopRow: desktopRowCls,
+        mobileRow: mobileRowCls,
+        slotRow: slotRowCls,
+        fieldWidth: fieldWidthCls,
+        minus: minusCls,
+        icons: iconsCls,
+    } = multiple ? LAYOUT.multiple : LAYOUT.single;
 
     const commit = ( dayKey: string, nextDay: WeeklyDay, isTouched = true ) => {
         const nextValue: WeeklyValue = { ...value, [ dayKey ]: nextDay };
@@ -182,7 +215,7 @@ const WeeklyTimeSlots = ( {
             <div
                 key={ index }
                 className={ twMerge(
-                    'flex items-center gap-4',
+                    slotRowCls,
                     slotError && 'dokan-weekly-slot-error'
                 ) }
             >
@@ -197,60 +230,70 @@ const WeeklyTimeSlots = ( {
                     // Full Day only ever lives on the opening dropdown; picking it collapses the day.
                     includeFullDay={ allowFullDay }
                     step={ step }
+                    wrapperClassName={ fieldWidthCls }
                 />
+                <Minus size={ 20 } color={ '#828282' } className={ minusCls } />
+                { /* Full Day spans the day, so its closing is a static read-only "Full Day" (matches admin). */ }
                 { isFullDaySlot ? (
-                    // Full Day spans the day: static, read-only "Full Day" closing (matches admin settings).
-                    <>
-                        <Minus size={ 20 } color={ '#828282' } />
-                        <TimeDropdown
-                            value={ FULL_DAY }
-                            is12Hour={ is12Hour }
-                            readOnly
-                        />
-                    </>
+                    <TimeDropdown
+                        value={ FULL_DAY }
+                        is12Hour={ is12Hour }
+                        readOnly
+                        wrapperClassName={ fieldWidthCls }
+                    />
                 ) : (
-                    <>
-                        <Minus size={ 20 } color={ '#828282' } />
-                        <TimeDropdown
-                            value={ slot.closing_time }
-                            placeholder={ closesAt }
-                            onChange={ ( v ) =>
-                                handleTimeChange(
-                                    dayKey,
-                                    index,
-                                    'closing_time',
-                                    v
-                                )
-                            }
-                            is12Hour={ is12Hour }
-                            hasError={ Boolean( slotError?.closing ) }
-                            includeFullDay={ false }
-                            step={ step }
-                        />
-                    </>
+                    <TimeDropdown
+                        value={ slot.closing_time }
+                        placeholder={ closesAt }
+                        onChange={ ( v ) =>
+                            handleTimeChange( dayKey, index, 'closing_time', v )
+                        }
+                        is12Hour={ is12Hour }
+                        hasError={ Boolean( slotError?.closing ) }
+                        includeFullDay={ false }
+                        step={ step }
+                        wrapperClassName={ fieldWidthCls }
+                    />
                 ) }
                 { multiple && (
-                    <div className="flex gap-2 ml-2">
-                        <DokanButton
-                            variant="tertiary"
-                            className="p-2! text-gray-500! hover:text-red-500! hover:bg-red-50! h-8 w-8"
+                    <div className={ iconsCls }>
+                        <button
+                            type="button"
+                            aria-label={ __(
+                                'Remove time slot',
+                                'dokan-lite'
+                            ) }
+                            // A Full Day range is removed by toggling the day off, so its delete is disabled.
+                            disabled={ isFullDaySlot }
                             onClick={ () => handleRemoveSlot( dayKey, index ) }
+                            className={ twMerge(
+                                iconBtnBase,
+                                'text-gray-500!',
+                                isFullDaySlot
+                                    ? 'cursor-not-allowed opacity-50'
+                                    : 'hover:border-red-300! hover:bg-red-50! hover:text-red-600!'
+                            ) }
                         >
                             <Trash size={ 16 } className="shrink-0" />
-                        </DokanButton>
-                        { index === day.slots.length - 1 && (
-                            <DokanButton
-                                variant="tertiary"
-                                className={ twMerge(
-                                    'p-2! text-gray-500! h-8 w-8',
-                                    // Full Day takes no extra ranges: hide the add button but keep its space so the trash stays aligned.
-                                    isFullDaySlot && 'invisible'
-                                ) }
-                                onClick={ () => handleAddSlot( dayKey ) }
-                            >
-                                <Plus size={ 16 } className="shrink-0" />
-                            </DokanButton>
-                        ) }
+                        </button>
+                        { /* Add: real on the last non-Full-Day slot. On other rows it collapses when stacked (delete hugs the right edge) but keeps its space side-by-side so trashes stay in a column. */ }
+                        <button
+                            type="button"
+                            aria-label={ __( 'Add time slot', 'dokan-lite' ) }
+                            onClick={ () => handleAddSlot( dayKey ) }
+                            style={ {
+                                color: 'var(--dokan-button-background-color, #7047EB)',
+                            } }
+                            className={ twMerge(
+                                iconBtnBase,
+                                'hover:bg-gray-50!',
+                                ( isFullDaySlot ||
+                                    index !== day.slots.length - 1 ) &&
+                                    'hidden @3xl:flex @3xl:invisible'
+                            ) }
+                        >
+                            <Plus size={ 16 } className="shrink-0" />
+                        </button>
                     </div>
                 ) }
             </div>
@@ -281,6 +324,38 @@ const WeeklyTimeSlots = ( {
         const slotsOverlay =
             ! day.status && 'opacity-50 pointer-events-none select-none';
         const hasSlots = day.slots.length > 0;
+        // Admin centers rows; vendor top-aligns multi-slot rows so the switch/first field line up.
+        const desktopItems =
+            spread || day.slots.length <= 1 ? 'items-center' : 'items-start';
+
+        // Subtrees shared by the desktop and mobile layouts.
+        const nameBlock = ( fontCls: string ) => (
+            <div>
+                <span
+                    className={ twMerge(
+                        fontCls,
+                        ! day.status && 'opacity-50'
+                    ) }
+                >
+                    { days[ dayKey ] }
+                </span>
+                { dayMessages.length > 0 && renderDayMessages( dayMessages ) }
+            </div>
+        );
+        const slotsBlock = ( wrapCls: string ) =>
+            hasSlots && (
+                <div className={ twMerge( wrapCls, slotsOverlay ) }>
+                    { day.slots.map( ( slot, index ) =>
+                        renderSlotRow( dayKey, day, slot, index )
+                    ) }
+                </div>
+            );
+        const switchEl = (
+            <DokanSwitch
+                checked={ day.status }
+                onChange={ ( val: boolean ) => handleToggle( dayKey, val ) }
+            />
+        );
 
         return (
             <div
@@ -291,147 +366,41 @@ const WeeklyTimeSlots = ( {
                     ! spread && 'first:rounded-t-md last:rounded-b-md'
                 ) }
             >
-                { /* Desktop Layout */ }
-                <div className="hidden sm:block!">
-                    { spread ? (
-                        // Admin: day name left, switch + pickers pushed to the right edge.
-                        <div className="flex items-center justify-between gap-4 py-4 px-6 min-h-20">
-                            <div>
-                                <span
-                                    className={ twMerge(
-                                        'text-sm font-medium text-[#25252D]',
-                                        ! day.status && 'opacity-50'
-                                    ) }
-                                >
-                                    { days[ dayKey ] }
-                                </span>
-                                { dayMessages.length > 0 &&
-                                    renderDayMessages( dayMessages ) }
-                            </div>
-                            <div className="flex items-center gap-8 shrink-0">
-                                <div className="shrink-0">
-                                    <DokanSwitch
-                                        checked={ day.status }
-                                        onChange={ ( val: boolean ) =>
-                                            handleToggle( dayKey, val )
-                                        }
-                                    />
-                                </div>
-                                { hasSlots && (
-                                    <div
-                                        className={ twMerge(
-                                            'dokan-weekly-slots space-y-2',
-                                            slotsOverlay
-                                        ) }
-                                    >
-                                        { day.slots.map( ( slot, index ) =>
-                                            renderSlotRow(
-                                                dayKey,
-                                                day,
-                                                slot,
-                                                index
-                                            )
-                                        ) }
-                                    </div>
-                                ) }
-                            </div>
-                        </div>
-                    ) : (
-                        // Vendor: single-slot rows center everything; multi-slot rows top-align to the first slot. Message sits tight under the day name (admin style).
+                { /* Desktop: day name left, switch + pickers right. */ }
+                <div className={ desktopRowCls }>
+                    <div
+                        className={ twMerge(
+                            'flex justify-between gap-4 py-4 px-6',
+                            spread && 'min-h-20',
+                            desktopItems
+                        ) }
+                    >
+                        { nameBlock( 'text-sm font-medium text-[#25252D]' ) }
                         <div
                             className={ twMerge(
-                                'flex justify-between gap-4 py-4 px-6',
-                                day.slots.length > 1
-                                    ? 'items-start'
-                                    : 'items-center'
+                                'flex gap-8 shrink-0',
+                                desktopItems
                             ) }
                         >
-                            <div>
-                                <span
-                                    className={ twMerge(
-                                        'text-sm font-medium text-[#25252D]',
-                                        ! day.status && 'opacity-50'
-                                    ) }
-                                >
-                                    { days[ dayKey ] }
-                                </span>
-                                { dayMessages.length > 0 &&
-                                    renderDayMessages( dayMessages ) }
-                            </div>
                             <div
                                 className={ twMerge(
-                                    'flex gap-8 shrink-0',
-                                    day.slots.length > 1
-                                        ? 'items-start'
-                                        : 'items-center'
+                                    'shrink-0',
+                                    ! spread && 'flex items-center min-h-10'
                                 ) }
                             >
-                                <div className="shrink-0 flex items-center min-h-10">
-                                    <DokanSwitch
-                                        checked={ day.status }
-                                        onChange={ ( val: boolean ) =>
-                                            handleToggle( dayKey, val )
-                                        }
-                                    />
-                                </div>
-                                { hasSlots && (
-                                    <div
-                                        className={ twMerge(
-                                            'dokan-weekly-slots space-y-2',
-                                            slotsOverlay
-                                        ) }
-                                    >
-                                        { day.slots.map( ( slot, index ) =>
-                                            renderSlotRow(
-                                                dayKey,
-                                                day,
-                                                slot,
-                                                index
-                                            )
-                                        ) }
-                                    </div>
-                                ) }
+                                { switchEl }
                             </div>
+                            { slotsBlock( 'dokan-weekly-slots space-y-2' ) }
                         </div>
-                    ) }
-                </div>
-                { /* Mobile Layout */ }
-                <div className="sm:hidden! px-6 py-4 w-full">
-                    { /* Day name (+ validation message) + Switch row */ }
-                    <div className="flex items-center justify-between w-full">
-                        <div>
-                            <span
-                                className={ twMerge(
-                                    'text-sm font-semibold text-[#25252D]',
-                                    ! day.status && 'opacity-50'
-                                ) }
-                            >
-                                { days[ dayKey ] }
-                            </span>
-                            { dayMessages.length > 0 &&
-                                renderDayMessages( dayMessages ) }
-                        </div>
-                        <DokanSwitch
-                            checked={ day.status }
-                            onChange={ ( val: boolean ) =>
-                                handleToggle( dayKey, val )
-                            }
-                        />
                     </div>
-
-                    { /* Time picker rows — read-only overlay when the day is off */ }
-                    { hasSlots && (
-                        <div
-                            className={ twMerge(
-                                'mt-4 space-y-2',
-                                slotsOverlay
-                            ) }
-                        >
-                            { day.slots.map( ( slot, index ) =>
-                                renderSlotRow( dayKey, day, slot, index )
-                            ) }
-                        </div>
-                    ) }
+                </div>
+                { /* Mobile: name + switch stacked over the pickers. */ }
+                <div className={ twMerge( mobileRowCls, 'px-6 py-4 w-full' ) }>
+                    <div className="flex items-start justify-between w-full gap-4">
+                        { nameBlock( 'text-sm font-semibold text-[#25252D]' ) }
+                        { switchEl }
+                    </div>
+                    { slotsBlock( 'mt-4 space-y-2' ) }
                 </div>
             </div>
         );
@@ -440,7 +409,7 @@ const WeeklyTimeSlots = ( {
     // Render in `days` key order (honours WP "Week Starts On"), not the value's key order.
     // Admin keeps overflow-hidden; vendor drops it so a bottom-row dropdown isn't clipped.
     return (
-        <div className={ spread ? 'overflow-hidden' : undefined }>
+        <div className={ twMerge( '@container', spread && 'overflow-hidden' ) }>
             { Object.keys( days ).map( renderDayRow ) }
         </div>
     );

--- a/src/components/WeeklyTimeSlots/types.ts
+++ b/src/components/WeeklyTimeSlots/types.ts
@@ -42,6 +42,8 @@ export type WeeklyTimeSlotsProps = {
     days: Record< string, string >;
     // false (default): one range per day. true: N ranges with add/remove.
     multiple?: boolean;
+    // true (default): switch + pickers right-aligned (admin). false: grouped left by the day name (vendor).
+    spread?: boolean;
     // Display-only; storage is always canonical `g:i a`.
     is12Hour?: boolean;
     // Offer the "Full Day" preset in opening dropdowns. Default true.

--- a/src/components/WeeklyTimeSlots/utils.ts
+++ b/src/components/WeeklyTimeSlots/utils.ts
@@ -1,4 +1,4 @@
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 import type { TimeSlot } from './types';
 
 // "Full Day" sentinel; mirrors DeliveryDaysScheduleTransformer::FULL_DAY_SENTINEL.
@@ -45,8 +45,49 @@ export const minutesToCanonical = ( totalMinutes: number ): string => {
     return `${ hours12 }:${ pad( normalized % 60 ) } ${ meridiem }`;
 };
 
-// Localized time-of-day label. Build the instant in UTC and format in UTC (gmt=true) so the
-// wall-clock time survives any browser/site timezone gap; dateI18n still localizes the meridiem.
+// Site locale as a BCP-47 tag for Intl (l10n.locale is `bn_BD`; Intl needs `bn-BD`).
+const localeTag = (): string => {
+    const fromSettings = getSettings()?.l10n?.locale;
+    if ( fromSettings ) {
+        return fromSettings.replace( /_/g, '-' );
+    }
+    if ( typeof document !== 'undefined' && document.documentElement.lang ) {
+        return document.documentElement.lang;
+    }
+    return 'en';
+};
+
+// Per-locale ASCII→native digit maps; null means the locale already uses ASCII (no-op).
+const digitMaps: Record< string, Record< string, string > | null > = {};
+
+// dateI18n localizes the meridiem but never the digits; map ASCII 0-9 to the site
+// locale's numerals (e.g. Bangla ০-৯) so the whole label reads localized.
+const localizeDigits = ( text: string ): string => {
+    const tag = localeTag();
+    if ( ! ( tag in digitMaps ) ) {
+        try {
+            const formatter = new Intl.NumberFormat( tag, {
+                useGrouping: false,
+            } );
+            const map: Record< string, string > = {};
+            for ( let digit = 0; digit <= 9; digit++ ) {
+                map[ digit ] = formatter.format( digit );
+            }
+            digitMaps[ tag ] = map[ '0' ] === '0' ? null : map;
+        } catch ( error ) {
+            digitMaps[ tag ] = null;
+        }
+    }
+    const map = digitMaps[ tag ];
+    return map ? text.replace( /[0-9]/g, ( digit ) => map[ digit ] ) : text;
+};
+
+// Localized time-of-day label rendered with the EXACT site time format
+// (WP Settings → General → Time Format), so presets ('g:i a', 'g:i A', 'H:i')
+// and custom formats (e.g. 'G\h i') all display faithfully. is12Hour is only a
+// fallback for contexts without WP date settings (e.g. unit tests). Built and
+// formatted in UTC (gmt=true) so the wall-clock time survives any browser/site
+// timezone gap; dateI18n localizes the meridiem, localizeDigits the numerals.
 export const minutesToDisplay = (
     totalMinutes: number,
     is12Hour: boolean
@@ -60,7 +101,8 @@ export const minutesToDisplay = (
             totalMinutes % 60
         )
     );
-    return dateI18n( is12Hour ? 'g:i A' : 'H:i', date, true );
+    const format = getSettings().formats.time || ( is12Hour ? 'g:i a' : 'H:i' );
+    return localizeDigits( dateI18n( format, date, true ) );
 };
 
 // Localize any parseable stored value (even off the preset grid); raw fallback otherwise.

--- a/src/components/WeeklyTimeSlots/utils.ts
+++ b/src/components/WeeklyTimeSlots/utils.ts
@@ -45,16 +45,20 @@ export const minutesToCanonical = ( totalMinutes: number ): string => {
     return `${ hours12 }:${ pad( normalized % 60 ) } ${ meridiem }`;
 };
 
-// Site locale as a BCP-47 tag for Intl (l10n.locale is `bn_BD`; Intl needs `bn-BD`).
+// Site locale as a BCP-47 tag for Intl (l10n.locale `bn_BD` → `bn-BD`); constant per page, so resolve once.
+let cachedTag: string | undefined;
 const localeTag = (): string => {
-    const fromSettings = getSettings()?.l10n?.locale;
-    if ( fromSettings ) {
-        return fromSettings.replace( /_/g, '-' );
+    if ( cachedTag === undefined ) {
+        const fromSettings = getSettings()?.l10n?.locale;
+        const fromDom =
+            typeof document !== 'undefined'
+                ? document.documentElement.lang
+                : '';
+        cachedTag = fromSettings
+            ? fromSettings.replace( /_/g, '-' )
+            : fromDom || 'en';
     }
-    if ( typeof document !== 'undefined' && document.documentElement.lang ) {
-        return document.documentElement.lang;
-    }
-    return 'en';
+    return cachedTag;
 };
 
 // Per-locale ASCII→native digit maps; null means the locale already uses ASCII (no-op).
@@ -82,12 +86,7 @@ const localizeDigits = ( text: string ): string => {
     return map ? text.replace( /[0-9]/g, ( digit ) => map[ digit ] ) : text;
 };
 
-// Localized time-of-day label rendered with the EXACT site time format
-// (WP Settings → General → Time Format), so presets ('g:i a', 'g:i A', 'H:i')
-// and custom formats (e.g. 'G\h i') all display faithfully. is12Hour is only a
-// fallback for contexts without WP date settings (e.g. unit tests). Built and
-// formatted in UTC (gmt=true) so the wall-clock time survives any browser/site
-// timezone gap; dateI18n localizes the meridiem, localizeDigits the numerals.
+// Localized time label in the site's WP time format (is12Hour is a no-settings fallback); built/formatted in UTC so the wall-clock survives TZ gaps, with meridiem + digits localized.
 export const minutesToDisplay = (
     totalMinutes: number,
     is12Hour: boolean


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [ ] My code passes the PHPCS tests <!-- N/A — TypeScript/React only -->
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Refinements to the shared `WeeklyTimeSlots` component (consumed by both the **admin** delivery-days settings and the **vendor** delivery-time settings), branched fresh off `refactor/simplify-settings-to-flat-array`.

- **Localized numerals.** `minutesToDisplay` now maps the time digits to the site locale (e.g. Bangla `০–৯`) via `Intl.NumberFormat`. Previously `dateI18n` localized only the meridiem (পূর্বাহ্ন/অপরাহ্ন) and left the digits as `12:10`. It is a **no-op on Latin-digit locales**, and **storage stays canonical `g:i a`** — only the display changes.
- **Non-clipping dropdown placement.** The preset list flips up / sizes itself to the visible clip window, so it is never cut off inside `overflow-hidden` ancestors (the admin settings card + its internal scroll area). The vendor page needed nothing here — its only clipping ancestor is `<body>`.
- Carries the weekly-time-slots UI refinements (the `spread` prop, disabled-day read-only overlays, dynamic site time format) onto the flat-array base.

> PHPCS is N/A — this PR is TypeScript/React only.

### Related Pull Request(s)

* Dokan Pro (vendor consumer of this component): https://github.com/getdokan/dokan-pro/pull/5915

### Closes

* N/A

### How to test the changes in this Pull Request:

1. Settings → General → Site Language = **বাংলা**, Time Format = a 12-hour format (`g:i a`).
2. WP Admin → Dokan → Settings → Delivery Time: every time reads fully in Bangla numerals (e.g. `১২:২০ পূর্বাহ্ন`), including the preset dropdown.
3. Open the **last row (Monday)** dropdown — the preset list opens **upward** and is fully visible (previously it was clipped by the settings card).
4. Switch Site Language back to English → digits render in Latin (`12:20 am`); no regression.
5. `wp option get dokan_admin_settings --format=json` still shows canonical `"9:00 am"`-style values regardless of locale/time-format.

### Changelog entry

**Weekly time slots — localized numerals and a dropdown that never clips**

Previously the shared weekly time-slots picker localized only the AM/PM meridiem, leaving the hour/minute digits in Latin numerals on non-Latin locales, and its preset dropdown was clipped when opened on the last row inside the admin settings card. Now the digits are localized to the site locale and the dropdown flips up / resizes to stay fully visible. Stored values remain canonical `g:i a`.
