### PR TITLE
fix(intelligence): resolve stale AI model ids instead of fatalling on /ai/generate

### DIFF
--- a/includes/Intelligence/Admin/Settings.php
+++ b/includes/Intelligence/Admin/Settings.php
@@ -7,12 +7,53 @@ use WeDevs\Dokan\Intelligence\Manager;
 use WeDevs\Dokan\Intelligence\Services\ChatgptResponseService;
 use WeDevs\Dokan\Intelligence\Services\GeminiResponseService;
 use WeDevs\Dokan\Intelligence\Services\Model;
+use WeDevs\Dokan\Intelligence\Services\Provider;
 
 class Settings implements Hookable {
     public function register_hooks(): void {
         add_filter( 'dokan_settings_sections', [ $this, 'render_appearance_section' ] );
         add_filter( 'dokan_settings_fields', [ $this, 'render_ai_settings' ] );
         add_filter( 'dokan_rest_api_class_map', [ $this, 'rest_api_class_map' ] );
+        add_filter( 'dokan_get_settings_values', [ $this, 'remap_retired_model_values' ], 10, 2 );
+    }
+
+    /**
+     * Replace saved model ids that a provider has since retired.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array  $values     Section setting values.
+     * @param string $section_id Section id.
+     *
+     * @return array
+     */
+    public function remap_retired_model_values( $values, $section_id ): array {
+        if ( 'dokan_ai' !== $section_id || ! is_array( $values ) ) {
+            return (array) $values;
+        }
+
+        $manager = dokan_get_container()->get( Manager::class );
+
+        foreach ( [ Model::SUPPORTS_TEXT, Model::SUPPORTS_IMAGE ] as $type ) {
+            $prefix = $manager->get_type_prefix( $type );
+
+            foreach ( $manager->get_engines( $type ) as $provider_id => $provider ) {
+                $key = 'dokan_ai_' . $prefix . $provider_id . '_model';
+
+                if ( ! $provider instanceof Provider || empty( $values[ $key ] ) || ! is_scalar( $values[ $key ] ) ) {
+                    continue;
+                }
+
+                $models = $provider->get_models_by_type( $type );
+
+                // A retired model id is not among the select options, so it would render blank.
+                if ( ! isset( $models[ $values[ $key ] ] ) ) {
+                    $values[ $key ] = $provider->get_default_model_id_by_type( $type );
+                }
+            }
+        }
+
+        return $values;
     }
 
     /**
@@ -90,7 +131,7 @@ class Settings implements Hookable {
                 'type'    => 'select',
                 'options' => array_map( fn( $model ) => $model->get_title(), $provider->get_models_by_type( Model::SUPPORTS_TEXT ) ),
                 'desc'    => __( 'More advanced models provide higher quality output but may cost more per generation.', 'dokan-lite' ),
-                'default' => $provider->get_default_model_id(),
+                'default' => $provider instanceof Provider ? $provider->get_default_model_id_by_type( Model::SUPPORTS_TEXT ) : '',
                 'is_lite' => true,
                 'show_if' => [
                     'dokan_ai_engine' => [

--- a/includes/Intelligence/Admin/Settings.php
+++ b/includes/Intelligence/Admin/Settings.php
@@ -25,11 +25,11 @@ class Settings implements Hookable {
      * @param array  $values     Section setting values.
      * @param string $section_id Section id.
      *
-     * @return array
+     * @return mixed Untouched when the section is not the AI section.
      */
-    public function remap_retired_model_values( $values, $section_id ): array {
+    public function remap_retired_model_values( $values, $section_id ) {
         if ( 'dokan_ai' !== $section_id || ! is_array( $values ) ) {
-            return (array) $values;
+            return $values;
         }
 
         $manager = dokan_get_container()->get( Manager::class );

--- a/includes/Intelligence/REST/AIRequestController.php
+++ b/includes/Intelligence/REST/AIRequestController.php
@@ -101,13 +101,12 @@ class AIRequestController extends DokanBaseVendorController {
             $prefix      = $manager->get_type_prefix( $type );
             $provider_id = $manager->active_engine( $type );
             $model_id    = dokan_get_option( 'dokan_ai_' . $prefix . $provider_id . '_model', 'dokan_ai', '' );
+            $model_id    = is_scalar( $model_id ) ? (string) $model_id : '';
             $provider    = $manager->get_provider( $provider_id );
 
             if ( ! $provider instanceof AIProviderInterface ) {
                 return $this->configuration_error( __( 'The configured AI provider is no longer available. Kindly reach out to Marketplace Owner.', 'dokan-lite' ) );
             }
-
-            $model_id = is_scalar( $model_id ) ? (string) $model_id : '';
 
             // A model id saved before the provider retired that model must not break generation.
             $model = $provider instanceof Provider

--- a/includes/Intelligence/REST/AIRequestController.php
+++ b/includes/Intelligence/REST/AIRequestController.php
@@ -78,10 +78,11 @@ class AIRequestController extends DokanBaseVendorController {
         );
 
         // The payload schema declares no properties, so coerce before any string API touches these.
-        $args['type']  = is_scalar( $args['type'] ) ? sanitize_key( (string) $args['type'] ) : Model::SUPPORTS_TEXT;
-        $args['field'] = is_scalar( $args['field'] ) ? (string) $args['field'] : '';
-        $type          = '' !== $args['type'] ? $args['type'] : Model::SUPPORTS_TEXT;
+        $type = is_scalar( $args['type'] ) ? sanitize_key( (string) $args['type'] ) : '';
+        $type = '' !== $type ? $type : Model::SUPPORTS_TEXT;
+
         $args['type']  = $type;
+        $args['field'] = is_scalar( $args['field'] ) ? (string) $args['field'] : '';
 
         // Resolve the appropriate service based on the AI engine.
 		try {

--- a/includes/Intelligence/REST/AIRequestController.php
+++ b/includes/Intelligence/REST/AIRequestController.php
@@ -2,9 +2,12 @@
 
 namespace WeDevs\Dokan\Intelligence\REST;
 
-use Exception;
+use Throwable;
 use WeDevs\Dokan\Intelligence\Manager;
+use WeDevs\Dokan\Intelligence\Services\AIModelInterface;
+use WeDevs\Dokan\Intelligence\Services\AIProviderInterface;
 use WeDevs\Dokan\Intelligence\Services\Model;
+use WeDevs\Dokan\Intelligence\Services\Provider;
 use WeDevs\Dokan\Intelligence\Utils\PromptUtils;
 use WeDevs\Dokan\REST\DokanBaseVendorController;
 use WP_Error;
@@ -67,45 +70,71 @@ class AIRequestController extends DokanBaseVendorController {
 
     public function handle_request( $request ) {
         $prompt = $request->get_param( 'prompt' );
-        $args = wp_parse_args(
-            $request->get_param( 'payload' ), [
+        $args   = wp_parse_args(
+            (array) $request->get_param( 'payload' ), [
 				'field' => '',
                 'type'  => Model::SUPPORTS_TEXT,
 			]
         );
-        $type = $args['type'];
+
+        // The payload schema declares no properties, so coerce before any string API touches these.
+        $args['type']  = is_scalar( $args['type'] ) ? sanitize_key( (string) $args['type'] ) : Model::SUPPORTS_TEXT;
+        $args['field'] = is_scalar( $args['field'] ) ? (string) $args['field'] : '';
+        $type          = '' !== $args['type'] ? $args['type'] : Model::SUPPORTS_TEXT;
+        $args['type']  = $type;
 
         // Resolve the appropriate service based on the AI engine.
 		try {
-            $manager     = dokan_get_container()->get( Manager::class );
-            $prefix      = $type === Model::SUPPORTS_TEXT ? '' : sanitize_key( $type ) . '_';
-            $provider_id = dokan_get_option( 'dokan_ai_' . $prefix . 'engine', 'dokan_ai', '' );
-            $model_id    = dokan_get_option( 'dokan_ai_' . $prefix . $provider_id . '_model', 'dokan_ai', '' );
+            $manager = dokan_get_container()->get( Manager::class );
 
-            if ( empty( $provider_id ) || empty( $model_id ) ) {
-                throw new Exception(
-                    esc_html__( 'AI provider or model is not configured properly.', 'dokan-lite' ),
-                    400
+            // Image generation is billed to the marketplace owner, so the admin toggle must hold at the API too.
+            if ( Model::SUPPORTS_IMAGE === $type && 'on' !== dokan_get_option( 'dokan_ai_image_gen_availability', 'dokan_ai', 'off' ) ) {
+                return $this->configuration_error( __( 'AI image generation is not enabled for this marketplace.', 'dokan-lite' ) );
+            }
+
+            // active_engine() falls back to openai, so emptiness alone no longer proves a working setup.
+            if ( ! $manager->is_configured( $type ) ) {
+                return $this->configuration_error( __( 'AI is not configured for this marketplace. Kindly reach out to Marketplace Owner.', 'dokan-lite' ) );
+            }
+
+            $prefix      = $manager->get_type_prefix( $type );
+            $provider_id = $manager->active_engine( $type );
+            $model_id    = dokan_get_option( 'dokan_ai_' . $prefix . $provider_id . '_model', 'dokan_ai', '' );
+            $provider    = $manager->get_provider( $provider_id );
+
+            if ( ! $provider instanceof AIProviderInterface ) {
+                return $this->configuration_error( __( 'The configured AI provider is no longer available. Kindly reach out to Marketplace Owner.', 'dokan-lite' ) );
+            }
+
+            $model_id = is_scalar( $model_id ) ? (string) $model_id : '';
+
+            // A model id saved before the provider retired that model must not break generation.
+            $model = $provider instanceof Provider
+                ? $provider->resolve_model( $type, $model_id )
+                : $provider->get_model( $model_id );
+
+            if ( ! $model instanceof AIModelInterface ) {
+                return $this->configuration_error(
+                    // translators: %s: type of generation.
+                    sprintf( __( 'No AI model is available for %s generation. Kindly reach out to Marketplace Owner.', 'dokan-lite' ), $type )
                 );
             }
 
-            $provider     = $manager->get_provider( $provider_id );
-            $model        = $provider->get_model( $model_id );
-            $prompt       = PromptUtils::prepare_prompt( $args['field'], $prompt );
-            $process_call = 'process_' . sanitize_key( $type );
+            $process_call = 'process_' . $type;
 
             if ( ! method_exists( $model, $process_call ) ) {
-                throw new Exception(
+                return $this->configuration_error(
                     // translators: %s: type of generation.
-                    sprintf( esc_html__( 'Model does not support %s generation.', 'dokan-lite' ), $type ),
-                    400
+                    sprintf( __( 'Model does not support %s generation.', 'dokan-lite' ), $type )
                 );
 			}
 
-            $response = $model->{$process_call}( $prompt, $args );
+            $response = $model->{$process_call}( PromptUtils::prepare_prompt( $args['field'], $prompt ), $args );
 
             return rest_ensure_response( $response );
-        } catch ( Exception $e ) {
+        } catch ( Throwable $e ) {
+            dokan_log( 'AI generation request failed: ' . $e->getMessage(), 'error' );
+
             if ( in_array( $e->getCode(), [ 401, 429 ], true ) ) {
                 return new WP_Error(
                     'dokan_ai_service_error',
@@ -119,5 +148,18 @@ class AIRequestController extends DokanBaseVendorController {
                 [ 'status' => 403 ]
             );
         }
+    }
+
+    /**
+     * Build a misconfiguration error response.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $message Human readable reason.
+     *
+     * @return WP_Error
+     */
+    protected function configuration_error( string $message ): WP_Error {
+        return new WP_Error( 'dokan_ai_not_configured', esc_html( $message ), [ 'status' => 400 ] );
     }
 }

--- a/includes/Intelligence/Services/Provider.php
+++ b/includes/Intelligence/Services/Provider.php
@@ -84,22 +84,19 @@ abstract class Provider implements AIProviderInterface, Hookable {
      * @return AIModelInterface|null
      */
     public function resolve_model( string $type, string $model_id = '' ): ?AIModelInterface {
-        if ( '' !== $model_id ) {
-            $model = $this->get_model( $model_id );
+        // Keyed by model id, so every lookup below is an array read rather than another filter dispatch.
+        $models = $this->get_models_by_type( $type );
 
-            if ( $model instanceof AIModelInterface && $model->supports( $type ) ) {
-                return $model;
-            }
+        if ( '' !== $model_id && isset( $models[ $model_id ] ) ) {
+            return $models[ $model_id ];
         }
 
         // A model id saved before the provider retired that model must not break generation.
-        $default = $this->get_model( $this->get_default_model_id() );
+        $default_id = $this->get_default_model_id();
 
-        if ( $default instanceof AIModelInterface && $default->supports( $type ) ) {
-            return $default;
+        if ( isset( $models[ $default_id ] ) ) {
+            return $models[ $default_id ];
         }
-
-        $models = $this->get_models_by_type( $type );
 
         return ! empty( $models ) ? reset( $models ) : null;
     }

--- a/includes/Intelligence/Services/Provider.php
+++ b/includes/Intelligence/Services/Provider.php
@@ -73,6 +73,52 @@ abstract class Provider implements AIProviderInterface, Hookable {
 
     abstract public function get_default_model_id(): string;
 
+    /**
+     * Resolve the model to use for a generation type, tolerating stale saved ids.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $type     The type of generation (e.g., 'text', 'image').
+     * @param string $model_id Optional. Saved model id to prefer.
+     *
+     * @return AIModelInterface|null
+     */
+    public function resolve_model( string $type, string $model_id = '' ): ?AIModelInterface {
+        if ( '' !== $model_id ) {
+            $model = $this->get_model( $model_id );
+
+            if ( $model instanceof AIModelInterface && $model->supports( $type ) ) {
+                return $model;
+            }
+        }
+
+        // A model id saved before the provider retired that model must not break generation.
+        $default = $this->get_model( $this->get_default_model_id() );
+
+        if ( $default instanceof AIModelInterface && $default->supports( $type ) ) {
+            return $default;
+        }
+
+        $models = $this->get_models_by_type( $type );
+
+        return ! empty( $models ) ? reset( $models ) : null;
+    }
+
+    /**
+     * Get the default model id for a generation type.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $type The type of generation (e.g., 'text', 'image').
+     *
+     * @return string Empty string when the provider has no model of that type.
+     */
+    public function get_default_model_id_by_type( string $type ): string {
+        $model = $this->resolve_model( $type );
+
+        return $model instanceof AIModelInterface ? $model->get_id() : '';
+    }
+
 	/**
 	 * @inheritDoc
 	 */

--- a/includes/Intelligence/Services/Providers/Gemini.php
+++ b/includes/Intelligence/Services/Providers/Gemini.php
@@ -28,7 +28,7 @@ class Gemini extends Provider {
 	}
 
 	public function get_default_model_id(): string {
-		return 'gemini-2.0-flash';
+		return 'gemini-2.5-flash';
 	}
 
 

--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -308,20 +308,16 @@
                     if ( resp.success ) {
 
                         Object.keys( self.settingFields ).forEach( function( section, index ) {
-                            // Copy the saved section once up front; assigning it inside the loop wiped the
-                            // defaults already applied to fields that came before the first saved one.
+                            // Copy the saved section once up front — re-assigning it inside the loop wiped defaults already applied to earlier fields.
                             self.settingValues[section] = jQuery.extend( {}, resp.data[section] );
 
-                            Object.keys( self.settingFields[section] ).forEach( function( field, i ) {
+                            Object.keys( self.settingFields[section] ).forEach( function( field ) {
                                 if ( typeof( self.settingValues[section][field] ) !== 'undefined' ) {
                                     return;
                                 }
 
-                                if ( typeof( self.settingFields[section][field].default ) === 'undefined' ) {
-                                    self.settingValues[section][field] = '';
-                                } else {
-                                    self.settingValues[section][field] = self.settingFields[section][field].default;
-                                }
+                                var fieldDefault = self.settingFields[section][field].default;
+                                self.settingValues[section][field] = typeof fieldDefault === 'undefined' ? '' : fieldDefault;
                             });
                         });
 

--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -308,20 +308,19 @@
                     if ( resp.success ) {
 
                         Object.keys( self.settingFields ).forEach( function( section, index ) {
-                            Object.keys( self.settingFields[section] ).forEach( function( field, i ) {
+                            // Copy the saved section once up front; assigning it inside the loop wiped the
+                            // defaults already applied to fields that came before the first saved one.
+                            self.settingValues[section] = jQuery.extend( {}, resp.data[section] );
 
-                                if (!self.settingValues[section]) {
-                                    self.settingValues[section] = {};
+                            Object.keys( self.settingFields[section] ).forEach( function( field, i ) {
+                                if ( typeof( self.settingValues[section][field] ) !== 'undefined' ) {
+                                    return;
                                 }
 
-                                if ( typeof( resp.data[section][field] ) === 'undefined' ) {
-                                    if ( typeof( self.settingFields[section][field].default ) === 'undefined' ) {
-                                        self.settingValues[section][field] = '';
-                                    } else {
-                                        self.settingValues[section][field] = self.settingFields[section][field].default;
-                                    }
+                                if ( typeof( self.settingFields[section][field].default ) === 'undefined' ) {
+                                    self.settingValues[section][field] = '';
                                 } else {
-                                    self.settingValues[section] = resp.data[section];
+                                    self.settingValues[section][field] = self.settingFields[section][field].default;
                                 }
                             });
                         });


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

`Gemini::get_default_model_id()` returned `gemini-2.0-flash`, an id that is **no longer among the registered Gemini models** (`gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-2.5-flash-lite-preview-06-17`). `Provider::get_model()` returns `null` for an unknown id, and `handle_request()` passed that null straight into `method_exists()` — the exact `TypeError` in the report.

The reporter's second observation — *"some dropdowns, which were previously selected, appear empty after a few days"* — is **the same root cause, not a separate symptom**. That same unresolvable id is the `default` of the admin Model `<select>`, so it is not among the option keys and the select renders blank; saving the tab then persists `gemini-2.0-flash` into the `dokan_ai` option, which is what later reaches `/ai/generate`.

What changed:

1. **`Providers/Gemini.php`** — default now points at a registered model.
2. **`Services/Provider.php`** — new `resolve_model( $type, $model_id )` degrades a retired saved id to a working model of the right type instead of returning null, plus `get_default_model_id_by_type()`. Both are additive; the `get_default_model_id(): string` abstract signature is untouched so Pro's `BriaAi` keeps compiling.
3. **`REST/AIRequestController.php`** — returns `WP_Error` for every misconfiguration instead of dereferencing a null provider/model. Also fixes **a second, independent fatal one line earlier**: `$manager->get_provider()` returns null for an unregistered id, so a site still holding the 4.1 default `dokan_ai_engine = 'chatgpt'` hit `Call to a member function get_model() on null`.
4. **`Intelligence/Admin/Settings.php`** — type-aware default, plus a read-time remap of retired ids so the select self-heals.
5. **`src/admin/pages/Settings.vue`** — the hydration loop assigned the whole saved section *inside* the per-field loop, discarding defaults already applied to earlier fields. Hoisted the copy out of the loop.

Two deliberate calls worth reviewer attention:

- **Gated on `$manager->is_configured( $type )` rather than `empty( $provider_id )`.** `active_engine()` falls back to `openai`, so an emptiness check would have been dead code and an unconfigured site would have attempted a keyless upstream call.
- **`AIProviderInterface` was NOT widened.** `resolve_model()` / `get_default_model_id_by_type()` are not on the public interface, so every call site guards with `instanceof Provider` (or `method_exists` in Pro). Adding them to the interface would be a BC break for third-party providers.

Also enforces `dokan_ai_image_gen_availability` at the API — image generation is billed to the marketplace owner and the admin toggle previously held only in the UI.

### Related Pull Request(s)

* dokan-pro companion (image-model default): filed alongside — must ship in the **same release train**, though it is `method_exists`-guarded so merge order does not matter.

### Closes

* Closes https://github.com/getdokan/dokan-pro/issues/4910

### How to test the changes in this Pull Request:

Put the site into the reported configuration and call the endpoint:

```bash
wp eval '
$o = get_option( "dokan_ai", [] );
$o["dokan_ai_engine"]         = "gemini";
$o["dokan_ai_gemini_model"]   = "gemini-2.0-flash";  // retired id
$o["dokan_ai_gemini_api_key"] = "dummy";
update_option( "dokan_ai", $o );
wp_set_current_user( 1 );
$r = new WP_REST_Request( "POST", "/dokan/v1/ai/generate" );
$r->set_param( "prompt", "a short product title" );
$r->set_param( "payload", [ "field" => "title", "type" => "text" ] );
$res = rest_do_request( $r );
echo $res->get_status() . " " . wp_json_encode( $res->get_data() ) . "\n";'
```

**Before:** `PHP Fatal error: Uncaught TypeError: method_exists(): Argument #1 ... null given ... AIRequestController.php:97` with `method_exists(NULL, 'process_text')` — byte-identical to the trace in the issue.
**After:** no fatal; a clean JSON error response.

Verified matrix (all previously fatal or misleading, now clean — Lite 5.0.9 / Pro 5.0.7 / WC 10.9.4 / PHP 8.4):

| scenario | after |
|---|---|
| stale `gemini-2.0-flash` | 403 upstream error (model resolved, request attempted) |
| legacy engine `chatgpt` | 400 `dokan_ai_not_configured` (was a fatal on line 93) |
| unknown engine | 400 `dokan_ai_not_configured` |
| no API key | 400 `dokan_ai_not_configured` |
| `type=image`, toggle off | 400 "AI image generation is not enabled for this marketplace." |
| `payload.field`/`type` as arrays | 403, no `TypeError` |

Blank-dropdown half:

```
raw saved value      : gemini-2.0-flash
value seen by the UI : gemini-2.5-flash
select options       : gemini-2.5-flash, gemini-2.5-pro, gemini-2.5-flash-lite-preview-06-17
field default        : gemini-2.5-flash
default IS an option : YES   (before: NO -> blank dropdown)
other section intact : {"foo":"bar"}
```

**Browser check still needed from a reviewer** (my local session could not reach `/wp-admin`): Dokan → Settings → **AI Assist**, set Engine = Gemini, confirm the Model select pre-selects "Gemini 2.5 Flash" instead of rendering blank. `src/` changed, so run `npm run build` first — `assets/js/` is gitignored and no build artefacts are committed.

PHPCS clean on all four PHP files. `src/admin/pages/Settings.vue` has a pre-existing eslint parse error at 4:52, identical on `develop` — unrelated to this change; the script block passes `node --check`.

### Changelog entry

**Fix — AI Assist: a retired model id no longer crashes generation or blanks the settings dropdown**

Previously, when a provider retired a model that was already saved in settings (Gemini's default `gemini-2.0-flash`), the Model dropdown rendered blank and any vendor AI generation request crashed with a PHP fatal error. Dokan now falls back to a working model of the correct type, remaps retired ids when settings load, and returns a clear error message for every misconfiguration instead of failing fatally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI model selection now automatically falls back to a supported default when a saved/retired model isn’t available.
  - AI requests now resolve text vs. image compatible models more reliably.
- **Bug Fixes**
  - Updated the default Gemini model to **Gemini 2.5 Flash**.
  - Fixed AI settings loading to copy saved section values once and only apply field defaults when a value is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->