### PR TITLE
fix(product-editor): whitelist the spmv_search field variant

### DIFF
--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -63,6 +63,7 @@ class FormSchema {
         'gallery',
         'attribute',
         'location_map',
+        'spmv_search',
     ];
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code passes the PHPCS tests

### Changes proposed in this Pull Request:

One array entry: `'spmv_search'` added to `FormSchema::$supported_variants`.

`getFieldConfigFrom()` falls back to `defaultHandler` for an unknown variant, which renders a **plain text input** — so without this entry the SPMV panel's field would appear in the new product editor as a stray "Search Product" text box, on top of the `_doing_it_wrong` debug notice.

Deliberately an array entry rather than a new filter: `$supported_variants` already hardcodes `location_map` for the geolocation module, so this follows the house precedent. Adding a public filter would be permanent API surface introduced only to suppress a debug notice.

### Related Pull Request(s)

* getdokan/dokan-pro#5952 — the actual SPMV port. **That PR is functional without this one**; this only prevents the stray text input and the debug notice.

### Closes

* Refs https://github.com/getdokan/dokan-pro/issues/5930

### How to test the changes in this Pull Request:

With the Pro PR applied and the SPMV module enabled, open Vendor Dashboard → Products → **Add New**. Without this entry the SPMV card renders a bare text input; with it the registered React variant renders. PHPCS clean; no build required.

### Changelog entry

**Fix — register the `spmv_search` product editor field variant so the Single Product Multi Vendor search panel renders correctly.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)