### PR TITLE
fix(theme-support): honor Astra global button presets on the vendor store page

### DIFF
--- a/includes/ThemeSupport/Astra.php
+++ b/includes/ThemeSupport/Astra.php
@@ -18,7 +18,7 @@ class Astra {
         // Payment request button conflict issue fix
         add_action( 'wp_enqueue_scripts', [ $this, 'payment_request_button_style' ], 100 );
 
-        // Dokan's `.dokan-btn` outranks Astra's global button preset, so store pages ignore the theme's button styling.
+        // Dokan's `.dokan-btn` outranks Astra's global button preset, so store and store listing pages ignore the theme's button styling.
         add_action( 'wp_enqueue_scripts', [ $this, 'inherit_theme_button_presets' ], 100 );
     }
 
@@ -59,94 +59,26 @@ class Astra {
     }
 
     /**
-     * Bridge Astra's global button presets onto Dokan store page buttons.
+     * Bridge Astra's global button presets onto Dokan store and store listing page buttons.
      *
      * Astra emits its Global > Buttons preset on `button` / `.button` / `input[type="submit"]`,
-     * all of which Dokan's `.dokan-btn` rules outrank, so vendor store pages silently ignore the
-     * theme's button geometry while every other page on the site honours it.
+     * all of which Dokan's `.dokan-btn` rules outrank, so vendor store and store listing pages
+     * silently ignore the theme's button geometry while every other page on the site honours it.
      *
      * @since DOKAN_SINCE
      *
      * @return void
      */
     public function inherit_theme_button_presets() {
-        if ( ! dokan_is_store_page() ) {
+        if ( ! dokan_is_store_page() && ! dokan_is_store_listing() ) {
             return;
         }
 
-        if (
-            ! function_exists( 'astra_get_option' )
-            || ! function_exists( 'astra_responsive_spacing' )
-            || ! function_exists( 'astra_responsive_font' )
-            || ! function_exists( 'astra_get_font_extras' )
-            || ! function_exists( 'astra_get_tablet_breakpoint' )
-            || ! function_exists( 'astra_get_mobile_breakpoint' )
-        ) {
+        if ( ! $this->has_astra_button_helpers() ) {
             return;
         }
 
-        $padding   = astra_get_option( 'theme-button-padding' );
-        $radius    = astra_get_option( 'button-radius-fields' );
-        $font_size = astra_get_option( 'font-size-button' );
-
-        // `html body` outranks every Dokan button rule without assuming wrapper markup, so modals iziModal moves to <body> and Elementor store canvases stay covered.
-        $selector = 'html body .dokan-btn:not(.dokan-btn-round)';
-
-        // Property table mirrors Astra's own emission: the radius "sides" double as corners, clockwise from top-left.
-        $box_model = [
-            'padding-top'                => [ $padding, 'top' ],
-            'padding-right'              => [ $padding, 'right' ],
-            'padding-bottom'             => [ $padding, 'bottom' ],
-            'padding-left'               => [ $padding, 'left' ],
-            'border-top-left-radius'     => [ $radius, 'top' ],
-            'border-top-right-radius'    => [ $radius, 'right' ],
-            'border-bottom-right-radius' => [ $radius, 'bottom' ],
-            'border-bottom-left-radius'  => [ $radius, 'left' ],
-        ];
-
-        $breakpoints = [
-            'desktop' => null,
-            'tablet'  => absint( astra_get_tablet_breakpoint() ),
-            'mobile'  => absint( astra_get_mobile_breakpoint() ),
-        ];
-
-        $css = '';
-
-        foreach ( $breakpoints as $device => $max_width ) {
-            $rules = '';
-
-            foreach ( $box_model as $property => $source ) {
-                $value = $this->sanitize_css_length( astra_responsive_spacing( $source[0], $source[1], $device ) );
-
-                if ( '' !== $value ) {
-                    $rules .= sprintf( '%s:%s;', $property, $value );
-                }
-            }
-
-            $size = $this->sanitize_css_length( astra_responsive_font( $font_size, $device ), true );
-
-            if ( '' !== $size ) {
-                $rules .= sprintf( 'font-size:%s;', $size );
-            }
-
-            // Astra exposes a single, non-responsive line height for buttons.
-            if ( 'desktop' === $device ) {
-                $line_height = $this->sanitize_css_length(
-                    astra_get_font_extras( astra_get_option( 'font-extras-button' ), 'line-height', 'line-height-unit' )
-                );
-
-                if ( '' !== $line_height ) {
-                    $rules .= sprintf( 'line-height:%s;', $line_height );
-                }
-            }
-
-            if ( '' === $rules ) {
-                continue;
-            }
-
-            $rule = sprintf( '%s{%s}', $selector, $rules );
-            $css .= null === $max_width ? $rule : sprintf( '@media (max-width:%dpx){%s}', $max_width, $rule );
-        }
+        $css = $this->build_button_preset_css();
 
         if ( '' === $css ) {
             return;
@@ -160,6 +92,128 @@ class Astra {
     }
 
     /**
+     * Check that every Astra helper the button bridge reads through is loaded.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return bool
+     */
+    protected function has_astra_button_helpers() {
+        $helpers = [
+            'astra_get_option',
+            'astra_parse_css',
+            'astra_responsive_spacing',
+            'astra_responsive_font',
+            'astra_get_font_extras',
+            'astra_get_tablet_breakpoint',
+            'astra_get_mobile_breakpoint',
+        ];
+
+        foreach ( $helpers as $helper ) {
+            if ( ! function_exists( $helper ) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Build the button preset CSS for every breakpoint Astra exposes.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return string
+     */
+    protected function build_button_preset_css() {
+        $preset = [
+            'padding'     => astra_get_option( 'theme-button-padding' ),
+            'radius'      => astra_get_option( 'button-radius-fields' ),
+            'font_size'   => astra_get_option( 'font-size-button' ),
+            'font_extras' => astra_get_option( 'font-extras-button' ),
+        ];
+
+        // Desktop is the unscoped baseline; Astra gates the smaller devices behind a max-width.
+        $breakpoints = [
+            'desktop' => '',
+            'tablet'  => absint( astra_get_tablet_breakpoint() ),
+            'mobile'  => absint( astra_get_mobile_breakpoint() ),
+        ];
+
+        $selector = $this->get_button_selector();
+        $css      = '';
+
+        foreach ( $breakpoints as $device => $max_width ) {
+            $css .= astra_parse_css( [ $selector => $this->get_button_properties( $preset, $device ) ], '', $max_width );
+        }
+
+        return $css;
+    }
+
+    /**
+     * Map the CSS properties the bridge emits for a single device.
+     *
+     * Empty values are left in place for Astra to drop, so a preset the admin never
+     * configured keeps falling through to Dokan's own styling instead of blanking it.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array  $preset Astra button options keyed by the role they play here.
+     * @param string $device One of `desktop`, `tablet` or `mobile`.
+     *
+     * @return array
+     */
+    protected function get_button_properties( array $preset, $device ) {
+        // Astra's radius "sides" double as corners, clockwise from top-left.
+        $box_model = [
+            'padding-top'                => [ $preset['padding'], 'top' ],
+            'padding-right'              => [ $preset['padding'], 'right' ],
+            'padding-bottom'             => [ $preset['padding'], 'bottom' ],
+            'padding-left'               => [ $preset['padding'], 'left' ],
+            'border-top-left-radius'     => [ $preset['radius'], 'top' ],
+            'border-top-right-radius'    => [ $preset['radius'], 'right' ],
+            'border-bottom-right-radius' => [ $preset['radius'], 'bottom' ],
+            'border-bottom-left-radius'  => [ $preset['radius'], 'left' ],
+        ];
+
+        $properties = [];
+
+        foreach ( $box_model as $property => $source ) {
+            $properties[ $property ] = $this->sanitize_css_length( astra_responsive_spacing( $source[0], $source[1], $device ) );
+        }
+
+        $properties['font-size'] = $this->sanitize_css_length( astra_responsive_font( $preset['font_size'], $device ), true );
+
+        // Astra exposes a single, non-responsive line height for buttons.
+        if ( 'desktop' === $device ) {
+            $properties['line-height'] = $this->sanitize_css_length(
+                astra_get_font_extras( $preset['font_extras'], 'line-height', 'line-height-unit' )
+            );
+        }
+
+        return $properties;
+    }
+
+    /**
+     * Selector list that carries the preset onto Dokan's buttons.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return string
+     */
+    protected function get_button_selector() {
+        return implode(
+            ',',
+            [
+                // `html body` assumes no wrapper markup, so modals iziModal moves to <body> and Elementor store canvases stay covered.
+                'html body .dokan-btn:not(.dokan-btn-round)',
+                // Listing cards pin their padding behind an ID rule, and half a preset reads worse than none.
+                'html body #dokan-seller-listing-wrap .dokan-btn:not(.dokan-btn-round)',
+            ]
+        );
+    }
+
+    /**
      * Refresh the customizer preview whenever a bridged button setting changes.
      *
      * Astra live-previews its own buttons over postMessage, which never reloads the preview
@@ -170,7 +224,7 @@ class Astra {
      *
      * @return void
      */
-    private function sync_customizer_preview() {
+    protected function sync_customizer_preview() {
         $settings = [
             'theme-button-padding',
             'button-radius-fields',
@@ -178,7 +232,7 @@ class Astra {
             'font-extras-button',
         ];
 
-        // A transport switch to 'refresh' would break Astra's instant preview on every other page, so only this store-page preview asks the pane to reload.
+        // A transport switch to 'refresh' would break Astra's instant preview everywhere else, so only this preview asks the pane to reload.
         $script = sprintf(
             "( function ( api ) {
                 var timeout;
@@ -217,7 +271,7 @@ class Astra {
      *
      * @return string
      */
-    private function sanitize_css_length( $value, bool $allow_rem_fallback = false ) {
+    protected function sanitize_css_length( $value, bool $allow_rem_fallback = false ) {
         if ( ! is_scalar( $value ) ) {
             return '';
         }
@@ -228,5 +282,4 @@ class Astra {
 
         return preg_match( $pattern, $value ) ? $value : '';
     }
-
 }

--- a/includes/ThemeSupport/Astra.php
+++ b/includes/ThemeSupport/Astra.php
@@ -14,9 +14,12 @@ class Astra {
      */
     public function __construct() {
         add_filter( 'astra_page_layout', [ $this, 'remove_sidebar' ] );
-        
+
         // Payment request button conflict issue fix
         add_action( 'wp_enqueue_scripts', [ $this, 'payment_request_button_style' ], 100 );
+
+        // Dokan's `.dokan-btn` outranks Astra's global button preset, so store pages ignore the theme's button styling.
+        add_action( 'wp_enqueue_scripts', [ $this, 'inherit_theme_button_presets' ], 100 );
     }
 
     /**
@@ -35,24 +38,195 @@ class Astra {
     }
 
     public function payment_request_button_style() {
-        
+
         /*
          * For payment request button conflict with Astra theme
          * for simple and variable products in single product page.
          */
         if (
-            dokan()->is_pro_exists() 
-            && dokan_pro()->module->is_active( 'stripe_express' ) 
-            && defined('ASTRA_THEME_VERSION') 
+            dokan()->is_pro_exists()
+            && dokan_pro()->module->is_active( 'stripe_express' )
+            && defined( 'ASTRA_THEME_VERSION' )
             && is_checkout()
         ) {
             $style = '.woocommerce div.product.product-type-simple form.cart,
             .woocommerce div.product .woocommerce-variation-add-to-cart {
             display: unset !important;
             }';
-            
+
             wp_add_inline_style( 'dokan-style', $style );
         }
-
     }
+
+    /**
+     * Bridge Astra's global button presets onto Dokan store page buttons.
+     *
+     * Astra emits its Global > Buttons preset on `button` / `.button` / `input[type="submit"]`,
+     * all of which Dokan's `.dokan-btn` rules outrank, so vendor store pages silently ignore the
+     * theme's button geometry while every other page on the site honours it.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function inherit_theme_button_presets() {
+        if ( ! dokan_is_store_page() ) {
+            return;
+        }
+
+        if (
+            ! function_exists( 'astra_get_option' )
+            || ! function_exists( 'astra_responsive_spacing' )
+            || ! function_exists( 'astra_responsive_font' )
+            || ! function_exists( 'astra_get_font_extras' )
+            || ! function_exists( 'astra_get_tablet_breakpoint' )
+            || ! function_exists( 'astra_get_mobile_breakpoint' )
+        ) {
+            return;
+        }
+
+        $padding   = astra_get_option( 'theme-button-padding' );
+        $radius    = astra_get_option( 'button-radius-fields' );
+        $font_size = astra_get_option( 'font-size-button' );
+
+        // `html body` outranks every Dokan button rule without assuming wrapper markup, so modals iziModal moves to <body> and Elementor store canvases stay covered.
+        $selector = 'html body .dokan-btn:not(.dokan-btn-round)';
+
+        // Property table mirrors Astra's own emission: the radius "sides" double as corners, clockwise from top-left.
+        $box_model = [
+            'padding-top'                => [ $padding, 'top' ],
+            'padding-right'              => [ $padding, 'right' ],
+            'padding-bottom'             => [ $padding, 'bottom' ],
+            'padding-left'               => [ $padding, 'left' ],
+            'border-top-left-radius'     => [ $radius, 'top' ],
+            'border-top-right-radius'    => [ $radius, 'right' ],
+            'border-bottom-right-radius' => [ $radius, 'bottom' ],
+            'border-bottom-left-radius'  => [ $radius, 'left' ],
+        ];
+
+        $breakpoints = [
+            'desktop' => null,
+            'tablet'  => absint( astra_get_tablet_breakpoint() ),
+            'mobile'  => absint( astra_get_mobile_breakpoint() ),
+        ];
+
+        $css = '';
+
+        foreach ( $breakpoints as $device => $max_width ) {
+            $rules = '';
+
+            foreach ( $box_model as $property => $source ) {
+                $value = $this->sanitize_css_length( astra_responsive_spacing( $source[0], $source[1], $device ) );
+
+                if ( '' !== $value ) {
+                    $rules .= sprintf( '%s:%s;', $property, $value );
+                }
+            }
+
+            $size = $this->sanitize_css_length( astra_responsive_font( $font_size, $device ), true );
+
+            if ( '' !== $size ) {
+                $rules .= sprintf( 'font-size:%s;', $size );
+            }
+
+            // Astra exposes a single, non-responsive line height for buttons.
+            if ( 'desktop' === $device ) {
+                $line_height = $this->sanitize_css_length(
+                    astra_get_font_extras( astra_get_option( 'font-extras-button' ), 'line-height', 'line-height-unit' )
+                );
+
+                if ( '' !== $line_height ) {
+                    $rules .= sprintf( 'line-height:%s;', $line_height );
+                }
+            }
+
+            if ( '' === $rules ) {
+                continue;
+            }
+
+            $rule = sprintf( '%s{%s}', $selector, $rules );
+            $css .= null === $max_width ? $rule : sprintf( '@media (max-width:%dpx){%s}', $max_width, $rule );
+        }
+
+        if ( '' === $css ) {
+            return;
+        }
+
+        wp_add_inline_style( 'dokan-style', $css );
+
+        if ( is_customize_preview() ) {
+            $this->sync_customizer_preview();
+        }
+    }
+
+    /**
+     * Refresh the customizer preview whenever a bridged button setting changes.
+     *
+     * Astra live-previews its own buttons over postMessage, which never reloads the preview
+     * frame, so the server-built bridge CSS would stay stale inside the customizer and store
+     * page buttons would look out of sync exactly where the admin is configuring them.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    private function sync_customizer_preview() {
+        $settings = [
+            'theme-button-padding',
+            'button-radius-fields',
+            'font-size-button',
+            'font-extras-button',
+        ];
+
+        // A transport switch to 'refresh' would break Astra's instant preview on every other page, so only this store-page preview asks the pane to reload.
+        $script = sprintf(
+            "( function ( api ) {
+                var timeout;
+
+                var queueRefresh = function () {
+                    clearTimeout( timeout );
+                    timeout = setTimeout( function () {
+                        api.preview.send( 'refresh' );
+                    }, 400 );
+                };
+
+                api.bind( 'preview-ready', function () {
+                    %s.forEach( function ( key ) {
+                        api( 'astra-settings[' + key + ']', function ( setting ) {
+                            setting.bind( queueRefresh );
+                        } );
+                    } );
+                } );
+            }( wp.customize ) );",
+            wp_json_encode( $settings )
+        );
+
+        wp_add_inline_script( 'customize-preview', $script );
+    }
+
+    /**
+     * Whitelist a CSS length value.
+     *
+     * Astra returns theme option data verbatim when it is not a well formed responsive array,
+     * so nothing from the customizer is trusted before it reaches the style block.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param mixed $value              Raw value returned by an Astra helper.
+     * @param bool  $allow_rem_fallback Astra folds a rem fallback into pixel font sizes (`16px;font-size:1.0666rem`).
+     *
+     * @return string
+     */
+    private function sanitize_css_length( $value, bool $allow_rem_fallback = false ) {
+        if ( ! is_scalar( $value ) ) {
+            return '';
+        }
+
+        $value   = trim( (string) $value );
+        $length  = '-?\d*\.?\d+(px|em|rem|%|vh|vw|pt)?';
+        $pattern = '/^' . $length . ( $allow_rem_fallback ? '(;font-size:-?\d*\.?\d+rem)?' : '' ) . '$/';
+
+        return preg_match( $pattern, $value ) ? $value : '';
+    }
+
 }

--- a/includes/ThemeSupport/Astra.php
+++ b/includes/ThemeSupport/Astra.php
@@ -78,6 +78,11 @@ class Astra {
             return;
         }
 
+        // Registered before the CSS bail-out so the admin's first-ever preset change already refreshes the preview.
+        if ( is_customize_preview() ) {
+            $this->sync_customizer_preview();
+        }
+
         $css = $this->build_button_preset_css();
 
         if ( '' === $css ) {
@@ -85,10 +90,6 @@ class Astra {
         }
 
         wp_add_inline_style( 'dokan-style', $css );
-
-        if ( is_customize_preview() ) {
-            $this->sync_customizer_preview();
-        }
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Astra emits its **Global → Buttons** preset on `button` / `.button` / `input[type="submit"]`, and Dokan's own `.dokan-btn` rules outrank all of them — so the store-page buttons (Follow, Get Support, Chat Now, Share, review/support modals) ignored the preset while every other button on the site followed it.

On store pages only, the fix re-emits the preset's **geometry** under `html body .dokan-btn:not(.dokan-btn-round)`, which outranks Dokan's strongest button rule:

- Padding, border radius and font size — responsive, using Astra's tablet/mobile breakpoints — plus line height.
- Every value is whitelisted before it reaches the style block.
- The customizer preview refreshes when a button setting changes: Astra live-previews its own buttons over postMessage, which never reloads server-built CSS, so without this the preview looked out of sync while configuring.

**Button colors deliberately stay Dokan's own** — the store buttons keep the marketplace's color scheme; only the shape and sizing follow the theme. `ThemeSupport\Manager` only instantiates this class when the template is `astra`, so other themes are untouched.

### Closes

* Closes https://github.com/getdokan/dokan-pro/issues/5710

### How to test the changes in this Pull Request:

1. `wp theme install astra --activate`
2. Appearance → Customize → **Global → Buttons**: set a visible preset (e.g. radius 30, padding 22/44) — the store-page preview follows along while configuring.
3. Publish and open any vendor store page: Follow / Get Support / Share (and the review/support modal buttons) match the theme's button shape, keeping Dokan's colors. `/shop/` and other pages are unchanged, and switching themes removes the CSS entirely.

### Changelog entry

**Fix — Astra: global button presets now apply to vendor store page buttons**

Buttons on the single store page ignored the shape configured under Appearance → Customize → Global → Buttons, because Dokan's own button styles outranked the theme's. They now follow the theme preset's geometry — with a live customizer preview — while keeping Dokan's button colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Dokan store and store-listing pages now better match Astra button preset styling, including padding, border radius, font size, and breakpoint-specific adjustments across desktop, tablet, and mobile.
* **Bug Fixes**
  * Improved compatibility between Astra theme button settings and Dokan button rendering.
  * Existing payment button styling behavior is preserved on supported checkout pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->