### PR TITLE
fix(settings): make combine_input fill width inside field groups

### DIFF
--- a/src/components/commission/FixedCommissionInput.tsx
+++ b/src/components/commission/FixedCommissionInput.tsx
@@ -130,7 +130,7 @@ const FixedCommissionInput = ( {
     return (
         <div
             id={ hookKey }
-            className="@container/combine grid grid-cols-12 p-4 gap-2"
+            className="@container/combine grid grid-cols-12 p-4 gap-2 w-full"
         >
             { hasContent && (
                 <div className="flex flex-col justify-center @xl/combine:col-span-7 col-span-12 gap-1">


### PR DESCRIPTION
### Closes

* Closes getdokan/plugin-internal-tasks#2185

## Problem

On the flat settings **Transaction → Withdraw** page, the **Withdraw charges** fields (PayPal / Bank Transfer) render broken — the label wraps to two lines and the percentage + fixed-fee inputs collapse into a cramped single-input layout.

## Root cause

The **Withdraw charges** field uses the `combine_input` variant → `DokanCombineInput` → `FixedCommissionInput`. Its root element is a `@container/combine grid grid-cols-12` block with **no width constraint**.

- The **Commission** page's `combine_input` is a direct **section** child → rendered in a full-width block wrapper → works.
- The **Withdraw charges** `combine_input` is nested inside a **`fieldgroup`** (grouped with the method toggle). plugin-ui wraps fieldgroup children in a `flex flex-wrap gap-4` container, so the grid collapses to **content width**. That prevents the `@container/combine` breakpoints (`@xl/combine:col-span-7/5`) from ever triggering → label wraps, inputs mangle.

## Fix

Add `w-full` to the root so the field stretches to the full group width in both block **and** flex contexts.

```diff
- className="@container/combine grid grid-cols-12 p-4 gap-2"
+ className="@container/combine grid grid-cols-12 p-4 gap-2 w-full"
```

No-op for the Commission page (already full-width in a block context) → no regression.

## Testing

- [x] Withdraw settings: charges fields now render full-width with the *percentage + fixed fee* pair correctly laid out.
- [x] Commission settings: unchanged.
- [x] `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
