### PR TITLE
docs: add domain glossary (CONTEXT.md) and backfill architecture decision records

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,4 +42,5 @@ webpack-dependency-mapping.js
 webpack-entries.js
 base-tailwind.config.js
 CLAUDE.md
+CONTEXT.md
 /.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@
 
 Dokan Lite is a multi-vendor e-commerce marketplace plugin for WordPress, powered by WooCommerce. Version 4.2.8. Requires PHP 7.4+ and WooCommerce 8.5.0+.
 
+## Domain Model
+
+- **`CONTEXT.md`** — the canonical ubiquitous-language glossary for the whole Dokan bounded context (Lite **and** Pro). Read it before naming things or discussing domain concepts; use its canonical terms (e.g. Vendor not seller, Suborder vs Vendor order, Commission = admin's share) and respect its _Avoid_ lists.
+- **`docs/adr/`** — Architecture Decision Records. Check here before "fixing" surprising behavior (e.g. parent orders ignoring refunds/stock is deliberate — ADR-0004). Cross-cutting Lite+Pro decisions live here; Pro-only decisions live in dokan-pro's `docs/adr/`.
+- New root-level files must be added to `.distignore` or they ship in the release zip.
+
 ## Available Skills
 
 The `.claude/skills/` directory contains procedural HOW-TO instructions:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,114 @@
+# Dokan Marketplace
+
+The ubiquitous language for the Dokan multi-vendor marketplace. This is the canonical
+glossary for **both dokan-lite and dokan-pro** — the two repos form a single bounded
+context, with Pro extending Lite's language rather than redefining it. Pro-only terms
+live in dokan-pro's `CONTEXT.md`.
+
+## Language
+
+### Actors
+
+**Vendor**:
+A user account that sells through the marketplace. The canonical term for all new
+code, docs, and conversation.
+_Avoid_: Seller (legacy alias — survives only as the WordPress role name `seller`
+and in old function names), merchant, shop owner
+
+**Store**:
+The public-facing presentation of a Vendor: storefront page, store URL, store
+settings, the REST `/stores` resource. Exactly one Store per Vendor — a facet of
+the Vendor, not a separate entity.
+_Avoid_: Shop, storefront
+
+### Orders
+
+**Order**:
+A WooCommerce order as the customer sees it — what was placed at checkout,
+possibly containing products from several Vendors. A customer-facing mirror:
+operational effects (stock, commission, vendor balance, refund accounting)
+never happen here, only on Vendor orders.
+_Avoid_: Purchase, parent order (say "Order" when you mean the customer-facing
+whole; qualify as "parent" only when contrasting with its Suborders)
+
+**Suborder**:
+A per-vendor order split off a multi-vendor Order. Created only when the Order
+spans more than one Vendor; a single-vendor Order has no Suborders.
+_Avoid_: Child order, sub-order
+
+**Vendor order**:
+The order a Vendor processes and earns commission on: the Suborder when the
+Order spanned multiple Vendors, or the Order itself when it was single-vendor.
+One Order from Vendor A and Vendor B = one Order, two Suborders, two Vendor
+orders. From Vendor A alone = one Order, zero Suborders, one Vendor order.
+
+**Refund**:
+A return of money to the customer, recorded against a Vendor order and mirrored
+up to its Order. A refund created directly on a parent Order is outside the
+model: vendor accounting does not see it.
+
+### Money
+
+**Commission**:
+The admin's (marketplace operator's) share of a Vendor order, computed by a
+Commission formula. Never the Vendor's share.
+_Avoid_: Admin earning, admin fee
+
+**Earning**:
+The Vendor's share of a Vendor order after Commission — what accrues to their
+balance.
+_Avoid_: Vendor commission, net amount, payout (a payout is a Withdraw)
+
+**Commission formula**:
+The strategy that splits a line item between admin and Vendor: Fixed, Flat,
+Percentage, Combine (percentage + flat), or Category-based.
+_Avoid_: Commission type, rate
+
+**Fee recipient**:
+Whether admin or the Vendor receives a non-product amount of a Vendor order —
+shipping, tax, or shipping-tax. Respected everywhere money is computed,
+including Refunds.
+
+**Balance**:
+The running ledger of a Vendor's money — credited by Earnings, debited by
+Withdraws and Refunds.
+_Avoid_: Wallet, funds
+
+**Withdraw** _(noun — Dokan idiom)_:
+A Vendor's request to be paid out from their Balance via a withdraw method,
+subject to a minimum threshold and approval.
+_Avoid_: Withdrawal, payout, disbursement
+
+**Reverse withdrawal**:
+A debt owed by the Vendor to the admin, arising when the Vendor received the
+full order payment directly (e.g. cash on delivery) including the admin's
+Commission. Never a "negative Withdraw" — a Reverse withdrawal is a receivable,
+not a Balance entry; the two concepts never mix. The differing spellings
+(Withdraw vs Reverse withdrawal) are deliberate and match the code's module
+names.
+
+### Admin settings
+
+**Canonical setting**:
+A setting stored under its canonical id in the flat `dokan_admin_settings`
+store — the single source of truth for admin configuration.
+_Avoid_: New setting, migrated setting
+
+**Legacy key**:
+The old `wp_options` row (and sub-key) where a setting lived before migration.
+Meaningful only through the Legacy bridge and Legacy mirror.
+
+**Legacy bridge**:
+The per-module declaration mapping a canonical id to its Legacy key, with
+Transformers. Serves readers and writers at runtime: unmigrated code keeps
+working during the migration series.
+_Avoid_: Compat layer, shim
+
+**Legacy mirror**:
+The mode in which Legacy keys are kept physically populated with mapped values,
+so a plugin downgrade finds real data at rest. The bridge is about code paths;
+the mirror is about rows in the database.
+
+**Transformer**:
+The pair of value conversions between the canonical and legacy representations
+of one setting (e.g. `'on'`/`'off'` ↔ boolean).

--- a/docs/adr/0001-single-bounded-context-across-lite-and-pro.md
+++ b/docs/adr/0001-single-bounded-context-across-lite-and-pro.md
@@ -1,0 +1,19 @@
+# Single bounded context across dokan-lite and dokan-pro
+
+dokan-lite and dokan-pro are two repositories but one bounded context: Pro extends
+Lite's classes, hooks, and container rather than talking to it across a boundary, and
+every shared term (Vendor, Commission, Withdraw) means the same thing on both sides.
+We therefore keep one canonical glossary in `dokan-lite/CONTEXT.md`; dokan-pro's
+`CONTEXT.md` only adds Pro-only terms and never redefines Lite's.
+
+ADRs live in the repo whose code they govern, with independent numbering per repo.
+Cross-cutting decisions that span both repos are recorded in dokan-lite, because Pro
+depends on Lite and never the reverse.
+
+## Considered Options
+
+- Two self-contained glossaries (one per repo) — rejected: shared terms would be
+  defined twice and drift.
+- A context map with per-subdomain contexts (commission, withdraw, each Pro module) —
+  rejected as premature: everything shares one database, one hook bus, and one
+  language; no term means different things in different places.

--- a/docs/adr/0002-flat-dokan-admin-settings-as-canonical-store.md
+++ b/docs/adr/0002-flat-dokan-admin-settings-as-canonical-store.md
@@ -1,0 +1,21 @@
+# Flat dokan_admin_settings array as the canonical settings store
+
+Admin settings historically lived scattered across many `wp_options` rows with
+per-section nested arrays. We decided that a single flat array under the
+`dokan_admin_settings` option is the canonical store: every setting has one canonical
+id, and all new reads and writes go through the settings accessor API against that
+store. Legacy rows remain readable/writable only through the legacy bridge (see the
+dokan-pro ADR on the bridge pattern) and are kept populated by the legacy mirror
+(ADR-0003).
+
+A flat map makes ids globally unique and greppable, lets the admin UI, setup wizard,
+and REST layer share one schema, and avoids the migration ambiguity of deep merges
+over nested structures.
+
+## Considered Options
+
+- Keep per-section option rows and normalize access behind an API only — rejected:
+  every consumer still needs to know the physical layout, and cross-section renames
+  stay painful.
+- Nested canonical array — rejected: deep merges on save are error-prone and ids are
+  only unique within a section.

--- a/docs/adr/0003-settings-legacy-mirror-mode.md
+++ b/docs/adr/0003-settings-legacy-mirror-mode.md
@@ -1,0 +1,15 @@
+# Settings legacy mirror mode
+
+While `dokan_admin_settings` is the canonical store (ADR-0002), the legacy
+`wp_options` rows are not deleted or left stale: legacy mirror mode keeps them
+physically populated with mapped values on every canonical write, and a reconcile
+pass on `admin_init` repairs them after a plugin downgrade. The mirror can be
+disabled via the `dokan_admin_settings_legacy_mirror` filter.
+
+We chose this because a downgrade to a pre-migration plugin version must find real
+data at rest — a bridge that maps values only at runtime disappears together with the
+new code, leaving old versions reading empty or stale rows. The cost is dual writes
+and the risk of the two stores diverging, which the reconcile pass bounds.
+
+Note the division of labour: the legacy *bridge* serves readers and writers at
+runtime; the legacy *mirror* serves data at rest.

--- a/docs/adr/0004-vendor-order-is-authoritative-parent-is-mirror.md
+++ b/docs/adr/0004-vendor-order-is-authoritative-parent-is-mirror.md
@@ -1,0 +1,24 @@
+# Vendor order is authoritative; the parent order is a mirror
+
+When an order spans multiple vendors, Dokan splits it into real per-vendor
+WooCommerce orders (suborders). All operational effects — stock reduction, commission,
+vendor balance, refund accounting — happen only at the vendor-order level. The parent
+order is a customer-facing aggregate kept consistent by targeted, directional syncs:
+status changes are pushed down to suborders, completion is rolled up when all
+suborders complete, and item stock is copied up for display only.
+
+Consequences worth knowing before "fixing" any of this:
+
+- Parent orders are deliberately blocked from reducing stock
+  (`woocommerce_can_reduce_order_stock` filter).
+- A refund created directly against a parent order is outside the model: vendor
+  accounting ignores it in both Lite and Pro. Refunds are initiated on the vendor
+  order and mirrored up to the parent (Pro maps the suborder's line items onto a
+  matching parent refund; the gateway is charged once, at the parent level).
+- A single-vendor order produces no suborder at all — the order itself is the vendor
+  order. Code that filters on `parent_id != 0` silently drops these.
+
+The alternative — one shared order with per-line-item vendor attribution — was
+implicitly rejected by the split-order architecture: per-vendor orders give each
+vendor a real WC_Order to manage (statuses, notes, emails, gateways) at the cost of
+the sync rules above.


### PR DESCRIPTION
### All Submissions:

* [x] My code satisfies feature requirements
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Documentation only — no runtime code changes.

Adds the domain-model documentation that came out of a domain-modeling session:

* **`CONTEXT.md`** — the canonical ubiquitous-language glossary for the Dokan bounded context (shared by dokan-lite and dokan-pro). Seeds only the genuinely overloaded terms:
  * **Vendor / Store** — one entity; Store is the public facet, "seller" is a legacy alias
  * **Order / Suborder / Vendor order** — the split-order model, including the single-vendor case where no suborder exists
  * **Refund** — initiated on the Vendor order, mirrored up; parent-targeted refunds are outside the model
  * **Commission / Earning / Commission formula / Fee recipient** — commission is always the admin's share
  * **Balance / Withdraw / Reverse withdrawal** — a reverse withdrawal is a receivable, never a negative withdraw
  * **Admin settings vocabulary** — canonical setting, legacy key, legacy bridge, legacy mirror, transformer
* **`docs/adr/`** — four backfilled Architecture Decision Records:
  * `0001` single bounded context across lite and pro; where glossaries and ADRs live
  * `0002` flat `dokan_admin_settings` array as the canonical settings store
  * `0003` settings legacy mirror mode (downgrade safety, `dokan_admin_settings_legacy_mirror` kill switch)
  * `0004` vendor order is authoritative; the parent order is a customer-facing mirror

A companion PR in dokan-pro will add the thin Pro glossary (Pro-only terms) and the legacy-bridge ADR, linking back to these.

### How to test the changes in this Pull Request:

* Docs only — review the definitions and decisions for accuracy. Key claims in ADR-0004 are backed by `includes/Order/Hooks.php` (status sync, stock prevention) and `includes/Order/RefundHandler.php` / Pro `includes/Refund/Refund.php` (refund direction).

### Changelog entry

None — internal developer documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical marketplace glossary (“ubiquitous language”) in a new context document, with Pro-only terms scoped appropriately.
  * Documented the shared single bounded-context approach across core and Pro editions.
  * Defined how administration settings are stored canonically, plus how legacy settings are mirrored/bridged for compatibility.
  * Clarified Dokan’s split-order model (per-vendor suborders as the authoritative unit for stock/commissions/balances/refunds).
* **Chores**
  * Updated distribution ignore rules to exclude the new context document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->