### PR TITLE
fix(commission): keep admin and vendor shares summing to the order total

### DIFF
--- a/includes/Commission/Calculator.php
+++ b/includes/Commission/Calculator.php
@@ -2,6 +2,7 @@
 
 namespace WeDevs\Dokan\Commission;
 
+use Automattic\WooCommerce\Utilities\NumberUtil;
 use WeDevs\Dokan\Commission\AbstractCommissionCalculator;
 use WeDevs\Dokan\Commission\Model\Commission;
 use WeDevs\Dokan\Commission\Model\Setting;
@@ -113,8 +114,10 @@ class Calculator extends AbstractCommissionCalculator {
     public function calculate(): Commission {
         $raw_admin_commission = $this->calculate_raw_admin_commission();
 
+        // Round only the admin's share and let the vendor take the exact remainder.
+        // Rounding both shares leaves a fraction of a cent credited to neither party.
         $net_amount       = $this->get_total();
-        $admin_commission = min( $raw_admin_commission, $net_amount );
+        $admin_commission = min( NumberUtil::round( $raw_admin_commission, wc_get_price_decimals() ), $net_amount );
 
         $vendor_earning = $net_amount - $admin_commission;
 
@@ -197,8 +200,10 @@ class Calculator extends AbstractCommissionCalculator {
 
         $refund_amount = abs( $refund_amount );
 
-		$vendor_earning_for_refund   = ( $vendor_earning / $item_total ) * $refund_amount;
-		$admin_commission_for_refund = ( $admin_commission / $item_total ) * $refund_amount;
+		// Split the refund the same way calculate() splits a sale, so the amounts
+		// refunded always add back up to the amount taken off the order.
+		$admin_commission_for_refund = NumberUtil::round( ( $admin_commission / $item_total ) * $refund_amount, wc_get_price_decimals() );
+		$vendor_earning_for_refund   = $refund_amount - $admin_commission_for_refund;
 
         $commission->set_vendor_net_earning( $vendor_earning_for_refund );
         $commission->set_admin_net_commission( $admin_commission_for_refund );

--- a/tests/php/src/Commission/CommissionCalculatorTest.php
+++ b/tests/php/src/Commission/CommissionCalculatorTest.php
@@ -36,7 +36,8 @@ class CommissionCalculatorTest extends DokanTestCase {
             ->set_settings( $settings )
             ->calculate();
 
-        $this->assertEquals( 67.792, $comm->get_admin_commission() );
+        // 67.792 before the commission split was rounded to the currency's precision.
+        $this->assertEquals( 67.79, $comm->get_admin_commission() );
     }
 
     public function test_calculate_for_refund() {
@@ -65,5 +66,61 @@ class CommissionCalculatorTest extends DokanTestCase {
 
         $this->assertEquals( 0.0, $commission->get_vendor_net_earning() );
         $this->assertEquals( 0.0, $commission->get_admin_net_commission() );
+    }
+
+    /**
+     * The two shares must always add back up to the amount the customer paid.
+     *
+     * 6.45 at 30% is 1.935 — exactly half a cent. Rounding each share on its own
+     * sends 1.93 to the admin and 4.51 to the vendor, and the remaining cent is
+     * credited to nobody.
+     *
+     * @dataProvider half_cent_split_provider
+     */
+    public function test_admin_and_vendor_shares_sum_to_the_total( $total, $percentage, $expected_admin, $expected_vendor ) {
+        $settings = new Setting();
+        $settings->set_type( 'percentage' );
+        $settings->set_percentage( $percentage );
+        $settings->set_flat( 0 );
+
+        $commission = dokan_get_container()->get( Calculator::class )
+            ->set_total( $total )
+            ->set_quantity( 1 )
+            ->set_discount( new CouponInfo( [] ) )
+            ->set_settings( $settings )
+            ->calculate();
+
+        $admin  = $commission->get_admin_net_commission();
+        $vendor = $commission->get_vendor_net_earning();
+
+        // The vendor's share is the exact remainder rather than a second rounded
+        // figure, so it carries the usual float noise (0.15 - 0.08 is 0.0699...).
+        // Every path that shows or stores it rounds, so compare at that precision.
+        $this->assertEqualsWithDelta( $expected_admin, $admin, 0.0001 );
+        $this->assertEqualsWithDelta( $expected_vendor, $vendor, 0.0001 );
+        $this->assertEquals( $total, round( $admin + $vendor, 2 ) );
+    }
+
+    public function half_cent_split_provider() {
+        return [
+            'issue 5937 reproduction' => [ 6.45, 30, 1.94, 4.51 ],
+            'half cent rounds up'     => [ 0.15, 50, 0.08, 0.07 ],
+            'no rounding needed'      => [ 100.00, 25, 25.00, 75.00 ],
+            'admin takes everything'  => [ 6.45, 100, 6.45, 0.00 ],
+        ];
+    }
+
+    /**
+     * A refunded amount must split without losing a cent either, and the
+     * proration in calculate_for_refund() is a prime source of long tails.
+     */
+    public function test_refund_shares_sum_to_the_refunded_amount() {
+        $commission = dokan_get_container()->get( Calculator::class )
+            ->calculate_for_refund( 4.51, 1.94, 6.45, 6.45 );
+
+        $this->assertEquals(
+            6.45,
+            round( $commission->get_vendor_net_earning() + $commission->get_admin_net_commission(), 2 )
+        );
     }
 }

--- a/tests/php/src/Commission/OrderCommissionTest.php
+++ b/tests/php/src/Commission/OrderCommissionTest.php
@@ -484,13 +484,16 @@ class OrderCommissionTest extends \WeDevs\Dokan\Test\DokanTestCase {
 					'commission' => 20 + 3.5 - 3, // Shipping fee + Admin Net Commission
 					'vendor_earnings' => 31.5, // 13.5 + 18
 					'vendor_net_earnings' => 31.5,
+					// The admin's share of the refund is rounded to the currency's precision
+					// and the vendor is refunded the remainder, so the balances left behind
+					// move by exactly the figures the refund records.
 					'refund' => [ // Refund amount = 5
-						'commission_in_refund' => number_format( ( 5 / 12 * -1.5 ), 2 ), // Sum of ( Item wise net commission in refund = commission before refund * refund amount / paid amount ).
-						'vendor_earning_in_refund' => number_format( 5 / 12 * 13.5, 2 ), // Sum of ( Item wise net earning in refund  = earning before refund * refund amount / paid amount ).
-						'net_commission' => number_format( 0.5 - ( -1.5 / 12 * 5 ), 2 ), // Net commission after refund =  (Net commission before refund - Net commission in refund),
-						'commission' => number_format( 20 + 0.5 - ( -1.5 / 12 * 5 ), 2 ), // Admin Shipping Fee + Net commission after refund
-						'vendor_earnings' => number_format( 31.5 - ( 13.5 / 12 * 5 ), 2 ), // Item wise Vendor earning in refund = earning_before_refund / paid_amount * refund_amount
-						'vendor_net_earnings' => number_format( 31.5 - ( 13.5 / 12 * 5 ), 2 ), // Item wise Vendor earning in refund = earning_before_refund / paid_amount * refund_amount
+						'commission_in_refund' => number_format( ( 5 / 12 * -1.5 ), 2 ), // -0.63, the admin's rounded share.
+						'vendor_earning_in_refund' => number_format( 5 - -0.63, 2 ), // 5.63, the remainder of the refund.
+						'net_commission' => number_format( 0.5 - -0.63, 2 ), // Net commission before refund - net commission in refund.
+						'commission' => number_format( 20 + 0.5 - -0.63, 2 ), // Admin Shipping Fee + Net commission after refund
+						'vendor_earnings' => number_format( 31.5 - 5.63, 2 ), // Vendor earning before refund - vendor earning in refund.
+						'vendor_net_earnings' => number_format( 31.5 - 5.63, 2 ),
 					],
 				],
 			],
@@ -652,13 +655,16 @@ class OrderCommissionTest extends \WeDevs\Dokan\Test\DokanTestCase {
 					'vendor_earnings' => 28.98, // ( 35 - (3+4) ) + 0.98  line_item_total - coupon - commission (12.42 + 16.56)
 					'vendor_net_earnings' => 28.98, // vendor_earnings
 
+                    // The admin's share of the refund is rounded to the currency's precision
+                    // and the vendor is refunded the remainder, so the balances left behind
+                    // move by exactly the figures the refund records.
                     'refund' => [
-                        'commission_in_refund' => number_format( ( 5 / 12 * -0.42 ), 2 ), // Sum of (Item wise net commission in refund = commission before refund * refund amount / paid amount ).
-                        'vendor_earning_in_refund' => number_format( 5 / 12 * 12.42, 2 ), // Sum of (Item wise net earning in refund = earning before refund * refund amount / paid amount ).
-                        'net_commission' => number_format( -0.98 - ( 5 / 12 * -0.42 ), 2 ), // Net commission after refund =  (Net commission before refund - Net commission in refund),
-                        'commission' => number_format( 20 - 0.98 - ( 5 / 12 * -0.42 ), 2 ), // Admin Shipping Fee + Net commission after refund
-                        'vendor_earnings' => number_format( 28.98 - ( 12.42 / 12 * 5 ), 2 ), // Item wise Vendor earning in refund = earning_before_refund / paid_amount * refund_amount
-                        'vendor_net_earnings' => number_format( 28.98 - ( 12.42 / 12 * 5 ), 2 ), // Item wise Vendor earning in refund = earning_before_refund / paid_amount * refund_amount
+                        'commission_in_refund' => number_format( ( 5 / 12 * -0.42 ), 2 ), // -0.18, the admin's rounded share.
+                        'vendor_earning_in_refund' => number_format( 5 - -0.18, 2 ), // 5.18, the remainder of the refund.
+                        'net_commission' => number_format( -0.98 - -0.18, 2 ), // Net commission before refund - net commission in refund.
+                        'commission' => number_format( 20 - 0.98 - -0.18, 2 ), // Admin Shipping Fee + Net commission after refund
+                        'vendor_earnings' => number_format( 28.98 - 5.18, 2 ), // Vendor earning before refund - vendor earning in refund.
+                        'vendor_net_earnings' => number_format( 28.98 - 5.18, 2 ),
                     ],
 				],
 			],


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

The admin's commission and the vendor's earning are both money, and both get rounded before they are paid out — but they were rounded **independently**, so the two shares stopped adding up to what the customer actually paid.

On an order of `6.45` at 30% commission (`6.45 × 30% = 1.935` — exactly half a cent):

| | Before | After |
|---|---|---|
| Admin commission | 1.93 | **1.94** |
| Vendor earning | 4.51 | 4.51 |
| **Sum** | **6.44** ❌ | **6.45** ✅ |

The missing cent then propagated. With a `0.49` gateway fee borne by the admin, Dokan recorded the admin's earning as `1.44` while the admin actually kept `1.45`.

`Calculator` now rounds **only** the admin's share to the currency's precision and gives the vendor the **exact remainder** — in both `calculate()` (sales) and `calculate_for_refund()` (refunds, where the proration is what generates the long decimal tails).

This also settles a disagreement between the two ways admin earning is derived, which is why the same order could report different figures in different places:

* `Commission.php:391` — `order_total - net_amount` (residual; used by reports)
* `OrderCommission.php:509` — `get_admin_net_commission() + get_total_admin_fees()` (recomputed; used by order details)

Since `net_amount` is now `order_total - sum(rounded admin shares)`, both derivations land on the same figure by construction.

#### Notes for reviewers

* **`Calculator::calculate()` now returns currency-precision values** where it previously returned raw floats. `test_calculator`'s expectation moved `67.792 → 67.79` to match.
* **`calculate_for_refund()`'s `$vendor_earning` parameter is now unused** — the vendor's share is derived from `$refund_amount` instead. Kept in the signature for backward compatibility. This is safe because `$vendor_earning + $admin_commission == $item_total` holds by construction in `calculate()`.
* **Two `OrderCommissionTest` refund expectations were corrected**, not merely bumped. They encoded the bug: recording a `5.63` refund to the vendor while dropping the vendor's balance by only `5.625`. They now use the rounded figures so the record and the balance move by the same amount.
* **Existing orders are not backfilled.** Commissions already stored under the old split keep their figures until `RegenerateOrderCommission` runs.
* Rounding is per line item, so on a multi-item order the admin can gain up to half a cent versus an exact split. Nothing is ever lost — the invariant holds per item and therefore per order.

### Related Pull Request(s)

* N/A

### Closes

* Closes getdokan/dokan-pro#5937 — cross-repo reference, so it will not auto-close from this PR.

### How to test the changes in this Pull Request:

**Manual**

1. Set a global commission of **percentage, 30%**.
2. Place an order with a single product totalling **6.45**.
3. Check the admin commission and vendor earning on the order.
   * Expected: admin **1.94**, vendor **4.51** — summing to exactly `6.45`.
   * Before this PR: admin `1.93`, vendor `4.51` — summing to `6.44`.
4. Using a gateway where the admin bears the processing fee (e.g. Stripe, fee `0.49`), confirm the admin's recorded earning is **1.45**, not `1.44`.
5. Partially refund an order and confirm the vendor's balance drops by exactly the amount shown on the refund record.

**Automated**

```bash
npx wp-env run tests-cli --env-cwd=wp-content/plugins/dokan-lite \
  php -d memory_limit=2G vendor/bin/phpunit --group commission
```

```
OK (24 tests, 188 assertions)
```

Full suite: `250 tests, 965 assertions`, with one failure — `OrderStatusChangeTest::test_blocked_status_transitions` — which reproduces identically on a clean `develop` and is unrelated to commission. (The suite needs `-d memory_limit=2G`; the default 512M OOMs in a REST test.)

`CommissionCalculatorTest` gains a data-driven test asserting the `admin + vendor == total` invariant, covering the issue's exact numbers, a half-cent that rounds up, a clean split, and a 100% commission edge case — plus a refund-sum test.

### Changelog entry

*Fix: Admin commission and vendor earning no longer lose a cent to rounding*

Admin commission and vendor earning were each rounded on their own, so whenever a commission landed on a half-cent the two shares no longer added up to the order total — an order of 6.45 at 30% paid out 1.93 + 4.51 = 6.44. The remaining cent was credited to neither party, and admin earnings, gateway fee deductions, and reports all drifted from the amounts actually transacted. The admin's share is now rounded to the store's currency precision and the vendor receives the exact remainder, so the two always reconcile against the order total.

### Before Changes

`6.45` at 30% with a `0.49` admin-borne gateway fee: admin commission shown as `1.93`, vendor earning `4.51` (sum `6.44`, a cent short of the `6.45` paid), admin earning recorded as `1.44` against the `1.45` actually received.

### After Changes

Same order: admin commission `1.94`, vendor earning `4.51` (sum `6.45`), admin earning `1.45`.

_No screenshots: this is a backend arithmetic fix with no UI surface of its own. The figures above are covered by the automated tests listed under "How to test"._

### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.

### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commission rounding to match the store’s configured currency precision.
  * Ensured admin and vendor commission shares consistently add up to the sale or refund total.
  * Corrected refund commission calculations, including orders with coupons and shared discounts.
* **Tests**
  * Added coverage for currency rounding edge cases and refund share accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->