### PR TITLE
Vendor order details in the Vendor panel — server-rendered fragment over REST

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,6 +21,49 @@ settings, the REST `/stores` resource. Exactly one Store per Vendor — a facet 
 the Vendor, not a separate entity.
 _Avoid_: Shop, storefront
 
+### Vendor-facing surfaces
+
+**Vendor panel**:
+The React single-page application a Vendor works in, mounted at the `new`
+dashboard endpoint (`…/dashboard/new/#/…`). The destination of the migration —
+new Vendor screens are built here.
+_Avoid_: New dashboard, vendor dashboard (ambiguous — see below), React dashboard
+
+**Legacy Vendor dashboard**:
+The original PHP dashboard rendered by the `[dokan-dashboard]` shortcode, one
+endpoint per screen (`…/dashboard/orders/`). Still fully supported; several
+surfaces exist only here, and its URLs keep working after a surface moves to
+the Vendor panel.
+_Avoid_: Old dashboard, frontend dashboard
+
+**Vendor layout**:
+The chrome-only full-width wrapper (sidebar and header) that hosts either
+dashboard body. Layout, not content — it renders no Vendor data of its own.
+_Avoid_: Dashboard, dashboard wrapper
+
+**Vendor analytics**:
+The separate WooCommerce-Admin-derived reporting application. A distinct app
+from the Vendor panel despite living under the same dashboard page.
+_Avoid_: Reports dashboard, analytics dashboard
+
+> "Vendor dashboard" on its own is ambiguous — it has meant all four of the
+> above. Name the surface.
+
+**Legacy fragment**:
+A surface that stays server-rendered PHP and is delivered to the Vendor panel as
+an HTML fragment over a Dokan REST endpoint, so that every extension hook keeps
+firing unchanged. Vendor order details is the first one. Characterised by three
+things: the same template serves both entry points, the render simulates the
+page request context, and a documented re-init event tells JavaScript the markup
+has arrived.
+_Avoid_: Legacy embed, HTML widget, partial
+
+**Re-init event**:
+The event a Legacy fragment fires after its markup is injected
+(`dokan-order-details-fragment-rendered`), published both through the JavaScript
+hooks system and as a jQuery event on the body. The public compatibility contract
+that lets extension JavaScript bind to markup that did not exist at DOM-ready.
+
 ### Orders
 
 **Order**:

--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -44,7 +44,43 @@ window.dokan.orderDetails = window.dokan.orderDetails || {
             }
         } );
     },
+
+    /**
+     * Emit an order-details event on both channels.
+     *
+     * Every event is published through the modern JavaScript hooks system and as a
+     * jQuery event on `document.body`, so extension code from either era can consume
+     * it. See docs/frontend/order-details-fragment.md.
+     *
+     * @param {string} name Event name.
+     * @param {Array}  args Positional payload.
+     */
+    emit( name, args ) {
+        if ( window.wp && window.wp.hooks && window.wp.hooks.doAction ) {
+            window.wp.hooks.doAction.apply( null, [ name ].concat( args ) );
+        }
+
+        if ( window.jQuery ) {
+            window.jQuery( document.body ).trigger( name, args );
+        }
+    },
 };
+
+// Re-initialise whenever the Vendor panel injects the fragment. Third parties bind to
+// the very same event.
+if ( ! window.dokan.orderDetails.isBound ) {
+    window.dokan.orderDetails.isBound = true;
+
+    if ( window.wp && window.wp.hooks && window.wp.hooks.addAction ) {
+        window.wp.hooks.addAction(
+            'dokan-order-details-fragment-rendered',
+            'dokan-lite/order-details',
+            function ( container ) {
+                window.dokan.orderDetails.init( container );
+            }
+        );
+    }
+}
 
 jQuery(function($) {
 
@@ -82,6 +118,15 @@ jQuery(function($) {
                 li.addClass('dokan-hide');
                 prev_li.find('label').replaceWith(response.data);
                 prev_li.find('a.dokan-edit-status').removeClass('dokan-hide');
+
+                // Anything showing this order's status elsewhere on the page — the
+                // Vendor panel header, for one — would otherwise contradict what the
+                // Vendor is looking at.
+                window.dokan.orderDetails.emit( 'dokan-order-details-status-changed', [
+                    parseInt( self.find( 'input[name="order_id"]' ).val(), 10 ),
+                    String( self.find( '#order_status' ).val() || '' ).replace( /^wc-/, '' ),
+                    response.data,
+                ] );
             } else {
                 dokan_sweetalert( response.data, {
                     icon: 'success',

--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -1,20 +1,71 @@
+/**
+ * Re-initialisation registry for the Vendor order details view.
+ *
+ * The order details markup is server-rendered PHP. It is reachable two ways: the legacy
+ * dashboard page (markup present at DOM-ready) and the Vendor panel, which injects the
+ * same markup as an HTML fragment long after DOM-ready. Event handlers are therefore
+ * document-delegated, and anything that genuinely needs to run against elements —
+ * tooltips, date pickers, select2 — registers here so it can be re-run on demand.
+ *
+ * @since DOKAN_SINCE
+ */
+window.dokan = window.dokan || {};
+window.dokan.orderDetails = window.dokan.orderDetails || {
+    initializers: [],
+
+    /**
+     * Register a function to run whenever order details markup appears.
+     *
+     * @param {Function} callback Receives the container element (or `document`).
+     */
+    onInit( callback ) {
+        if ( typeof callback === 'function' ) {
+            window.dokan.orderDetails.initializers.push( callback );
+        }
+    },
+
+    /**
+     * Run every registered initialiser against a container.
+     *
+     * One initialiser throwing must not stop the rest, so each is isolated.
+     *
+     * @param {Object} [container] Element holding the markup. Defaults to `document`.
+     */
+    init( container ) {
+        const scope = container || document;
+
+        window.dokan.orderDetails.initializers.forEach( ( callback ) => {
+            try {
+                callback( scope );
+            } catch ( error ) {
+                if ( window.console && window.console.error ) {
+                    window.console.error( error );
+                }
+            }
+        } );
+    },
+};
+
 jQuery(function($) {
 
-    $('.tips').tooltip();
+    window.dokan.orderDetails.onInit( function ( scope ) {
+        // Bootstrap-style tooltips are a no-op when re-applied to an initialised element.
+        $( scope ).find( '.tips' ).addBack( '.tips' ).tooltip();
+    } );
 
-    $('ul.order-status').on('click', 'a.dokan-edit-status', function(e) {
+    $(document).on('click', 'ul.order-status a.dokan-edit-status', function(e) {
         $(this).addClass('dokan-hide').closest('li').next('li').removeClass('dokan-hide');
 
         return false;
     });
 
-    $('ul.order-status').on('click', 'a.dokan-cancel-status', function(e) {
+    $(document).on('click', 'ul.order-status a.dokan-cancel-status', function(e) {
         $(this).closest('li').addClass('dokan-hide').prev('li').find('a.dokan-edit-status').removeClass('dokan-hide');
 
         return false;
     });
 
-    $('form#dokan-order-status-form').on('submit', function(e) {
+    $(document).on('submit', 'form#dokan-order-status-form', function(e) {
         e.preventDefault();
 
         var self = $(this),
@@ -39,7 +90,7 @@ jQuery(function($) {
         });
     });
 
-    $('form#add-order-note').on( 'submit', function(e) {
+    $(document).on( 'submit', 'form#add-order-note', function(e) {
         e.preventDefault();
 
         if (!$('textarea#add-note-content').val()) return;
@@ -56,7 +107,7 @@ jQuery(function($) {
 
     })
 
-    $('#dokan-order-notes').on( 'click', 'a.delete_note', function() {
+    $(document).on( 'click', '#dokan-order-notes a.delete_note', function() {
 
         var note = $(this).closest('li.note');
 
@@ -77,7 +128,7 @@ jQuery(function($) {
 
     });
 
-    $('.order_download_permissions').on('click', 'button.grant_access', function() {
+    $(document).on('click', '.order_download_permissions button.grant_access', function() {
         var self = $(this),
             product = $('select.grant_access_id').val();
 
@@ -114,7 +165,7 @@ jQuery(function($) {
         return false;
     });
 
-    $( '.dokan-btn-action-confirm' ).on( 'click', async function ( e ) {
+    $( document ).on( 'click', '.dokan-btn-action-confirm', async function ( e ) {
         e.preventDefault();
 
         const message = $( this ).data( 'confirm-message' );
@@ -131,7 +182,7 @@ jQuery(function($) {
         }
     } );
 
-    $('.order_download_permissions').on('click', 'button.revoke_access', async function(e){
+    $(document).on('click', '.order_download_permissions button.revoke_access', async function(e){
         e.preventDefault();
         const answer = await dokan_sweetalert( dokan.i18n_download_permission, {
             action : 'confirm',
@@ -177,7 +228,7 @@ jQuery(function($) {
         return false;
     });
 
-    $("#grant_access_id").select2({
+    const grantAccessSelect2Args = {
         allowClear: true,
         minimumInputLength: 3,
         ajax: {
@@ -247,7 +298,22 @@ jQuery(function($) {
                 return dokan.i18n_searching;
             }
         },
-    });
+    };
+
+    window.dokan.orderDetails.onInit( function ( scope ) {
+        if ( ! $.fn.select2 ) {
+            return;
+        }
+
+        $( scope )
+            .find( '#grant_access_id' )
+            .addBack( '#grant_access_id' )
+            .filter( ':not(.select2-hidden-accessible)' )
+            .select2( grantAccessSelect2Args );
+    } );
+
+    // Legacy page: the markup is already in the document at DOM-ready.
+    window.dokan.orderDetails.init( document );
 
 });
 
@@ -258,6 +324,55 @@ jQuery(function($) {
      */
     var dokan_seller_meta_boxes_order_items = {
         init: function() {
+
+            window.dokan.orderDetails.onInit( this.initDatePicker );
+
+            //saving note
+            $( 'body' ).on('click','#dokan-add-tracking-number', this.showTrackingForm );
+            $( 'body' ).on('click','#dokan-cancel-tracking-note', this.cancelTrackingForm );
+            $( 'body' ).on('click','#add-tracking-details', this.insertShippingTrackingInfo);
+
+            // Delegated from the document, not from `#woocommerce-order-items`: the
+            // container itself is part of the injected fragment in the Vendor panel, so
+            // it does not exist when this runs.
+            $( document )
+                .on( 'click', '#woocommerce-order-items button.refund-items', this.refund_items )
+                .on( 'click', '#woocommerce-order-items .cancel-action', this.cancel )
+
+                // Refunds
+                .on( 'click', '#woocommerce-order-items button.do-api-refund, #woocommerce-order-items button.do-manual-refund', this.refunds.do_refund )
+                .on( 'change', '#woocommerce-order-items .refund input.refund_line_total, #woocommerce-order-items .refund input.refund_line_tax', this.refunds.input_changed )
+                .on( 'change keyup', '#woocommerce-order-items .wc-order-refund-items #refund_amount', this.refunds.amount_changed )
+                .on( 'change', '#woocommerce-order-items input.refund_order_item_qty', this.refunds.refund_quantity_changed )
+
+                // Subtotal/total
+                .on( 'keyup', '#woocommerce-order-items .woocommerce_order_items .split-input input:eq(0)', function() {
+                    var $subtotal = $( this ).next();
+                    if ( $subtotal.val() === '' || $subtotal.is( '.match-total' ) ) {
+                        $subtotal.val( $( this ).val() ).addClass( 'match-total' );
+                    }
+                })
+
+                .on( 'keyup', '#woocommerce-order-items .woocommerce_order_items .split-input input:eq(1)', function() {
+                    $( this ).removeClass( 'match-total' );
+                })
+        },
+
+        /**
+         * Attach the shipped-date picker.
+         *
+         * Runs at DOM-ready on the legacy page and again whenever the order details
+         * fragment is injected into the Vendor panel.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param {Object} scope Container holding the freshly-rendered markup.
+         */
+        initDatePicker: function( scope ) {
+
+            if ( ! $.fn.datepicker || ! window.dokan || ! window.dokan.i18n_date_format ) {
+                return;
+            }
 
             let formatMap = {
                 // Day
@@ -292,36 +407,15 @@ jQuery(function($) {
                 }
             }
 
-            $( "#shipped-date" ).datepicker({
-                dateFormat: datepickerFormat
-            });
-
-            //saving note
-            $( 'body' ).on('click','#dokan-add-tracking-number', this.showTrackingForm );
-            $( 'body' ).on('click','#dokan-cancel-tracking-note', this.cancelTrackingForm );
-            $( 'body' ).on('click','#add-tracking-details', this.insertShippingTrackingInfo);
-
-            $( '#woocommerce-order-items' )
-                .on( 'click', 'button.refund-items', this.refund_items )
-                .on( 'click', '.cancel-action', this.cancel )
-
-                // Refunds
-                .on( 'click', 'button.do-api-refund, button.do-manual-refund', this.refunds.do_refund )
-                .on( 'change', '.refund input.refund_line_total, .refund input.refund_line_tax', this.refunds.input_changed )
-                .on( 'change keyup', '.wc-order-refund-items #refund_amount', this.refunds.amount_changed )
-                .on( 'change', 'input.refund_order_item_qty', this.refunds.refund_quantity_changed )
-
-                // Subtotal/total
-                .on( 'keyup', '.woocommerce_order_items .split-input input:eq(0)', function() {
-                    var $subtotal = $( this ).next();
-                    if ( $subtotal.val() === '' || $subtotal.is( '.match-total' ) ) {
-                        $subtotal.val( $( this ).val() ).addClass( 'match-total' );
-                    }
-                })
-
-                .on( 'keyup', '.woocommerce_order_items .split-input input:eq(1)', function() {
-                    $( this ).removeClass( 'match-total' );
-                })
+            // `hasDatepicker` is jQuery UI's own marker — filtering on it keeps a
+            // re-init from stacking a second picker on the same input.
+            $( scope || document )
+                .find( '#shipped-date' )
+                .addBack( '#shipped-date' )
+                .filter( ':not(.hasDatepicker)' )
+                .datepicker({
+                    dateFormat: datepickerFormat
+                });
         },
 
         showTrackingForm: function(e) {

--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -75,7 +75,16 @@ if ( ! window.dokan.orderDetails.isBound ) {
         window.wp.hooks.addAction(
             'dokan-order-details-fragment-rendered',
             'dokan-lite/order-details',
-            function ( container ) {
+            function ( container, orderId ) {
+                // The refund cluster below reads its order id from `dokan_refund`,
+                // which is built once at page load from the request. On the legacy
+                // page that request carries `order_id`; in the Vendor panel it does
+                // not, so the id would be empty and a refund would be submitted
+                // against nothing. The fragment knows which order it just rendered.
+                if ( window.dokan_refund && orderId ) {
+                    window.dokan_refund.post_id = orderId;
+                }
+
                 window.dokan.orderDetails.init( container );
             }
         );

--- a/docs/adr/0005-vendor-order-details-stays-server-rendered.md
+++ b/docs/adr/0005-vendor-order-details-stays-server-rendered.md
@@ -41,9 +41,11 @@ Consequences worth knowing before "fixing" any of this:
   Hence the rule published to extension authors: register script handles on `init`,
   enqueue them on `wp_enqueue_scripts`.
 - **The feature is behind `dokan_vendor_panel_order_details_enabled`**, which defaults
-  off until dokan-pro's companion change ships. Without it the delivery-time panel
-  renders dead and unstyled, refund requests submit an empty order id, and the shipment
-  date picker never initialises.
+  on. It stays as the escape hatch for any store whose theme or third-party plugin
+  misbehaves; returning it to false restores full-page navigation with no data or
+  routing consequences. Pro's contributions — the delivery-time panel, refund requests
+  and the shipment date picker — depend on dokan-pro's companion change to be fully
+  functional inside a fragment.
 
 Three alternatives were rejected. A **React rewrite** would silently delete every hooked
 contribution — affected Vendors would get no error, just missing features. A **Gutenberg

--- a/docs/adr/0005-vendor-order-details-stays-server-rendered.md
+++ b/docs/adr/0005-vendor-order-details-stays-server-rendered.md
@@ -1,0 +1,60 @@
+# Vendor order details stays server-rendered, bridged into the panel as a fragment
+
+The Vendor panel is React, but Vendor order details is not and will not become a React
+screen. `templates/orders/details.php` fires eleven Dokan extension hooks plus
+WooCommerce's item-rendering hooks, and Pro injects shipments, delivery time, store
+pickup and the entire item/refund table through them. A REST endpoint
+(`GET /dokan/v{1,2,3}/orders/<id>/details-html`) renders that same template and returns
+its markup; the panel's `/orders/:orderId` route fetches the HTML, injects it, and fires
+a documented event so legacy and third-party JavaScript can bind to the new markup.
+
+The legacy order-details URL keeps working unchanged, with no redirect, and both entry
+points call the same template — so they cannot drift, rollback is free, and the links
+already sitting in Vendors' inboxes keep resolving.
+
+Consequences worth knowing before "fixing" any of this:
+
+- **Page-level wrapper hooks do not fire in a fragment.** `dokan_dashboard_wrap_start`,
+  `dokan_dashboard_content_before`, `dokan_order_content_before`,
+  `dokan_order_content_inside_before`, `dokan_order_inside_content` and their `_after`
+  counterparts are skipped deliberately: they also render the PHP sidebar navigation and
+  the status-filter bar, both of which the panel already provides. Everything *inside*
+  the template fires untouched.
+- **Pro's "Edit Order" control lived on that status-filter bar.** The panel header
+  re-provides it. Anything else attached to those wrapper hooks needs the same treatment.
+- **The render simulates a page request.** For the duration of the render only, dashboard
+  detection reports true, the `orders` query var and the order id are present, and a
+  valid `dokan_view_order` nonce is fabricated. Extension code was written against a page
+  render — Pro's shipment panel reads the order id from the request and ignores the
+  argument the hook passes it, and terminates the whole response if a nonce is present
+  but does not verify. Authorization is already established by the endpoint's permission
+  rule before any of this runs, and CSRF is preserved at the outer layer by the REST
+  nonce. Everything is restored in a `finally`, so a throwing callback cannot leak state
+  into the next request.
+- **The endpoint does not reuse the shared single-order permission rule.**
+  `get_single_order_permissions_check()` compares against the raw current user id, which
+  refuses Vendor staff who can open the legacy page. That is a real bug, but fixing it
+  changes already-shipped public v1/v2/v3 routes and needs its own change and coverage.
+  The fragment endpoint has its own rule: the order-viewing capability plus ownership
+  resolved through `dokan_get_current_user_id()`.
+- **Render-time inline data only works for handles that exist during a REST request.**
+  Hence the rule published to extension authors: register script handles on `init`,
+  enqueue them on `wp_enqueue_scripts`.
+- **The feature is behind `dokan_vendor_panel_order_details_enabled`**, which defaults
+  off until dokan-pro's companion change ships. Without it the delivery-time panel
+  renders dead and unstyled, refund requests submit an empty order id, and the shipment
+  date picker never initialises.
+
+Three alternatives were rejected. A **React rewrite** would silently delete every hooked
+contribution — affected Vendors would get no error, just missing features. A **Gutenberg
+dynamic block** through core's block-renderer endpoint is editor-shaped and gated on
+`edit_posts`, which is both wrong for Vendors and far too permissive; a Dokan-owned
+endpoint lets us own the permission rule, the nonce and the response shape. An **iframe**
+(or Shadow DOM) would isolate the markup at the cost of breaking the delegated-handler
+contract and reintroducing exactly the "two products stitched together" feel the
+migration exists to remove.
+
+A general "legacy fragment" registry for other PHP surfaces — coupons, reports, settings
+tabs — is deliberately deferred until a second surface needs one. Designing a general
+HTML-returning endpoint against a single consumer is a security surface we do not need
+yet.

--- a/docs/frontend/order-details-fragment.md
+++ b/docs/frontend/order-details-fragment.md
@@ -58,11 +58,17 @@ add_action( 'dokan_order_details_fragment_before', function ( $order ) { /* … 
 add_action( 'dokan_order_details_fragment_after',  function ( $order ) { /* … */ } );
 ```
 
-And a filter on the response payload itself:
+And filters on the response itself:
 
 ```php
-add_filter( 'dokan_rest_prepare_order_details_html', function ( $data, $order, $request ) {
+// The payload array.
+add_filter( 'dokan_rest_prepare_order_details_html_data', function ( $data, $order, $request ) {
     return $data; // [ 'html' => …, 'inline_scripts' => [ … ], 'order' => [ … ] ]
+}, 10, 3 );
+
+// The WP_REST_Response, if you need headers or links.
+add_filter( 'dokan_rest_prepare_order_details_html_object', function ( $response, $order, $request ) {
+    return $response;
 }, 10, 3 );
 ```
 
@@ -129,6 +135,10 @@ Two more events are available:
 | `dokan-order-details-fragment-rendered` | `( container, orderId )` | markup is on the page and inline data is executing |
 | `dokan-order-details-status-changed` | `( orderId, status, labelHtml )` | a Vendor changed the status inline and it persisted |
 
+These use the `dokan-` prefix rather than `dokan_`, matching the panel's existing
+JavaScript hooks (`dokan-dashboard-routes`, `dokan-header-actions`,
+`dokan-vendor-{route}-dashboard-header-backUrl`) that extensions already bind to.
+
 ## Passing render-time data to the browser
 
 `wp_add_inline_script()` from inside your template still works — the endpoint snapshots
@@ -165,9 +175,11 @@ Two things to know:
 - The payload is executed at **global scope**, as a real script element — not `eval`,
   which would function-scope it and leave your consuming script finding nothing.
 - **Do not declare render-time data with a top-level `let` or `const`.** Those bindings
-  cannot be redeclared, so when the Vendor opens a second order the new payload throws a
-  `SyntaxError` and your script keeps reading the *previous* order's data. Assign to
-  `window`, or use `var`.
+  live in the global lexical environment and outlive the script element that created
+  them, so when the Vendor opens a second order the new payload is refused with a
+  redeclaration `SyntaxError` and your script keeps reading the *previous* order's data.
+  Assign to `window`, or use `var`. The panel logs a console warning naming your handle
+  when it detects this, but it cannot fix it for you.
 
 Script tags embedded in your rendered HTML are also re-created so they execute — HTML
 assigned as a string never runs its scripts.

--- a/docs/frontend/order-details-fragment.md
+++ b/docs/frontend/order-details-fragment.md
@@ -210,8 +210,8 @@ The legacy URL never stops working, so this is free to flip:
 add_filter( 'dokan_vendor_panel_order_details_enabled', '__return_false' );
 ```
 
-It currently defaults **off** and will default on once dokan-pro's companion change has
-shipped.
+It defaults **on**. The legacy order details URL keeps working indefinitely, so turning
+it off has no data or routing consequences.
 
 ## Reference
 

--- a/docs/frontend/order-details-fragment.md
+++ b/docs/frontend/order-details-fragment.md
@@ -1,0 +1,214 @@
+# Vendor order details in the Vendor panel — extension author guide
+
+Vendor order details is server-rendered PHP. It stays that way. When a Vendor opens an
+order in the Vendor panel, the panel asks a REST endpoint to render
+`templates/orders/details.php` and injects the resulting HTML — it does not re-implement
+the view in React.
+
+**Your PHP hooks fire with the same arguments, in the same order, as they always have.**
+What is new is a JavaScript event to re-initialise against, and one rule about where you
+register your scripts.
+
+- [What changes for you](#what-changes-for-you)
+- [Hooks that fire](#hooks-that-fire)
+- [Hooks that do not fire](#hooks-that-do-not-fire)
+- [Re-initialising your JavaScript](#re-initialising-your-javascript)
+- [Passing render-time data to the browser](#passing-render-time-data-to-the-browser)
+- [The request context during a fragment render](#the-request-context-during-a-fragment-render)
+- [The kill-switch](#the-kill-switch)
+- [Reference](#reference)
+
+## What changes for you
+
+| | Legacy order details page | Vendor panel |
+|---|---|---|
+| Template | `templates/orders/details.php` | the same file |
+| Theme overrides & `dokan_set_template_path` | honoured | honoured |
+| In-template hooks | fire | fire |
+| Page wrapper hooks | fire | **do not fire** |
+| Your markup exists at DOM-ready | yes | **no** — it arrives later |
+| `$_GET['order_id']`, view nonce, `dokan_is_seller_dashboard()` | present | present (simulated) |
+
+Two things need action: **JavaScript that binds at DOM-ready**, and **assets registered
+on `wp_enqueue_scripts` only**.
+
+## Hooks that fire
+
+Everything inside the details template, unchanged:
+
+| Hook | Arguments |
+|---|---|
+| `dokan_order_detail_after_order_items` | `WC_Order $order` |
+| `dokan_order_details_after_customer_info` | `WC_Order $order` |
+| `dokan_order_detail_after_order_general_details` | `WC_Order $order` |
+| `dokan_order_detail_after_order_notes` | `WC_Order $order` |
+| `dokan_order_details_show_billing_address` (filter) | `bool $show, WC_Order $order` |
+| `dokan_order_details_billing_address` (filter) | `string $html, WC_Order $order` |
+| `dokan_order_details_show_shipping_address` (filter) | `bool $show, WC_Order $order` |
+| `dokan_order_details_shipping_address` (filter) | `string $html, WC_Order $order` |
+| `woocommerce_admin_order_item_headers` | `WC_Order $order` |
+| `woocommerce_admin_order_item_types` (filter) | `array $types` |
+| `woocommerce_order_item_{type}_html` | `int $item_id, WC_Order_Item $item, WC_Order $order` |
+
+Plus two actions that exist **only** during a fragment render, if you need to tell the
+two entry points apart:
+
+```php
+add_action( 'dokan_order_details_fragment_before', function ( $order ) { /* … */ } );
+add_action( 'dokan_order_details_fragment_after',  function ( $order ) { /* … */ } );
+```
+
+And a filter on the response payload itself:
+
+```php
+add_filter( 'dokan_rest_prepare_order_details_html', function ( $data, $order, $request ) {
+    return $data; // [ 'html' => …, 'inline_scripts' => [ … ], 'order' => [ … ] ]
+}, 10, 3 );
+```
+
+## Hooks that do not fire
+
+The page-level wrappers from `templates/orders/orders.php`:
+
+`dokan_dashboard_wrap_start` · `dokan_dashboard_content_before` ·
+`dokan_order_content_before` · `dokan_order_content_inside_before` ·
+`dokan_order_inside_content` · `dokan_order_content_inside_after` ·
+`dokan_dashboard_content_after` · `dokan_order_content_after` ·
+`dokan_dashboard_wrap_end` · `dokan_order_status_filter_before`
+
+This is a **documented boundary, not an oversight**: those hooks also render the PHP
+sidebar navigation and the status-filter bar, and the panel provides both itself.
+
+If you attach UI to one of them, move it to an in-template hook, or contribute a header
+action from the panel side with a `Fill` on `dokan-header-actions`.
+
+## Re-initialising your JavaScript
+
+Your handlers run at DOM-ready, when the fragment does not exist yet. Two things fix
+that, and you want both:
+
+**1. Delegate your event handlers from `document`** so binding order stops mattering:
+
+```js
+// Before — silently does nothing in the panel.
+jQuery( '#my-order-widget button' ).on( 'click', handler );
+
+// After — works on the legacy page and in the panel.
+jQuery( document ).on( 'click', '#my-order-widget button', handler );
+```
+
+**2. Re-run anything that initialises an element** — date pickers, select2, tooltips,
+charts — when the fragment arrives. The event carries the container and the order id, and
+is published on both channels, so use whichever suits your codebase:
+
+```js
+// Modern
+wp.hooks.addAction(
+    'dokan-order-details-fragment-rendered',
+    'my-plugin/order-details',
+    function ( container, orderId ) {
+        jQuery( container ).find( '.my-datepicker:not(.hasDatepicker)' ).datepicker();
+    }
+);
+
+// jQuery
+jQuery( document.body ).on(
+    'dokan-order-details-fragment-rendered',
+    function ( event, container, orderId ) { /* … */ }
+);
+```
+
+Guard against double-initialising (`:not(.hasDatepicker)`, `:not(.select2-hidden-accessible)`,
+your own marker class) — the event fires again every time the Vendor opens another order.
+
+Two more events are available:
+
+| Event | Payload | Fires |
+|---|---|---|
+| `dokan-order-details-loaded` | `( order )` | order metadata is known, before the markup is inserted |
+| `dokan-order-details-fragment-rendered` | `( container, orderId )` | markup is on the page and inline data is executing |
+| `dokan-order-details-status-changed` | `( orderId, status, labelHtml )` | a Vendor changed the status inline and it persisted |
+
+## Passing render-time data to the browser
+
+`wp_add_inline_script()` from inside your template still works — the endpoint snapshots
+the script registry before the render, diffs it afterwards, and the panel injects the
+delta as real `<script>` elements before inserting the HTML.
+
+**The rule this depends on: register your handle on `init`, enqueue it on
+`wp_enqueue_scripts`.**
+
+```php
+// Registration must happen on `init`, because a REST request never reaches
+// `wp_enqueue_scripts` — and `wp_add_inline_script()` silently no-ops for a handle
+// that is not registered.
+add_action( 'init', function () {
+    wp_register_script( 'my-order-widget', plugins_url( 'widget.js', __FILE__ ), [ 'jquery' ], '1.0.0', true );
+} );
+
+add_action( 'wp_enqueue_scripts', function () {
+    wp_enqueue_script( 'my-order-widget' );
+} );
+
+// Then, from inside a hook on the details template:
+add_action( 'dokan_order_detail_after_order_items', function ( $order ) {
+    wp_add_inline_script(
+        'my-order-widget',
+        'window.myOrderData = ' . wp_json_encode( [ 'orderId' => $order->get_id() ] ) . ';',
+        'before'
+    );
+} );
+```
+
+Two things to know:
+
+- The payload is executed at **global scope**, as a real script element — not `eval`,
+  which would function-scope it and leave your consuming script finding nothing.
+- **Do not declare render-time data with a top-level `let` or `const`.** Those bindings
+  cannot be redeclared, so when the Vendor opens a second order the new payload throws a
+  `SyntaxError` and your script keeps reading the *previous* order's data. Assign to
+  `window`, or use `var`.
+
+Script tags embedded in your rendered HTML are also re-created so they execute — HTML
+assigned as a string never runs its scripts.
+
+## The request context during a fragment render
+
+Code written against a page render keeps working: for the duration of the render only,
+
+- `dokan_is_seller_dashboard()` returns `true`,
+- the `orders` query var is set,
+- `$_GET['order_id']` / `$_REQUEST['order_id']` hold the order id,
+- `$_GET['_wpnonce']` holds a valid `dokan_view_order` nonce.
+
+All of it is restored afterwards, guaranteed, even if a hooked callback throws.
+Authorization is established by the endpoint's own permission rule — the order-viewing
+capability plus ownership through `dokan_get_current_user_id()` — before any of this
+happens, and CSRF protection is preserved at the outer layer by the REST nonce.
+
+**Do not call `wp_send_json_error()` or `wp_die()` from a render callback.** It
+terminates the whole response mid-document, on the legacy page as well.
+
+## The kill-switch
+
+A marketplace admin can send the panel back to full-page navigation with one snippet.
+The legacy URL never stops working, so this is free to flip:
+
+```php
+add_filter( 'dokan_vendor_panel_order_details_enabled', '__return_false' );
+```
+
+It currently defaults **off** and will default on once dokan-pro's companion change has
+shipped.
+
+## Reference
+
+| | |
+|---|---|
+| Endpoint | `GET /dokan/v1/orders/<id>/details-html` (also on `v2`, `v3`) |
+| Response | `{ html, inline_scripts: [ { handle, position, code } ], order: { id, number, status, status_label, date_created } }` |
+| Panel route | `#/orders/<id>` |
+| Legacy URL | `…/dashboard/orders/?order_id=<id>&_wpnonce=<dokan_view_order nonce>` — unchanged |
+| Renderer | `WeDevs\Dokan\Order\DetailsFragment` |
+| Decision record | `docs/adr/0005-vendor-order-details-stays-server-rendered.md` |
+| Vocabulary | `CONTEXT.md` → *Vendor-facing surfaces* |

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -1049,7 +1049,10 @@ class Assets {
         wp_localize_script( 'dokan-util-helper', 'dokan_helper', $localize_data );
 
         $dokan_frontend = [
-            'currency' => dokan_get_container()->get( 'scripts' )->get_localized_price(),
+            'currency'      => dokan_get_container()->get( 'scripts' )->get_localized_price(),
+            'order_details' => [
+                'panel_route_enabled' => dokan_is_vendor_panel_order_details_enabled(),
+            ],
         ];
 
         // localize dokan frontend script
@@ -1118,6 +1121,9 @@ class Assets {
                 isset( $wp->query_vars['orders'] ) ||
                 isset( $wp->query_vars['coupons'] ) ||
                 isset( $wp->query_vars['reports'] ) ||
+                // The Vendor panel renders the same server-rendered order details
+                // markup as the legacy `orders` page, so it needs the same styles.
+                isset( $wp->query_vars['new'] ) ||
                 ( isset( $wp->query_vars['settings'] ) && in_array( $wp->query_vars['settings'], [ 'store', 'shipping' ], true ) )
             ) {
                 wp_enqueue_style( 'dokan-timepicker' );

--- a/includes/DependencyManagement/Providers/ServiceProvider.php
+++ b/includes/DependencyManagement/Providers/ServiceProvider.php
@@ -32,6 +32,7 @@ class ServiceProvider extends BootableServiceProvider {
         'registration'        => \WeDevs\Dokan\Registration::class,
         'order'               => \WeDevs\Dokan\Order\Manager::class,
         'order_controller'    => \WeDevs\Dokan\Order\Controller::class,
+        'order_details_fragment' => \WeDevs\Dokan\Order\DetailsFragment::class,
         'api'                 => \WeDevs\Dokan\REST\Manager::class,
         'withdraw'            => \WeDevs\Dokan\Withdraw\Manager::class,
         'dashboard'           => \WeDevs\Dokan\Dashboard\Manager::class,

--- a/includes/DependencyManagement/Providers/ServiceProvider.php
+++ b/includes/DependencyManagement/Providers/ServiceProvider.php
@@ -32,7 +32,7 @@ class ServiceProvider extends BootableServiceProvider {
         'registration'        => \WeDevs\Dokan\Registration::class,
         'order'               => \WeDevs\Dokan\Order\Manager::class,
         'order_controller'    => \WeDevs\Dokan\Order\Controller::class,
-        'order_details_fragment' => \WeDevs\Dokan\Order\DetailsFragment::class,
+        'order_details_fragment'  => \WeDevs\Dokan\Order\DetailsFragment::class,
         'api'                 => \WeDevs\Dokan\REST\Manager::class,
         'withdraw'            => \WeDevs\Dokan\Withdraw\Manager::class,
         'dashboard'           => \WeDevs\Dokan\Dashboard\Manager::class,

--- a/includes/Order/DetailsFragment.php
+++ b/includes/Order/DetailsFragment.php
@@ -100,6 +100,12 @@ class DetailsFragment {
      * Third-party CSS is written against the legacy page's class names, so the fragment
      * reproduces them rather than inventing new ones.
      *
+     * `dokan-legacy-fragment` is the hook the panel stylesheet needs to tell a bridged
+     * PHP surface apart from a React one: it excludes the subtree from the panel's
+     * element resets, and neutralises the page-layout half of the reproduced classes,
+     * which was written for a page that has a sidebar beside it. Every future Legacy
+     * fragment carries the same class.
+     *
      * @since DOKAN_SINCE
      *
      * @param string $html Rendered template output.
@@ -107,7 +113,7 @@ class DetailsFragment {
      * @return string
      */
     private function wrap( string $html ): string {
-        return '<div class="dokan-dashboard-wrap dokan-order-details-fragment">'
+        return '<div class="dokan-legacy-fragment dokan-dashboard-wrap dokan-order-details-fragment">'
             . '<div class="dokan-dashboard-content dokan-orders-content">'
             . '<article class="dokan-orders-area">'
             . $html

--- a/includes/Order/DetailsFragment.php
+++ b/includes/Order/DetailsFragment.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace WeDevs\Dokan\Order;
+
+use WC_Order;
+use WP;
+use WP_Query;
+
+/**
+ * Renders the Vendor order details template as an HTML fragment.
+ *
+ * The Vendor panel is React, but order details stays server-rendered PHP so that every
+ * Pro and third-party hook inside `templates/orders/details.php` keeps firing exactly as
+ * it does on the legacy page. This class renders that template inside a simulated page
+ * context and hands the markup — plus any render-time inline script data — to the caller.
+ *
+ * The page-level wrapper hooks from `templates/orders/orders.php`
+ * (`dokan_dashboard_wrap_start`, `dokan_order_inside_content`, …) deliberately do NOT
+ * fire here: they also render the PHP sidebar navigation and the status-filter bar, both
+ * of which the Vendor panel already provides. That is a documented compatibility
+ * boundary, not an oversight — see `docs/adr/0005-vendor-order-details-as-html-fragment.md`.
+ *
+ * @since DOKAN_SINCE
+ */
+class DetailsFragment {
+
+    /**
+     * Inline-script positions captured from the script registry.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @var string[]
+     */
+    private const POSITIONS = [ 'before', 'after' ];
+
+    /**
+     * Render the order details template as a fragment.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WC_Order $order Order being rendered.
+     *
+     * @return array{html: string, inline_scripts: array<int, array{handle: string, position: string, code: string}>}
+     */
+    public function render( WC_Order $order ): array {
+        $restore         = $this->simulate_request_context( $order->get_id() );
+        $scripts_before  = $this->snapshot_inline_scripts();
+        $buffering_level = ob_get_level();
+        $html            = '';
+
+        try {
+            ob_start();
+
+            /**
+             * Fires before the Vendor order details fragment markup.
+             *
+             * Scoped to the fragment render only — it does not fire on the legacy
+             * order details page.
+             *
+             * @since DOKAN_SINCE
+             *
+             * @param WC_Order $order Order being rendered.
+             */
+            do_action( 'dokan_order_details_fragment_before', $order );
+
+            dokan_get_template_part( 'orders/details', '', [ 'order_id' => $order->get_id() ] );
+
+            /**
+             * Fires after the Vendor order details fragment markup.
+             *
+             * Scoped to the fragment render only — it does not fire on the legacy
+             * order details page.
+             *
+             * @since DOKAN_SINCE
+             *
+             * @param WC_Order $order Order being rendered.
+             */
+            do_action( 'dokan_order_details_fragment_after', $order );
+
+            $html = ob_get_clean();
+        } finally {
+            // Guarantee the buffer is popped and the request context is restored even if
+            // a hooked callback throws.
+            while ( ob_get_level() > $buffering_level ) {
+                ob_end_clean();
+            }
+
+            $restore();
+        }
+
+        return [
+            'html'           => $this->wrap( is_string( $html ) ? $html : '' ),
+            'inline_scripts' => $this->diff_inline_scripts( $scripts_before, $this->snapshot_inline_scripts() ),
+        ];
+    }
+
+    /**
+     * Wrap the rendered template in the legacy content containers.
+     *
+     * Third-party CSS is written against the legacy page's class names, so the fragment
+     * reproduces them rather than inventing new ones.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $html Rendered template output.
+     *
+     * @return string
+     */
+    private function wrap( string $html ): string {
+        return '<div class="dokan-dashboard-wrap dokan-order-details-fragment">'
+            . '<div class="dokan-dashboard-content dokan-orders-content">'
+            . '<article class="dokan-orders-area">'
+            . $html
+            . '</article></div></div>';
+    }
+
+    /**
+     * Make a REST request look like a legacy order details page render.
+     *
+     * Extension code was written against a page render: it asks whether it is on the
+     * Vendor dashboard, reads the order id from the request, and verifies the order-view
+     * nonce. Inside a REST request none of that is true, so guarded extension output
+     * silently vanishes.
+     *
+     * Authorization has already been established by the endpoint's permission rule before
+     * this runs, and CSRF protection is preserved at the outer layer by the REST nonce —
+     * the fabricated nonce exists so that "verify or bail" extension code renders.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int $order_id Order being rendered.
+     *
+     * @return callable Restores everything this method changed. Always call it.
+     */
+    private function simulate_request_context( int $order_id ): callable {
+        global $wp, $wp_query;
+
+        // phpcs:disable WordPress.Security.NonceVerification.Recommended
+        $get_backup      = $_GET;
+        $request_backup  = $_REQUEST;
+        $wp_vars_backup  = $wp instanceof WP ? $wp->query_vars : null;
+        $query_backup    = $wp_query instanceof WP_Query ? $wp_query->query_vars : null;
+
+        // dokan_is_seller_dashboard() compares the dashboard page id with `absint()` on
+        // the left and an unfiltered value on the right, so this must return an int.
+        $current_page_id = static function (): int {
+            return absint( apply_filters( 'dokan_get_dashboard_page_id', dokan_get_option( 'dashboard', 'dokan_pages' ) ) );
+        };
+
+        add_filter( 'dokan_get_current_page_id', $current_page_id );
+
+        // The `orders` endpoint is read from both WP::$query_vars (the dashboard
+        // shortcode) and WP_Query (get_query_var()), so both are simulated.
+        if ( $wp instanceof WP ) {
+            $wp->query_vars['orders'] = '';
+        }
+
+        if ( $wp_query instanceof WP_Query ) {
+            $wp_query->query_vars['orders'] = '';
+        }
+
+        $nonce = wp_create_nonce( 'dokan_view_order' );
+
+        $_GET['order_id']     = $order_id;
+        $_GET['_wpnonce']     = $nonce;
+        $_REQUEST['order_id'] = $order_id;
+        $_REQUEST['_wpnonce'] = $nonce;
+        // phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+        return static function () use ( $get_backup, $request_backup, $wp_vars_backup, $query_backup, $current_page_id ) {
+            global $wp, $wp_query;
+
+            $_GET     = $get_backup; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $_REQUEST = $request_backup; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+            if ( null !== $wp_vars_backup && $wp instanceof WP ) {
+                $wp->query_vars = $wp_vars_backup;
+            }
+
+            if ( null !== $query_backup && $wp_query instanceof WP_Query ) {
+                $wp_query->query_vars = $query_backup;
+            }
+
+            remove_filter( 'dokan_get_current_page_id', $current_page_id );
+        };
+    }
+
+    /**
+     * Capture the inline data currently attached to every registered script handle.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return array<string, array{before: array, after: array, data: string}>
+     */
+    private function snapshot_inline_scripts(): array {
+        $snapshot = [];
+
+        foreach ( wp_scripts()->registered as $handle => $script ) {
+            $extra = is_array( $script->extra ) ? $script->extra : [];
+
+            $snapshot[ $handle ] = [
+                'before' => isset( $extra['before'] ) ? (array) $extra['before'] : [],
+                'after'  => isset( $extra['after'] ) ? (array) $extra['after'] : [],
+                'data'   => isset( $extra['data'] ) ? (string) $extra['data'] : '',
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Work out which inline script data was added during the render.
+     *
+     * Only handles that are registered during a REST request can be captured, which is
+     * why extension authors are told to register handles on `init` and enqueue them on
+     * `wp_enqueue_scripts`.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array $before Snapshot taken before the render.
+     * @param array $after  Snapshot taken after the render.
+     *
+     * @return array<int, array{handle: string, position: string, code: string}>
+     */
+    private function diff_inline_scripts( array $before, array $after ): array {
+        $delta = [];
+        $empty = [
+            'before' => [],
+            'after'  => [],
+            'data'   => '',
+        ];
+
+        foreach ( $after as $handle => $current ) {
+            $previous = $before[ $handle ] ?? $empty;
+
+            foreach ( self::POSITIONS as $position ) {
+                $added = array_slice( $current[ $position ], count( $previous[ $position ] ) );
+
+                foreach ( $added as $code ) {
+                    if ( '' === trim( (string) $code ) ) {
+                        continue;
+                    }
+
+                    $delta[] = [
+                        'handle'   => (string) $handle,
+                        'position' => $position,
+                        'code'     => (string) $code,
+                    ];
+                }
+            }
+
+            // wp_localize_script() appends to one concatenated string rather than a list.
+            $previous_length = strlen( $previous['data'] );
+
+            if (
+                strlen( $current['data'] ) > $previous_length
+                && 0 === strncmp( $current['data'], $previous['data'], $previous_length )
+            ) {
+                $added = substr( $current['data'], $previous_length );
+
+                if ( '' !== trim( $added ) ) {
+                    $delta[] = [
+                        'handle'   => (string) $handle,
+                        'position' => 'before',
+                        'code'     => $added,
+                    ];
+                }
+            }
+        }
+
+        return $delta;
+    }
+}

--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -979,3 +979,28 @@ function dokan_apply_bulk_order_status_change( $postdata ) {
         $order->update_status( $status );
     }
 }
+
+/**
+ * Whether the Vendor panel opens order details in-panel.
+ *
+ * When this is off — the default until dokan-pro's companion change ships — the panel's
+ * order list navigates to the legacy order details URL exactly as before. The legacy URL
+ * keeps working either way, so flipping this back is free: no data migration, no routing
+ * consequences, and links already sitting in Vendors' inboxes keep resolving.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @return bool
+ */
+function dokan_is_vendor_panel_order_details_enabled(): bool {
+    /**
+     * Filters whether the Vendor panel renders order details in-panel.
+     *
+     * Return false to restore full-page navigation to the legacy order details page.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param bool $enabled Whether the in-panel order details route is enabled.
+     */
+    return (bool) apply_filters( 'dokan_vendor_panel_order_details_enabled', false );
+}

--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -983,10 +983,10 @@ function dokan_apply_bulk_order_status_change( $postdata ) {
 /**
  * Whether the Vendor panel opens order details in-panel.
  *
- * When this is off — the default until dokan-pro's companion change ships — the panel's
- * order list navigates to the legacy order details URL exactly as before. The legacy URL
- * keeps working either way, so flipping this back is free: no data migration, no routing
- * consequences, and links already sitting in Vendors' inboxes keep resolving.
+ * On by default: a Vendor clicking an order in the panel stays in the panel. Turning it
+ * off sends the order list back to full-page navigation to the legacy order details URL.
+ * That URL never stops working, so reverting is free — no data migration, no routing
+ * consequences, and links already sitting in Vendors' inboxes keep resolving either way.
  *
  * @since DOKAN_SINCE
  *
@@ -1002,5 +1002,5 @@ function dokan_is_vendor_panel_order_details_enabled(): bool {
      *
      * @param bool $enabled Whether the in-panel order details route is enabled.
      */
-    return (bool) apply_filters( 'dokan_vendor_panel_order_details_enabled', false );
+    return (bool) apply_filters( 'dokan_vendor_panel_order_details_enabled', true );
 }

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -173,6 +173,23 @@ class OrderController extends DokanRESTController {
         );
 
         register_rest_route(
+            $this->namespace, '/' . $this->base . '/(?P<id>[\d]+)/details-html', array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the object.', 'dokan-lite' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_order_details_html' ),
+					'permission_callback' => array( $this, 'get_order_details_html_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_order_details_html_schema' ),
+            )
+        );
+
+        register_rest_route(
             $this->namespace, '/' . $this->base . '/summary', array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -809,6 +826,189 @@ class OrderController extends DokanRESTController {
         }
 
         return false;
+    }
+
+    /**
+     * Permission rule for the Vendor order details HTML fragment.
+     *
+     * Mirrors exactly what the legacy order details page enforces: the order-viewing
+     * capability plus ownership resolved through Dokan's staff-aware current-user
+     * helper. `get_single_order_permissions_check()` is deliberately NOT reused — it
+     * compares against the raw current user id and so refuses Vendor staff who can
+     * open the legacy page. That is a real bug, but fixing it changes already-shipped
+     * public routes and belongs in its own change.
+     *
+     * The endpoint returns customer PII (billing and shipping addresses, phone, email,
+     * order notes), so this is the highest-risk code in the fragment feature.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return true|WP_Error
+     */
+    public function get_order_details_html_permissions_check( $request ) {
+        if ( ! current_user_can( 'dokan_view_order' ) ) {
+            return new WP_Error(
+                'dokan_rest_cannot_view_order',
+                __( 'Sorry, you are not allowed to view this order.', 'dokan-lite' ),
+                array( 'status' => rest_authorization_required_code() )
+            );
+        }
+
+        $order = wc_get_order( absint( $request['id'] ) );
+
+        if ( ! $order || 'trash' === $order->get_status() ) {
+            return new WP_Error(
+                'dokan_rest_invalid_order_id',
+                __( 'Invalid Order ID.', 'dokan-lite' ),
+                array( 'status' => 404 )
+            );
+        }
+
+        // Marketplace admins support Vendors and investigate disputes, so they reach
+        // any Vendor order — the same as the legacy page.
+        if ( current_user_can( 'manage_woocommerce' ) ) {
+            return true;
+        }
+
+        if ( dokan_is_seller_has_order( dokan_get_current_user_id(), $order->get_id() ) ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'dokan_rest_cannot_view_order',
+            __( 'Sorry, you are not allowed to view this order.', 'dokan-lite' ),
+            array( 'status' => 403 )
+        );
+    }
+
+    /**
+     * Render the Vendor order details template as an HTML fragment.
+     *
+     * Keeps order details server-rendered so every Pro and third-party hook keeps
+     * firing, and hands the markup to the React Vendor panel.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_order_details_html( $request ) {
+        $order = wc_get_order( absint( $request['id'] ) );
+
+        if ( ! $order ) {
+            return new WP_Error(
+                'dokan_rest_invalid_order_id',
+                __( 'Invalid Order ID.', 'dokan-lite' ),
+                array( 'status' => 404 )
+            );
+        }
+
+        $fragment    = dokan()->order_details_fragment->render( $order );
+        $date_create = $order->get_date_created();
+
+        $data = array(
+            'html'           => $fragment['html'],
+            'inline_scripts' => $fragment['inline_scripts'],
+            'order'          => array(
+                'id'           => $order->get_id(),
+                'number'       => (string) $order->get_order_number(),
+                'status'       => $order->get_status(),
+                'status_label' => dokan_get_order_status_translated( $order->get_status() ),
+                'date_created' => $date_create ? wc_rest_prepare_date_response( $date_create, false ) : null,
+            ),
+        );
+
+        /**
+         * Filters the Vendor order details fragment response payload.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array           $data    Response payload.
+         * @param WC_Order        $order   Order being rendered.
+         * @param WP_REST_Request $request Request object.
+         */
+        $data = apply_filters( 'dokan_rest_prepare_order_details_html', $data, $order, $request );
+
+        return rest_ensure_response( $data );
+    }
+
+    /**
+     * Schema for the order details HTML fragment response.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return array
+     */
+    public function get_order_details_html_schema() {
+        return array(
+            '$schema'    => 'http://json-schema.org/draft-04/schema#',
+            'title'      => 'order-details-html',
+            'type'       => 'object',
+            'properties' => array(
+                'html'           => array(
+                    'description' => __( 'Rendered order details markup.', 'dokan-lite' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view' ),
+                    'readonly'    => true,
+                ),
+                'inline_scripts' => array(
+                    'description' => __( 'Inline script data emitted while rendering the fragment.', 'dokan-lite' ),
+                    'type'        => 'array',
+                    'context'     => array( 'view' ),
+                    'readonly'    => true,
+                    'items'       => array(
+                        'type'       => 'object',
+                        'properties' => array(
+                            'handle'   => array(
+                                'description' => __( 'Script handle the data belongs to.', 'dokan-lite' ),
+                                'type'        => 'string',
+                            ),
+                            'position' => array(
+                                'description' => __( 'Whether the data runs before or after its handle.', 'dokan-lite' ),
+                                'type'        => 'string',
+                                'enum'        => array( 'before', 'after' ),
+                            ),
+                            'code'     => array(
+                                'description' => __( 'JavaScript to execute at global scope.', 'dokan-lite' ),
+                                'type'        => 'string',
+                            ),
+                        ),
+                    ),
+                ),
+                'order'          => array(
+                    'description' => __( 'Order metadata for the panel header.', 'dokan-lite' ),
+                    'type'        => 'object',
+                    'context'     => array( 'view' ),
+                    'readonly'    => true,
+                    'properties'  => array(
+                        'id'           => array(
+                            'description' => __( 'Unique identifier for the object.', 'dokan-lite' ),
+                            'type'        => 'integer',
+                        ),
+                        'number'       => array(
+                            'description' => __( 'Order number.', 'dokan-lite' ),
+                            'type'        => 'string',
+                        ),
+                        'status'       => array(
+                            'description' => __( 'Order status.', 'dokan-lite' ),
+                            'type'        => 'string',
+                        ),
+                        'status_label' => array(
+                            'description' => __( 'Translated order status.', 'dokan-lite' ),
+                            'type'        => 'string',
+                        ),
+                        'date_created' => array(
+                            'description' => __( "The date the order was created, in the site's timezone.", 'dokan-lite' ),
+                            'type'        => array( 'string', 'null' ),
+                            'format'      => 'date-time',
+                        ),
+                    ),
+                ),
+            ),
+        );
     }
 
     /**

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -226,7 +226,7 @@ class OrderController extends DokanRESTController {
         $order = dokan()->order->get( $request->get_param( 'id' ) );
 
         if ( empty( $order ) ) {
-            return new WP_Error( "dokan_rest_invalid_order_id", __( 'Invalid Order ID.', 'dokan-lite' ), array( 'status' => 404 ) );
+            return new WP_Error( 'dokan_rest_invalid_order_id', __( 'Invalid Order ID.', 'dokan-lite' ), array( 'status' => 404 ) );
         }
 
         $data     = $this->prepare_data_for_response( $order, $request );
@@ -815,6 +815,11 @@ class OrderController extends DokanRESTController {
      * @return boolean
      */
     public function get_single_order_permissions_check( $request ) {
+        // Pre-existing role check on a shipped public route. Swapping it for a
+        // capability would change who can read single orders on v1/v2/v3 — a behaviour
+        // change needing its own release note and coverage, not a drive-by edit inside
+        // a UI migration.
+        // phpcs:ignore WordPress.WP.Capabilities.RoleFound
         if ( current_user_can( 'shop_manager' ) || current_user_can( 'administrator' ) ) {
             return true;
         }

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -856,18 +856,17 @@ class OrderController extends DokanRESTController {
             );
         }
 
-        $order = wc_get_order( absint( $request['id'] ) );
+        $order = $this->get_viewable_order( $request );
 
-        if ( ! $order || 'trash' === $order->get_status() ) {
-            return new WP_Error(
-                'dokan_rest_invalid_order_id',
-                __( 'Invalid Order ID.', 'dokan-lite' ),
-                array( 'status' => 404 )
-            );
+        if ( is_wp_error( $order ) ) {
+            return $order;
         }
 
         // Marketplace admins support Vendors and investigate disputes, so they reach
-        // any Vendor order — the same as the legacy page.
+        // any Vendor order — the same as the legacy page. Note that the details
+        // template applies its own vendor-ownership guard, so what an admin is shown
+        // is whatever the legacy page shows them; this endpoint neither grants nor
+        // removes access relative to that page.
         if ( current_user_can( 'manage_woocommerce' ) ) {
             return true;
         }
@@ -896,9 +895,31 @@ class OrderController extends DokanRESTController {
      * @return WP_REST_Response|WP_Error
      */
     public function get_order_details_html( $request ) {
+        $order = $this->get_viewable_order( $request );
+
+        if ( is_wp_error( $order ) ) {
+            return $order;
+        }
+
+        return $this->prepare_order_details_html_for_response( $order, $request );
+    }
+
+    /**
+     * Resolve the order a fragment request is asking for.
+     *
+     * A trashed order is treated as missing so the panel gets a clean error rather
+     * than a blank view.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WC_Order|WP_Error
+     */
+    protected function get_viewable_order( $request ) {
         $order = wc_get_order( absint( $request['id'] ) );
 
-        if ( ! $order ) {
+        if ( ! $order || 'trash' === $order->get_status() ) {
             return new WP_Error(
                 'dokan_rest_invalid_order_id',
                 __( 'Invalid Order ID.', 'dokan-lite' ),
@@ -906,8 +927,26 @@ class OrderController extends DokanRESTController {
             );
         }
 
-        $fragment    = dokan()->order_details_fragment->render( $order );
-        $date_create = $order->get_date_created();
+        return $order;
+    }
+
+    /**
+     * Shape the order details fragment into a response.
+     *
+     * Named for the fragment rather than overriding `prepare_item_for_response()`,
+     * because this controller's item is an order — a future caller reaching for the
+     * generic name must not be handed a rendered document instead.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WC_Order        $order   Order being rendered.
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response
+     */
+    public function prepare_order_details_html_for_response( $order, $request ) {
+        $fragment     = dokan()->order_details_fragment->render( $order );
+        $date_created = $order->get_date_created();
 
         $data = array(
             'html'           => $fragment['html'],
@@ -917,12 +956,12 @@ class OrderController extends DokanRESTController {
                 'number'       => (string) $order->get_order_number(),
                 'status'       => $order->get_status(),
                 'status_label' => dokan_get_order_status_translated( $order->get_status() ),
-                'date_created' => $date_create ? wc_rest_prepare_date_response( $date_create, false ) : null,
+                'date_created' => $date_created ? wc_rest_prepare_date_response( $date_created, false ) : null,
             ),
         );
 
         /**
-         * Filters the Vendor order details fragment response payload.
+         * Filters the Vendor order details fragment payload.
          *
          * @since DOKAN_SINCE
          *
@@ -930,9 +969,41 @@ class OrderController extends DokanRESTController {
          * @param WC_Order        $order   Order being rendered.
          * @param WP_REST_Request $request Request object.
          */
-        $data = apply_filters( 'dokan_rest_prepare_order_details_html', $data, $order, $request );
+        $data = apply_filters( 'dokan_rest_prepare_order_details_html_data', $data, $order, $request );
 
-        return rest_ensure_response( $data );
+        $response = rest_ensure_response( $data );
+        $response->add_links( $this->prepare_order_details_html_links( $order ) );
+
+        /**
+         * Filters the Vendor order details fragment response.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param WP_REST_Response $response Response object.
+         * @param WC_Order         $order    Order being rendered.
+         * @param WP_REST_Request  $request  Request object.
+         */
+        return apply_filters( 'dokan_rest_prepare_order_details_html_object', $response, $order, $request );
+    }
+
+    /**
+     * Links for the order details fragment.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WC_Order $order Order being rendered.
+     *
+     * @return array
+     */
+    protected function prepare_order_details_html_links( $order ) {
+        return array(
+            'self'  => array(
+                'href' => rest_url( sprintf( '/%s/%s/%d/details-html', $this->namespace, $this->base, $order->get_id() ) ),
+            ),
+            'order' => array(
+                'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->base, $order->get_id() ) ),
+            ),
+        );
     }
 
     /**

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -22,6 +22,57 @@ const inlineScriptKey = ( script: OrderDetailsInlineScript ) =>
     `${ script.handle }|${ script.position }|${ script.code }`;
 
 /**
+ * Top-level lexical declarations found in a payload, e.g. `let vendorInfo = {…}`.
+ */
+const TOP_LEVEL_DECLARATION = /(?:^|\n)\s*(?:let|const)\s+([A-Za-z_$][\w$]*)/g;
+
+const topLevelBindings = ( code: string ): string[] => {
+    const names: string[] = [];
+    let match: RegExpExecArray | null;
+
+    TOP_LEVEL_DECLARATION.lastIndex = 0;
+
+    // eslint-disable-next-line no-cond-assign
+    while ( ( match = TOP_LEVEL_DECLARATION.exec( code ) ) !== null ) {
+        names.push( match[ 1 ] );
+    }
+
+    return names;
+};
+
+/**
+ * Warn when a payload cannot take effect because of a binding it already created.
+ *
+ * A top-level `let`/`const` executed at global scope lives in the global lexical
+ * environment and outlives the element that declared it. If a later order ships a
+ * different value under the same name, the browser refuses the whole script with a
+ * redeclaration `SyntaxError` and the consumer silently keeps reading the previous
+ * order's data. Nothing here can undo that binding — but a named warning turns a
+ * silent stale-data bug into one an extension author can act on.
+ *
+ * The fix is theirs: assign to `window`, or use `var`.
+ */
+const warnOnRedeclaration = (
+    handle: string,
+    previousCode: string,
+    nextCode: string
+) => {
+    const clashing = topLevelBindings( previousCode ).filter( ( name ) =>
+        topLevelBindings( nextCode ).includes( name )
+    );
+
+    if ( ! clashing.length || ! window.console?.warn ) {
+        return;
+    }
+
+    window.console.warn(
+        `[dokan] Inline data for "${ handle }" redeclares ${ clashing
+            .map( ( name ) => `\`${ name }\`` )
+            .join( ', ' ) } at global scope, so this order's value cannot replace the previous one. Assign to \`window\` or use \`var\` instead. See docs/frontend/order-details-fragment.md.`
+    );
+};
+
+/**
  * Put render-time inline data on the page as real script elements.
  *
  * Deliberately not `eval`: the known payloads declare top-level `let` bindings, which
@@ -46,6 +97,19 @@ const syncInlineScripts = ( scripts: OrderDetailsInlineScript[] ) => {
             // Already executing with exactly this code — leave it alone.
             wanted.delete( key );
             return;
+        }
+
+        const [ handle ] = key.split( '|' );
+        const replacement = Array.from( wanted.values() ).find(
+            ( script ) => script.handle === handle
+        );
+
+        if ( replacement ) {
+            warnOnRedeclaration(
+                handle,
+                element.textContent ?? '',
+                replacement.code
+            );
         }
 
         element.remove();
@@ -125,6 +189,14 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
                 // be in place before anyone is told to re-initialise against it.
                 syncInlineScripts( fragment?.inline_scripts ?? [] );
 
+                // Announced before the markup lands so the panel header can show the
+                // order number and status while the fragment is still being inserted.
+                if ( fragment?.order ) {
+                    emitOrderDetailsEvent( ORDER_DETAILS_LOADED, [
+                        fragment.order,
+                    ] );
+                }
+
                 // Assigning server-rendered markup is the whole point of this
                 // component, not an oversight. The HTML comes from Dokan's own REST
                 // endpoint, which requires `dokan_view_order` plus ownership before it
@@ -134,12 +206,6 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
                 container.innerHTML = fragment?.html ?? '';
 
                 executeEmbeddedScripts( container );
-
-                if ( fragment?.order ) {
-                    emitOrderDetailsEvent( ORDER_DETAILS_LOADED, [
-                        fragment.order,
-                    ] );
-                }
 
                 emitOrderDetailsEvent( ORDER_DETAILS_RENDERED, [
                     container,

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -2,7 +2,85 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { DokanAlert } from '@dokan/components';
-import type { OrderDetailsFragment } from './types';
+import {
+    ORDER_DETAILS_LOADED,
+    ORDER_DETAILS_RENDERED,
+    emitOrderDetailsEvent,
+} from './events';
+import type { OrderDetailsFragment, OrderDetailsInlineScript } from './types';
+
+/**
+ * Inline script elements this route currently has live in the document.
+ *
+ * Keyed by handle + position + code, so re-rendering the same order reuses the
+ * elements already executing instead of appending duplicates, and opening a different
+ * order drops the ones that are no longer part of the render.
+ */
+const liveInlineScripts = new Map< string, HTMLScriptElement >();
+
+const inlineScriptKey = ( script: OrderDetailsInlineScript ) =>
+    `${ script.handle }|${ script.position }|${ script.code }`;
+
+/**
+ * Put render-time inline data on the page as real script elements.
+ *
+ * Deliberately not `eval`: the known payloads declare top-level `let` bindings, which
+ * are only globally visible when executed at global scope. Evaluating them inside a
+ * closure would scope them to that closure and the consuming script would still find
+ * nothing.
+ *
+ * Note for extension authors: a top-level `let` or `const` cannot be redeclared, so a
+ * payload that changes between orders should use `var` or assign to `window`.
+ */
+const syncInlineScripts = ( scripts: OrderDetailsInlineScript[] ) => {
+    const wanted = new Map< string, OrderDetailsInlineScript >();
+
+    scripts.forEach( ( script ) => {
+        if ( script?.code ) {
+            wanted.set( inlineScriptKey( script ), script );
+        }
+    } );
+
+    liveInlineScripts.forEach( ( element, key ) => {
+        if ( wanted.has( key ) ) {
+            // Already executing with exactly this code — leave it alone.
+            wanted.delete( key );
+            return;
+        }
+
+        element.remove();
+        liveInlineScripts.delete( key );
+    } );
+
+    wanted.forEach( ( script, key ) => {
+        const element = document.createElement( 'script' );
+
+        element.setAttribute( 'data-dokan-order-details-handle', script.handle );
+        element.textContent = script.code;
+
+        document.head.appendChild( element );
+        liveInlineScripts.set( key, element );
+    } );
+};
+
+/**
+ * Re-create script tags found inside the inserted markup.
+ *
+ * HTML assigned as a string never executes its scripts. Nothing in the current render
+ * path emits one, but third-party templates may.
+ */
+const executeEmbeddedScripts = ( container: HTMLElement ) => {
+    container.querySelectorAll( 'script' ).forEach( ( original ) => {
+        const replacement = document.createElement( 'script' );
+
+        Array.from( original.attributes ).forEach( ( attribute ) => {
+            replacement.setAttribute( attribute.name, attribute.value );
+        } );
+        replacement.textContent = original.textContent;
+
+        original.parentNode?.replaceChild( replacement, original );
+    } );
+};
 
 /**
  * Vendor order details, rendered by PHP and bridged into the Vendor panel.
@@ -36,9 +114,16 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
             path: `/dokan/v1/orders/${ orderId }/details-html`,
         } )
             .then( ( fragment ) => {
-                if ( cancelled || ! containerRef.current ) {
+                const container = containerRef.current;
+
+                if ( cancelled || ! container ) {
                     return;
                 }
+
+                // Order matters and is not obvious. Inline data has to be executing
+                // before the markup that depends on it exists, and everything has to
+                // be in place before anyone is told to re-initialise against it.
+                syncInlineScripts( fragment?.inline_scripts ?? [] );
 
                 // Assigning server-rendered markup is the whole point of this
                 // component, not an oversight. The HTML comes from Dokan's own REST
@@ -46,7 +131,20 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
                 // renders anything, and the template escapes its own output with the
                 // WordPress escaping API. Sanitising here would strip exactly the
                 // markup Pro and third-party hooks contribute.
-                containerRef.current.innerHTML = fragment?.html ?? '';
+                container.innerHTML = fragment?.html ?? '';
+
+                executeEmbeddedScripts( container );
+
+                if ( fragment?.order ) {
+                    emitOrderDetailsEvent( ORDER_DETAILS_LOADED, [
+                        fragment.order,
+                    ] );
+                }
+
+                emitOrderDetailsEvent( ORDER_DETAILS_RENDERED, [
+                    container,
+                    orderId,
+                ] );
             } )
             .catch( ( fetchError ) => {
                 if ( cancelled ) {
@@ -72,6 +170,14 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
             cancelled = true;
         };
     }, [ orderId ] );
+
+    // Leaving the route entirely takes the render's inline data with it, so a later
+    // visit cannot read a global belonging to an order the Vendor is no longer on.
+    useEffect( () => {
+        return () => {
+            syncInlineScripts( [] );
+        };
+    }, [] );
 
     if ( error ) {
         return (

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { DokanAlert } from '@dokan/components';
+import type { OrderDetailsFragment } from './types';
+
+/**
+ * Vendor order details, rendered by PHP and bridged into the Vendor panel.
+ *
+ * The details view is not a React component and deliberately never becomes one: the
+ * template fires eleven extension hooks plus WooCommerce's item hooks, and Pro injects
+ * shipments, delivery time, store pickup and the whole item/refund table into it.
+ * Rewriting it in React would delete all of that silently. Instead the server renders
+ * the same template it renders for the legacy page, and this component asks for the
+ * resulting HTML and puts it on screen.
+ */
+const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
+    const orderId = Number( params?.orderId ?? 0 );
+    const containerRef = useRef< HTMLDivElement >( null );
+    const [ isLoading, setIsLoading ] = useState( true );
+    const [ error, setError ] = useState< string >( '' );
+
+    useEffect( () => {
+        if ( ! orderId ) {
+            setIsLoading( false );
+            setError( __( 'No order was requested.', 'dokan-lite' ) );
+            return;
+        }
+
+        let cancelled = false;
+
+        setIsLoading( true );
+        setError( '' );
+
+        apiFetch< OrderDetailsFragment >( {
+            path: `/dokan/v1/orders/${ orderId }/details-html`,
+        } )
+            .then( ( fragment ) => {
+                if ( cancelled || ! containerRef.current ) {
+                    return;
+                }
+
+                // Assigning server-rendered markup is the whole point of this
+                // component, not an oversight. The HTML comes from Dokan's own REST
+                // endpoint, which requires `dokan_view_order` plus ownership before it
+                // renders anything, and the template escapes its own output with the
+                // WordPress escaping API. Sanitising here would strip exactly the
+                // markup Pro and third-party hooks contribute.
+                containerRef.current.innerHTML = fragment?.html ?? '';
+            } )
+            .catch( ( fetchError ) => {
+                if ( cancelled ) {
+                    return;
+                }
+
+                setError(
+                    fetchError?.message ||
+                        sprintf(
+                            /* translators: %d: order number */
+                            __( 'Order #%d could not be loaded.', 'dokan-lite' ),
+                            orderId
+                        )
+                );
+            } )
+            .finally( () => {
+                if ( ! cancelled ) {
+                    setIsLoading( false );
+                }
+            } );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [ orderId ] );
+
+    if ( error ) {
+        return (
+            <DokanAlert
+                variant="danger"
+                label={ __( 'Order details unavailable', 'dokan-lite' ) }
+            >
+                { error }
+            </DokanAlert>
+        );
+    }
+
+    return (
+        <div className="dokan-order-details-wrapper dokan-react-order-details">
+            { isLoading && (
+                <div
+                    className="h-64 animate-pulse rounded-md bg-muted"
+                    aria-label={ __( 'Loading order details', 'dokan-lite' ) }
+                />
+            ) }
+            <div ref={ containerRef } />
+        </div>
+    );
+};
+
+export default OrderDetails;

--- a/src/dashboard/orders/OrderDetailsHeader.tsx
+++ b/src/dashboard/orders/OrderDetailsHeader.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Slot } from '@wordpress/components';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { ArrowLeft, Pencil } from 'lucide-react';
+import { DokanBadge, DokanButton } from '@dokan/components';
+import { usePermission } from '@dokan/hooks';
+import {
+    ORDER_DETAILS_LOADED,
+    ORDER_DETAILS_STATUS_CHANGED,
+    onOrderDetailsEvent,
+} from './events';
+import { getStatusBadgeVariant, getStatusLabel } from './status';
+import type { OrderDetailsMeta } from './types';
+
+/**
+ * Panel chrome for the order details route.
+ *
+ * The panel owns the chrome, not the fragment: the order number as the page title, the
+ * current status as a badge, a back control, and an Edit Order action.
+ *
+ * Edit Order matters more than it looks. Pro attaches that control to the status-filter
+ * bar, which renders above the details on the legacy page but which the fragment
+ * deliberately does not include — the panel already provides that navigation. Without
+ * re-providing it here the affordance simply disappears for Pro users.
+ *
+ * The status comes in over events rather than a second fetch, because the fragment is
+ * the thing that knows: it loads the order, and the legacy script announces an inline
+ * status change the moment it succeeds. A header that disagrees with the view beneath
+ * it is worse than no header.
+ */
+const OrderDetailsHeader = () => {
+    const params = useParams();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const orderId = Number( params?.orderId ?? 0 );
+
+    const [ order, setOrder ] = useState< OrderDetailsMeta | null >( null );
+    const [ status, setStatus ] = useState< string >( '' );
+
+    const canEditOrder = usePermission( 'dokan_manage_manual_order' );
+
+    useEffect( () => {
+        const unsubscribeLoaded = onOrderDetailsEvent(
+            ORDER_DETAILS_LOADED,
+            ( loaded ) => {
+                const meta = loaded as OrderDetailsMeta;
+
+                setOrder( meta );
+                setStatus( meta?.status ?? '' );
+            }
+        );
+
+        const unsubscribeStatus = onOrderDetailsEvent(
+            ORDER_DETAILS_STATUS_CHANGED,
+            ( changedOrderId, changedStatus ) => {
+                if ( Number( changedOrderId ) !== orderId ) {
+                    return;
+                }
+
+                setStatus( String( changedStatus ) );
+            }
+        );
+
+        return () => {
+            unsubscribeLoaded();
+            unsubscribeStatus();
+        };
+    }, [ orderId ] );
+
+    /**
+     * Hand the list back the view it was on before the Vendor opened this order.
+     */
+    const goBackToList = () => {
+        const from = ( location?.state ?? {} ) as {
+            fromView?: unknown;
+            fromFilters?: unknown;
+        };
+
+        navigate( '/orders', {
+            state: {
+                restoreView: from.fromView,
+                restoreFilters: from.fromFilters,
+            },
+        } );
+    };
+
+    const title = order?.number
+        ? sprintf(
+              /* translators: %s: order number */
+              __( 'Order #%s', 'dokan-lite' ),
+              order.number
+          )
+        : __( 'Order Details', 'dokan-lite' );
+
+    return (
+        <div className="@container/header flex flex-col gap-4">
+            <div className="@container/before-header grid grid-cols-4 gap-4">
+                <Slot name="dokan-before-header" />
+            </div>
+            <div className="dokan-header-title-section @container/header-title-section flex gap-y-4 justify-between items-center flex-wrap">
+                <div className="dokan-header-title w-full md:!w-1/2 flex flex-wrap items-center gap-3">
+                    <h3 className="text-2xl font-semibold text-gray-800 md:text-4xl lg:text-3xl">
+                        { title }
+                    </h3>
+                    { status && (
+                        <DokanBadge
+                            variant={ getStatusBadgeVariant( status ) }
+                            label={ getStatusLabel( status ) }
+                        />
+                    ) }
+                    <Slot
+                        name="dokan-header-after-title"
+                        fillProps={ { title, navigate, params, location } }
+                    />
+                </div>
+                <div className="dokan-header-actions w-full md:!w-1/2 flex flex-wrap gap-2.5 md:!justify-end">
+                    <DokanButton variant="secondary" onClick={ goBackToList }>
+                        <ArrowLeft className="text-dokan-link" size={ 16 } />
+                        { __( 'Back', 'dokan-lite' ) }
+                    </DokanButton>
+                    { canEditOrder && orderId > 0 && (
+                        <DokanButton
+                            variant="secondary"
+                            onClick={ () =>
+                                navigate( `/orders/edit/${ orderId }` )
+                            }
+                        >
+                            <Pencil className="text-dokan-link" size={ 16 } />
+                            { __( 'Edit Order', 'dokan-lite' ) }
+                        </DokanButton>
+                    ) }
+                    <Slot
+                        name="dokan-header-actions"
+                        fillProps={ { navigate, params, location } }
+                    />
+                </div>
+            </div>
+            <div className="@container/after-header grid grid-cols-4 gap-4">
+                <Slot
+                    name="dokan-after-header"
+                    fillProps={ { navigate, params, location } }
+                />
+            </div>
+        </div>
+    );
+};
+
+export default OrderDetailsHeader;

--- a/src/dashboard/orders/OrderList.tsx
+++ b/src/dashboard/orders/OrderList.tsx
@@ -18,6 +18,7 @@ import {
     CustomerFilter,
 } from '@dokan/components';
 import { ShoppingCart, ChevronDown, Download, Calendar } from 'lucide-react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useOrders } from './hooks/useOrders';
 import type { OrderItem, OrderFilterState } from './types';
 
@@ -52,7 +53,44 @@ declare const window: Window & {
         allow_shipment?: string;
         has_shipment_func?: boolean;
     };
+    dokanFrontend?: {
+        order_details?: {
+            panel_route_enabled?: boolean;
+        };
+    };
 };
+
+/**
+ * Whether order details opens inside the panel.
+ *
+ * Mirrors the `dokan_vendor_panel_order_details_enabled` PHP filter. While it is off —
+ * the default until dokan-pro's companion change ships — the list navigates to the
+ * legacy order details URL exactly as it always has.
+ */
+const isPanelRouteEnabled = () =>
+    Boolean( window?.dokanFrontend?.order_details?.panel_route_enabled );
+
+const getPanelOrderDetailsUrl = ( orderId: number ) => `#/orders/${ orderId }`;
+
+interface OrderListView {
+    perPage: number;
+    page: number;
+    search: string;
+    type: 'table';
+    status: string;
+    fields: string[];
+    layout: {
+        styles: Record< string, { width: string } >;
+    };
+}
+
+/**
+ * State the details route hands back so returning to the list is not a reset.
+ */
+interface OrderListLocationState {
+    restoreView?: OrderListView;
+    restoreFilters?: OrderFilterState;
+}
 
 // Status helpers use unprefixed values (e.g. 'completed', 'processing') because
 // the REST API returns unprefixed statuses on order items. Tabs and filters use
@@ -159,6 +197,13 @@ const getCustomerName = ( item: OrderItem ) => {
 
 function OrderList() {
     const toast = useToast();
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    // The details route hands the list back its own state on the way out, so returning
+    // from an order lands on the page, filters and sort the Vendor left behind.
+    const restoredState = ( location?.state ?? {} ) as OrderListLocationState;
+
     const [ selection, setSelection ] = useState< string[] >( [] );
     const [ exportOpen, setExportOpen ] = useState( false );
     const exportFormRef = useRef< HTMLFormElement >( null );
@@ -174,12 +219,14 @@ function OrderList() {
     const [ selectedCustomer, setSelectedCustomer ] =
         useState< CustomerOption | null >( null );
 
-    const [ filterArgs, setFilterArgs ] = useState< OrderFilterState >( {
-        page: 1,
-        per_page: 10,
-        status: 'all',
-        search: '',
-    } );
+    const [ filterArgs, setFilterArgs ] = useState< OrderFilterState >(
+        restoredState.restoreFilters ?? {
+            page: 1,
+            per_page: 10,
+            status: 'all',
+            search: '',
+        }
+    );
 
     const allowShipment =
         window?.dokan?.allow_shipment === 'on' &&
@@ -197,7 +244,8 @@ function OrderList() {
         fieldsColumns.push( 'shipment' );
     }
 
-    const [ view, setView ] = useState( {
+    const [ view, setView ] = useState< OrderListView >(
+        restoredState.restoreView ?? {
         perPage: 10,
         page: 1,
         search: '',
@@ -226,7 +274,35 @@ function OrderList() {
                 },
             },
         },
-    } );
+        }
+    );
+
+    const panelRouteEnabled = isPanelRouteEnabled();
+
+    /**
+     * Open an order.
+     *
+     * With the panel route enabled this stays inside the SPA and carries the list's
+     * current view along so Back can restore it. With it disabled — the default — it
+     * navigates to the legacy details page exactly as before.
+     */
+    const openOrderDetails = useCallback(
+        ( orderId: number ) => {
+            if ( panelRouteEnabled ) {
+                navigate( `/orders/${ orderId }`, {
+                    state: { fromView: view, fromFilters: filterArgs },
+                } );
+                return;
+            }
+
+            const url = getOrderDetailsUrl( orderId );
+
+            if ( url && url !== '#' ) {
+                window.location.href = url;
+            }
+        },
+        [ panelRouteEnabled, navigate, view, filterArgs ]
+    );
 
     const {
         data,
@@ -258,13 +334,15 @@ function OrderList() {
             render: ( { item }: { item: OrderItem } ) => (
                 <div>
                     <a
-                        href={ getOrderDetailsUrl( item.id ) }
+                        href={
+                            panelRouteEnabled
+                                ? getPanelOrderDetailsUrl( item.id )
+                                : getOrderDetailsUrl( item.id )
+                        }
                         className="font-medium text-primary"
                         onClick={ ( e ) => {
                             e.preventDefault();
-                            window.location.href = getOrderDetailsUrl(
-                                item.id
-                            );
+                            openOrderDetails( item.id );
                         } }
                     >
                         { `#${ item.number || item.id }` }
@@ -603,12 +681,7 @@ function OrderList() {
                 id: 'view',
                 label: __( 'View', 'dokan-lite' ),
                 callback: ( items: OrderItem[] ) => {
-                    const item = items[ 0 ];
-                    const url = getOrderDetailsUrl( item.id );
-
-                    if ( url && url !== '#' ) {
-                        window.location.href = url;
-                    }
+                    openOrderDetails( items[ 0 ].id );
                 },
             },
             {
@@ -694,10 +767,7 @@ function OrderList() {
                 selection={ selection }
                 onChangeSelection={ ( ids: string[] ) => setSelection( ids ) }
                 onClickItem={ ( item: OrderItem ) => {
-                    const url = getOrderDetailsUrl( item.id );
-                    if ( url && url !== '#' ) {
-                        window.location.href = url;
-                    }
+                    openOrderDetails( item.id );
                 } }
                 isItemClickable={ () => true }
                 emptyIcon={

--- a/src/dashboard/orders/OrderList.tsx
+++ b/src/dashboard/orders/OrderList.tsx
@@ -208,34 +208,34 @@ function OrderList() {
 
     const [ view, setView ] = useState< OrderListView >(
         restoredState.restoreView ?? {
-        perPage: 10,
-        page: 1,
-        search: '',
-        type: 'table' as const,
-        status: 'all',
-        fields: fieldsColumns,
-        layout: {
-            styles: {
-                order: {
-                    width: '20%',
-                },
-                order_total: {
-                    width: '15%',
-                },
-                earning: {
-                    width: '15%',
-                },
-                status: {
-                    width: '15%',
-                },
-                customer: {
-                    width: '15%',
-                },
-                shipment: {
-                    width: '20%',
+            perPage: 10,
+            page: 1,
+            search: '',
+            type: 'table' as const,
+            status: 'all',
+            fields: fieldsColumns,
+            layout: {
+                styles: {
+                    order: {
+                        width: '20%',
+                    },
+                    order_total: {
+                        width: '15%',
+                    },
+                    earning: {
+                        width: '15%',
+                    },
+                    status: {
+                        width: '15%',
+                    },
+                    customer: {
+                        width: '15%',
+                    },
+                    shipment: {
+                        width: '20%',
+                    },
                 },
             },
-        },
         }
     );
 

--- a/src/dashboard/orders/OrderList.tsx
+++ b/src/dashboard/orders/OrderList.tsx
@@ -20,6 +20,7 @@ import {
 import { ShoppingCart, ChevronDown, Download, Calendar } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useOrders } from './hooks/useOrders';
+import { getStatusBadgeVariant, getStatusLabel } from './status';
 import type { OrderItem, OrderFilterState } from './types';
 
 interface CustomerOption {
@@ -91,45 +92,6 @@ interface OrderListLocationState {
     restoreView?: OrderListView;
     restoreFilters?: OrderFilterState;
 }
-
-// Status helpers use unprefixed values (e.g. 'completed', 'processing') because
-// the REST API returns unprefixed statuses on order items. Tabs and filters use
-// wc-prefixed values (e.g. 'wc-completed') because the API expects that format
-// for filtering queries.
-const getStatusBadgeVariant = ( status: string ) => {
-    switch ( status ) {
-        case 'completed':
-            return 'success';
-        case 'processing':
-            return 'info';
-        case 'on-hold':
-            return 'warning';
-        case 'pending':
-        case 'failed':
-            return 'danger';
-        case 'cancelled':
-        case 'refunded':
-            return 'secondary';
-        default:
-            return 'secondary';
-    }
-};
-
-const getStatusLabel = ( status: string ) => {
-    const statuses = window?.dokan?.orderStatuses;
-
-    if ( Array.isArray( statuses ) ) {
-        const prefixed = `wc-${ status }`;
-        const found = statuses.find(
-            ( s ) => s.value === prefixed || s.value === status
-        );
-        if ( found ) {
-            return found.label;
-        }
-    }
-
-    return status;
-};
 
 const getShipmentBadgeVariant = ( shipment: string ) => {
     if ( ! shipment || shipment === '--' ) {

--- a/src/dashboard/orders/OrderList.tsx
+++ b/src/dashboard/orders/OrderList.tsx
@@ -64,9 +64,9 @@ declare const window: Window & {
 /**
  * Whether order details opens inside the panel.
  *
- * Mirrors the `dokan_vendor_panel_order_details_enabled` PHP filter. While it is off —
- * the default until dokan-pro's companion change ships — the list navigates to the
- * legacy order details URL exactly as it always has.
+ * Mirrors the `dokan_vendor_panel_order_details_enabled` PHP filter, which is on by
+ * default. Turned off, the list navigates to the legacy order details URL exactly as it
+ * always has.
  */
 const isPanelRouteEnabled = () =>
     Boolean( window?.dokanFrontend?.order_details?.panel_route_enabled );

--- a/src/dashboard/orders/events.ts
+++ b/src/dashboard/orders/events.ts
@@ -1,0 +1,87 @@
+import { doAction } from '@wordpress/hooks';
+
+/**
+ * The public re-init contract for the Vendor order details fragment.
+ *
+ * Order details is server-rendered PHP injected into the React panel long after
+ * DOM-ready, so JavaScript that binds to that markup needs to be told when it exists.
+ * These events are that signal, and they are the compatibility contract for the whole
+ * migration — their names, payloads and timing must not drift.
+ *
+ * Every event is emitted twice: through the modern JavaScript hooks system and as a
+ * jQuery event on `document.body`, so extension code from either era can consume it.
+ *
+ * @see docs/frontend/order-details-fragment.md
+ */
+
+/**
+ * Fires once the fragment is on the page and any render-time inline data is executing.
+ *
+ * Payload: `( container: HTMLElement, orderId: number )`
+ */
+export const ORDER_DETAILS_RENDERED = 'dokan-order-details-fragment-rendered';
+
+/**
+ * Fires when the fragment's order metadata is known, before the markup is inserted.
+ *
+ * Payload: `( order: OrderDetailsMeta )`
+ */
+export const ORDER_DETAILS_LOADED = 'dokan-order-details-loaded';
+
+/**
+ * Fires after a Vendor changes the order status inline, so nothing on the page can
+ * contradict the status inside the fragment.
+ *
+ * Payload: `( orderId: number, status: string, labelHtml: string )`
+ */
+export const ORDER_DETAILS_STATUS_CHANGED =
+    'dokan-order-details-status-changed';
+
+type JQueryLike = ( target: unknown ) => {
+    trigger: ( name: string, args: unknown[] ) => void;
+    on: ( name: string, handler: ( ...args: unknown[] ) => void ) => void;
+    off: ( name: string, handler: ( ...args: unknown[] ) => void ) => void;
+};
+
+const getJQuery = (): JQueryLike | undefined =>
+    ( window as unknown as { jQuery?: JQueryLike } ).jQuery;
+
+/**
+ * Emit one of the order-details events on both channels.
+ *
+ * @param name Event name.
+ * @param args Positional payload.
+ */
+export const emitOrderDetailsEvent = ( name: string, args: unknown[] ) => {
+    doAction( name, ...args );
+
+    getJQuery()?.( document.body ).trigger( name, args );
+};
+
+/**
+ * Subscribe to an order-details event fired on either channel.
+ *
+ * Listens on the jQuery channel only, because every emitter fires both — subscribing to
+ * both would run the handler twice.
+ *
+ * @param name    Event name.
+ * @param handler Receives the payload without jQuery's leading event object.
+ *
+ * @return Unsubscribe function.
+ */
+export const onOrderDetailsEvent = (
+    name: string,
+    handler: ( ...args: unknown[] ) => void
+) => {
+    const jQuery = getJQuery();
+
+    if ( ! jQuery ) {
+        return () => undefined;
+    }
+
+    const wrapped = ( ...args: unknown[] ) => handler( ...args.slice( 1 ) );
+
+    jQuery( document.body ).on( name, wrapped );
+
+    return () => jQuery( document.body ).off( name, wrapped );
+};

--- a/src/dashboard/orders/events.ts
+++ b/src/dashboard/orders/events.ts
@@ -1,4 +1,4 @@
-import { doAction } from '@wordpress/hooks';
+import { addAction, doAction, removeAction } from '@wordpress/hooks';
 
 /**
  * The public re-init contract for the Vendor order details fragment.
@@ -39,12 +39,12 @@ export const ORDER_DETAILS_STATUS_CHANGED =
 
 type JQueryLike = ( target: unknown ) => {
     trigger: ( name: string, args: unknown[] ) => void;
-    on: ( name: string, handler: ( ...args: unknown[] ) => void ) => void;
-    off: ( name: string, handler: ( ...args: unknown[] ) => void ) => void;
 };
 
 const getJQuery = (): JQueryLike | undefined =>
     ( window as unknown as { jQuery?: JQueryLike } ).jQuery;
+
+let subscriptionCount = 0;
 
 /**
  * Emit one of the order-details events on both channels.
@@ -59,13 +59,14 @@ export const emitOrderDetailsEvent = ( name: string, args: unknown[] ) => {
 };
 
 /**
- * Subscribe to an order-details event fired on either channel.
+ * Subscribe to an order-details event.
  *
- * Listens on the jQuery channel only, because every emitter fires both — subscribing to
- * both would run the handler twice.
+ * Listens on the hooks channel only. Every emitter publishes on both, so subscribing to
+ * both would run the handler twice — and the hooks channel is the one panel code can
+ * count on, since it is imported rather than assumed present on `window`.
  *
  * @param name    Event name.
- * @param handler Receives the payload without jQuery's leading event object.
+ * @param handler Receives the event payload.
  *
  * @return Unsubscribe function.
  */
@@ -73,15 +74,11 @@ export const onOrderDetailsEvent = (
     name: string,
     handler: ( ...args: unknown[] ) => void
 ) => {
-    const jQuery = getJQuery();
+    // Hook namespaces are unique per subscription so two mounted listeners on the same
+    // event cannot unregister each other.
+    const namespace = `dokan-lite/order-details-${ ++subscriptionCount }`;
 
-    if ( ! jQuery ) {
-        return () => undefined;
-    }
+    addAction( name, namespace, handler );
 
-    const wrapped = ( ...args: unknown[] ) => handler( ...args.slice( 1 ) );
-
-    jQuery( document.body ).on( name, wrapped );
-
-    return () => jQuery( document.body ).off( name, wrapped );
+    return () => removeAction( name, namespace );
 };

--- a/src/dashboard/orders/status.ts
+++ b/src/dashboard/orders/status.ts
@@ -1,0 +1,60 @@
+/**
+ * Order status presentation, shared by the list and the details header.
+ *
+ * Status helpers take unprefixed values (e.g. `completed`, `processing`) because the
+ * REST API returns unprefixed statuses on order items. Tabs and filters use wc-prefixed
+ * values (e.g. `wc-completed`) because the API expects that format for filtering.
+ */
+
+declare const window: Window & {
+    dokan?: {
+        orderStatuses?: Array< {
+            value: string;
+            label: string;
+        } >;
+    };
+};
+
+export type OrderStatusBadgeVariant =
+    | 'success'
+    | 'info'
+    | 'warning'
+    | 'danger'
+    | 'secondary';
+
+export const getStatusBadgeVariant = (
+    status: string
+): OrderStatusBadgeVariant => {
+    switch ( status ) {
+        case 'completed':
+            return 'success';
+        case 'processing':
+            return 'info';
+        case 'on-hold':
+            return 'warning';
+        case 'pending':
+        case 'failed':
+            return 'danger';
+        case 'cancelled':
+        case 'refunded':
+            return 'secondary';
+        default:
+            return 'secondary';
+    }
+};
+
+export const getStatusLabel = ( status: string ) => {
+    const statuses = window?.dokan?.orderStatuses;
+
+    if ( Array.isArray( statuses ) ) {
+        const prefixed = `wc-${ status }`;
+        const found = statuses.find(
+            ( s ) => s.value === prefixed || s.value === status
+        );
+        if ( found ) {
+            return found.label;
+        }
+    }
+
+    return status;
+};

--- a/src/dashboard/orders/types.ts
+++ b/src/dashboard/orders/types.ts
@@ -50,3 +50,29 @@ export interface OrderStatusCount {
     label: string;
     count: number;
 }
+
+export interface OrderDetailsInlineScript {
+    handle: string;
+    position: 'before' | 'after';
+    code: string;
+}
+
+export interface OrderDetailsMeta {
+    id: number;
+    number: string;
+    status: string;
+    status_label: string;
+    date_created: string | null;
+}
+
+/**
+ * Response of `GET /dokan/v1/orders/<id>/details-html`.
+ *
+ * The details view stays server-rendered PHP so every Pro and third-party hook keeps
+ * firing; the panel receives its markup as an HTML fragment.
+ */
+export interface OrderDetailsFragment {
+    html: string;
+    inline_scripts: OrderDetailsInlineScript[];
+    order: OrderDetailsMeta;
+}

--- a/src/dokan-components.css
+++ b/src/dokan-components.css
@@ -11,12 +11,24 @@
     border-color: var(--color-border);
 }
 
-/* ========== Resets ========== */
+/* ========== Resets ==========
+ *
+ * These are written for React surfaces. A Legacy fragment — server-rendered PHP
+ * markup injected into the panel, see docs/frontend/order-details-fragment.md — is
+ * styled by the legacy Dokan stylesheet instead, and these resets outrank it
+ * (`table:not(.dataviews-view-table) th` is 0,1,2; `.dokan-table th` is 0,1,1), which
+ * flattens its tables and lists.
+ *
+ * Each reset is therefore excluded from fragment subtrees with a `:where()` guard.
+ * `:where()` contributes ZERO specificity, so every rule below keeps the exact weight
+ * it had before against everything outside a fragment — no existing panel surface can
+ * be affected by this.
+ */
 
 /* Table Reset */
-table:not(.dataviews-view-table),
-table:not(.dataviews-view-table) th,
-table:not(.dataviews-view-table) td {
+table:not(.dataviews-view-table):where(:not(.dokan-legacy-fragment *)),
+table:not(.dataviews-view-table) th:where(:not(.dokan-legacy-fragment *)),
+table:not(.dataviews-view-table) td:where(:not(.dokan-legacy-fragment *)) {
     margin: 0;
     padding: 0;
     border: 0;
@@ -29,40 +41,65 @@ table:not(.dataviews-view-table) td {
     box-sizing: border-box;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1:where(:not(.dokan-legacy-fragment *)),
+h2:where(:not(.dokan-legacy-fragment *)),
+h3:where(:not(.dokan-legacy-fragment *)),
+h4:where(:not(.dokan-legacy-fragment *)),
+h5:where(:not(.dokan-legacy-fragment *)),
+h6:where(:not(.dokan-legacy-fragment *)) {
     font-size: inherit;
     font-weight: inherit;
 }
 /* List Reset */
-ul,
-ol {
+ul:where(:not(.dokan-legacy-fragment *)),
+ol:where(:not(.dokan-legacy-fragment *)) {
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-li {
+li:where(:not(.dokan-legacy-fragment *)) {
     margin: 0;
     list-style: none;
     padding: 0;
 }
-p {
+p:where(:not(.dokan-legacy-fragment *)) {
     margin: 0;
 }
 /* Headings Reset */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1:where(:not(.dokan-legacy-fragment *)),
+h2:where(:not(.dokan-legacy-fragment *)),
+h3:where(:not(.dokan-legacy-fragment *)),
+h4:where(:not(.dokan-legacy-fragment *)),
+h5:where(:not(.dokan-legacy-fragment *)),
+h6:where(:not(.dokan-legacy-fragment *)) {
     padding: 0;
     margin: 0;
+}
+
+/* ========== Legacy fragment ==========
+ *
+ * A fragment reproduces the legacy page's content class names so third-party CSS
+ * written against that page keeps matching. Those class names also carry Dokan's own
+ * PAGE-LAYOUT rules, though, and those were written for a page that has a 250px
+ * sidebar next to them — `.dokan-dashboard-content` resolves to `display: none;
+ * width: calc(100% - 250px); overflow: hidden` outside that context, which collapses
+ * the whole fragment to zero height.
+ *
+ * The panel provides its own navigation, so the layout half of those classes is
+ * neutralised here while the selectors themselves keep matching.
+ *
+ * `!important` is required, not lazy: the legacy rule this overrides is itself
+ * `!important`, so no amount of specificity beats it. Verified in a browser — a
+ * (0,3,0) selector still loses to it.
+ */
+.dokan-legacy-fragment,
+.dokan-legacy-fragment .dokan-dashboard-content {
+    display: block !important;
+    float: none !important;
+    width: 100% !important;
+    max-width: none !important;
+    overflow: visible !important;
 }
 
 /* ========== Focus States ========== */

--- a/src/routing/routes.tsx
+++ b/src/routing/routes.tsx
@@ -6,6 +6,7 @@ import App from '@src/dashboard/product-editor/App';
 import Products from '@src/dashboard/products';
 import Orders from '@src/dashboard/orders';
 import OrderDetails from '@src/dashboard/orders/OrderDetails';
+import OrderDetailsHeader from '@src/dashboard/orders/OrderDetailsHeader';
 import ReverseWithdrawal from '@src/dashboard/reverse-withdraw';
 
 export default [
@@ -36,8 +37,11 @@ export default [
         id: 'dokan-order-details',
         title: __( 'Order Details', 'dokan-lite' ),
         element: OrderDetails,
+        // The panel owns the chrome here: the order number as the title, a live status
+        // badge, Back, and the Edit Order action Pro would otherwise lose with the
+        // status-filter bar the fragment does not render.
+        header: <OrderDetailsHeader />,
         path: '/orders/:orderId',
-        backUrl: '/orders',
         exact: true,
         order: 5,
         parent: 'orders',

--- a/src/routing/routes.tsx
+++ b/src/routing/routes.tsx
@@ -5,6 +5,7 @@ import WithdrawRequests from '@src/dashboard/withdraw/WithdrawRequests';
 import App from '@src/dashboard/product-editor/App';
 import Products from '@src/dashboard/products';
 import Orders from '@src/dashboard/orders';
+import OrderDetails from '@src/dashboard/orders/OrderDetails';
 import ReverseWithdrawal from '@src/dashboard/reverse-withdraw';
 
 export default [
@@ -25,6 +26,22 @@ export default [
         exact: true,
         order: 5,
         capabilities: [ 'dokan_view_order_menu' ],
+    },
+    {
+        // Vendor order details. The view itself is server-rendered PHP delivered as an
+        // HTML fragment — see src/dashboard/orders/OrderDetails.tsx.
+        //
+        // This dynamic path cannot shadow Pro's `orders/edit/:id`: the router ranks
+        // static segments above dynamic ones regardless of registration order.
+        id: 'dokan-order-details',
+        title: __( 'Order Details', 'dokan-lite' ),
+        element: OrderDetails,
+        path: '/orders/:orderId',
+        backUrl: '/orders',
+        exact: true,
+        order: 5,
+        parent: 'orders',
+        capabilities: [ 'dokan_view_order' ],
     },
     {
         id: 'dokan-withdraw',

--- a/tests/php/src/REST/OrderDetailsFragmentTest.php
+++ b/tests/php/src/REST/OrderDetailsFragmentTest.php
@@ -425,6 +425,22 @@ class OrderDetailsFragmentTest extends DokanTestCase {
     }
 
     /**
+     * The panel opens order details in-panel unless a store turns it off.
+     *
+     * Pinned as a test because this default is the whole feature switching on for
+     * Vendors, and the escape hatch has to keep working.
+     *
+     * @return void
+     */
+    public function test_panel_order_details_is_enabled_by_default_and_can_be_turned_off(): void {
+        $this->assertTrue( dokan_is_vendor_panel_order_details_enabled() );
+
+        add_filter( 'dokan_vendor_panel_order_details_enabled', '__return_false' );
+
+        $this->assertFalse( dokan_is_vendor_panel_order_details_enabled(), 'The kill-switch must still restore full-page navigation' );
+    }
+
+    /**
      * The response shape is the API contract.
      *
      * @return void

--- a/tests/php/src/REST/OrderDetailsFragmentTest.php
+++ b/tests/php/src/REST/OrderDetailsFragmentTest.php
@@ -1,0 +1,444 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use RuntimeException;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Tests for the Vendor order details HTML fragment endpoint.
+ *
+ * This endpoint is the whole server-side seam for the Vendor panel order details
+ * migration: one request exercises the permission rule, the request-context
+ * simulation, the template render, hook dispatch, inline-data harvesting and the
+ * response shape together.
+ *
+ * @group dokan-order-controller
+ * @group dokan-authorization
+ *
+ * @covers \WeDevs\Dokan\REST\OrderController::get_order_details_html
+ * @covers \WeDevs\Dokan\REST\OrderController::get_order_details_html_permissions_check
+ * @covers \WeDevs\Dokan\Order\DetailsFragment::render
+ */
+class OrderDetailsFragmentTest extends DokanTestCase {
+
+    /**
+     * An order belonging to seller_id1.
+     *
+     * @var int
+     */
+    protected int $order_id;
+
+    /**
+     * Vendor staff belonging to seller_id1.
+     *
+     * @var int
+     */
+    protected int $vendor_staff_id;
+
+    /**
+     * Setup test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->order_id        = $this->create_single_vendor_order( $this->seller_id1 );
+        $this->vendor_staff_id = $this->create_vendor_staff( $this->seller_id1 );
+
+        // The customer-info block — and the extension point inside it — only renders
+        // when the order actually has an address.
+        $order = wc_get_order( $this->order_id );
+        $order->set_billing_first_name( 'Ada' );
+        $order->set_billing_last_name( 'Lovelace' );
+        $order->set_billing_address_1( '1 Analytical Engine Way' );
+        $order->set_billing_city( 'London' );
+        $order->set_billing_country( 'GB' );
+        $order->set_billing_email( 'ada@example.test' );
+        $order->save();
+
+        // Lite does not register the `vendor_staff` role — Pro does, and grants staff
+        // the Vendor's order capabilities. Model that here so the test isolates what
+        // this endpoint is actually responsible for: resolving ownership through the
+        // staff-aware helper rather than the raw current user id.
+        get_user_by( 'id', $this->vendor_staff_id )->add_cap( 'dokan_view_order' );
+    }
+
+    /**
+     * Build the fragment route for an order.
+     *
+     * @param int $order_id Order id.
+     *
+     * @return string
+     */
+    protected function fragment_route( int $order_id ): string {
+        return "orders/{$order_id}/details-html";
+    }
+
+    /**
+     * The route is registered across every order namespace.
+     *
+     * @return void
+     */
+    public function test_route_is_registered_on_every_order_namespace(): void {
+        $routes = $this->server->get_routes();
+
+        foreach ( [ 'dokan/v1', 'dokan/v2', 'dokan/v3' ] as $namespace ) {
+            $this->assertArrayHasKey(
+                "/{$namespace}/orders/(?P<id>[\\d]+)/details-html",
+                $routes,
+                "Fragment route should be available on {$namespace}"
+            );
+        }
+    }
+
+    /**
+     * A Vendor can open their own Vendor order.
+     *
+     * @return void
+     */
+    public function test_vendor_can_view_own_order(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertStringContainsString( 'dokan-order-details-wrap', $response->get_data()['html'] );
+    }
+
+    /**
+     * A Vendor is refused another Vendor's order.
+     *
+     * @return void
+     */
+    public function test_vendor_cannot_view_another_vendors_order(): void {
+        wp_set_current_user( $this->seller_id2 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 403, $response->get_status() );
+    }
+
+    /**
+     * Vendor staff get the same access the legacy page grants them.
+     *
+     * The legacy template resolves ownership through the staff-aware current-user
+     * helper, so staff must be able to open their Vendor's orders.
+     *
+     * @return void
+     */
+    public function test_vendor_staff_can_view_their_vendors_order(): void {
+        wp_set_current_user( $this->vendor_staff_id );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 200, $response->get_status() );
+    }
+
+    /**
+     * A marketplace admin can open any Vendor order.
+     *
+     * @return void
+     */
+    public function test_admin_can_view_any_order(): void {
+        wp_set_current_user( $this->admin_id );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 200, $response->get_status() );
+    }
+
+    /**
+     * A user without the order-viewing capability is refused.
+     *
+     * @return void
+     */
+    public function test_customer_without_capability_is_refused(): void {
+        wp_set_current_user( $this->customer_id );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 403, $response->get_status() );
+    }
+
+    /**
+     * A logged-out request is refused.
+     *
+     * @return void
+     */
+    public function test_logged_out_request_is_refused(): void {
+        wp_set_current_user( 0 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * A non-existent order id gets a clean error, not a fatal or a blank view.
+     *
+     * @return void
+     */
+    public function test_non_existent_order_returns_not_found(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( $this->fragment_route( 99999999 ) );
+
+        $this->assertEquals( 404, $response->get_status() );
+    }
+
+    /**
+     * A trashed order gets a clean error too.
+     *
+     * @return void
+     */
+    public function test_trashed_order_returns_not_found(): void {
+        $order = wc_get_order( $this->order_id );
+        $order->set_status( 'trash' );
+        $order->save();
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 404, $response->get_status() );
+    }
+
+    /**
+     * The compatibility promise, tested as an outcome.
+     *
+     * Every extension point inside the details template must still fire during a
+     * fragment render, and its output must reach the client. Asserting the hook
+     * "was fired" would test our implementation; asserting the marker arrives tests
+     * the promise Pro and third parties rely on.
+     *
+     * @return void
+     */
+    public function test_in_template_extension_hooks_reach_the_html(): void {
+        $hooks = [
+            'dokan_order_detail_after_order_items',
+            'dokan_order_details_after_customer_info',
+            'dokan_order_detail_after_order_general_details',
+            'dokan_order_detail_after_order_notes',
+            'dokan_order_details_fragment_before',
+            'dokan_order_details_fragment_after',
+        ];
+
+        foreach ( $hooks as $hook ) {
+            add_action(
+                $hook,
+                function () use ( $hook ) {
+                    echo '<span class="marker-' . esc_attr( $hook ) . '"></span>';
+                }
+            );
+        }
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        foreach ( $hooks as $hook ) {
+            $this->assertStringContainsString(
+                'marker-' . $hook,
+                $html,
+                "Output of {$hook} should reach the client"
+            );
+        }
+    }
+
+    /**
+     * Filters inside the template are honoured during a fragment render.
+     *
+     * @return void
+     */
+    public function test_in_template_filters_apply_during_render(): void {
+        add_filter( 'dokan_order_details_billing_address', fn () => 'FILTERED_BILLING_ADDRESS' );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        $this->assertStringContainsString( 'FILTERED_BILLING_ADDRESS', $html );
+    }
+
+    /**
+     * The render looks like a Vendor dashboard page to extension code, and stops
+     * looking like one the moment it is over.
+     *
+     * @return void
+     */
+    public function test_dashboard_detection_is_simulated_during_render_and_restored_after(): void {
+        $observed = null;
+
+        add_action(
+            'dokan_order_detail_after_order_items',
+            function () use ( &$observed ) {
+                $observed = [
+                    'is_dashboard' => dokan_is_seller_dashboard(),
+                    'order_id'     => isset( $_GET['order_id'] ) ? absint( $_GET['order_id'] ) : 0, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                    'nonce_valid'  => isset( $_GET['_wpnonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), 'dokan_view_order' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                ];
+            }
+        );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertTrue( $observed['is_dashboard'], 'Dashboard detection should report true during the render' );
+        $this->assertSame( $this->order_id, $observed['order_id'], 'The order id should be readable from the request' );
+        $this->assertNotFalse( $observed['nonce_valid'], 'A valid order-view nonce should be present' );
+
+        $this->assertFalse( dokan_is_seller_dashboard(), 'Dashboard detection should be restored after the render' );
+        $this->assertArrayNotHasKey( 'order_id', $_GET );
+        $this->assertArrayNotHasKey( '_wpnonce', $_GET );
+    }
+
+    /**
+     * The simulated context is restored even when a hooked callback throws.
+     *
+     * One request must not be able to leak state into the next.
+     *
+     * @return void
+     */
+    public function test_context_is_restored_when_a_hooked_callback_throws(): void {
+        add_action(
+            'dokan_order_detail_after_order_items',
+            function () {
+                throw new RuntimeException( 'Extension blew up' );
+            }
+        );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $before = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        try {
+            $this->get_request( $this->fragment_route( $this->order_id ) );
+        } catch ( RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            // The endpoint is allowed to surface the failure; what matters is cleanup.
+        }
+
+        $this->assertSame( $before, $_GET, 'Request superglobals should be restored' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $this->assertFalse( dokan_is_seller_dashboard(), 'Dashboard detection should be restored' );
+    }
+
+    /**
+     * Render-time inline data reaches the browser.
+     *
+     * Only handles that exist during a REST request can be captured — the fixture
+     * therefore registers on `init`, which is the rule published to extension authors.
+     *
+     * @return void
+     */
+    public function test_render_time_inline_script_data_is_returned(): void {
+        wp_register_script( 'dokan-test-fragment-handle', 'https://example.test/fragment.js', [], '1.0.0', true );
+
+        add_action(
+            'dokan_order_detail_after_order_items',
+            function () {
+                wp_add_inline_script( 'dokan-test-fragment-handle', 'let dokanTestFragmentData = { ok: true };', 'before' );
+            }
+        );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $inline_scripts = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['inline_scripts'];
+
+        $handles = wp_list_pluck( $inline_scripts, 'handle' );
+        $index   = array_search( 'dokan-test-fragment-handle', $handles, true );
+
+        $this->assertNotFalse( $index, 'Inline data attached during the render should be in the response' );
+        $this->assertSame( 'before', $inline_scripts[ $index ]['position'] );
+        $this->assertStringContainsString( 'dokanTestFragmentData', $inline_scripts[ $index ]['code'] );
+    }
+
+    /**
+     * Inline data attached to a handle that does not exist is skipped, not fatal.
+     *
+     * @return void
+     */
+    public function test_inline_data_for_unregistered_handle_is_skipped(): void {
+        add_action(
+            'dokan_order_detail_after_order_items',
+            function () {
+                wp_add_inline_script( 'dokan-handle-that-does-not-exist', 'let nope = 1;', 'before' );
+            }
+        );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertSame(
+            [],
+            wp_list_filter( $response->get_data()['inline_scripts'], [ 'handle' => 'dokan-handle-that-does-not-exist' ] )
+        );
+    }
+
+    /**
+     * The response shape is the API contract.
+     *
+     * @return void
+     */
+    public function test_response_shape_and_order_metadata(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $data  = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data();
+        $order = wc_get_order( $this->order_id );
+
+        $this->assertSame( [ 'html', 'inline_scripts', 'order' ], array_keys( $data ) );
+        $this->assertIsString( $data['html'] );
+        $this->assertIsArray( $data['inline_scripts'] );
+
+        $this->assertSame(
+            [ 'id', 'number', 'status', 'status_label', 'date_created' ],
+            array_keys( $data['order'] )
+        );
+        $this->assertSame( $this->order_id, $data['order']['id'] );
+        $this->assertSame( $order->get_order_number(), $data['order']['number'] );
+        $this->assertSame( $order->get_status(), $data['order']['status'] );
+        $this->assertNotEmpty( $data['order']['status_label'] );
+    }
+
+    /**
+     * The fragment reproduces the legacy content class names so third-party CSS
+     * written against the legacy page keeps matching.
+     *
+     * @return void
+     */
+    public function test_fragment_reproduces_legacy_content_class_names(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        foreach ( [ 'dokan-dashboard-wrap', 'dokan-dashboard-content', 'dokan-orders-content', 'dokan-orders-area' ] as $class ) {
+            $this->assertStringContainsString( $class, $html );
+        }
+    }
+
+    /**
+     * The page-level wrapper hooks deliberately do not fire — the panel already
+     * renders the navigation and status-filter bar they produce.
+     *
+     * @return void
+     */
+    public function test_page_level_wrapper_hooks_do_not_fire(): void {
+        foreach ( [ 'dokan_dashboard_wrap_start', 'dokan_order_inside_content', 'dokan_order_content_inside_before' ] as $hook ) {
+            add_action(
+                $hook,
+                function () use ( $hook ) {
+                    echo '<span class="page-marker-' . esc_attr( $hook ) . '"></span>';
+                }
+            );
+        }
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        $this->assertStringNotContainsString( 'page-marker-', $html );
+    }
+}

--- a/tests/php/src/REST/OrderDetailsFragmentTest.php
+++ b/tests/php/src/REST/OrderDetailsFragmentTest.php
@@ -463,6 +463,11 @@ class OrderDetailsFragmentTest extends DokanTestCase {
         foreach ( [ 'dokan-dashboard-wrap', 'dokan-dashboard-content', 'dokan-orders-content', 'dokan-orders-area' ] as $class ) {
             $this->assertStringContainsString( $class, $html );
         }
+
+        // The stylesheet hook that keeps the panel's React-oriented element resets and
+        // its page-layout rules off a bridged PHP surface. Without it the fragment
+        // renders at zero height.
+        $this->assertStringContainsString( 'dokan-legacy-fragment', $html );
     }
 
     /**

--- a/tests/php/src/REST/OrderDetailsFragmentTest.php
+++ b/tests/php/src/REST/OrderDetailsFragmentTest.php
@@ -137,7 +137,7 @@ class OrderDetailsFragmentTest extends DokanTestCase {
     }
 
     /**
-     * A marketplace admin can open any Vendor order.
+     * A marketplace admin reaches any Vendor order's endpoint.
      *
      * @return void
      */
@@ -147,6 +147,50 @@ class OrderDetailsFragmentTest extends DokanTestCase {
         $response = $this->get_request( $this->fragment_route( $this->order_id ) );
 
         $this->assertEquals( 200, $response->get_status() );
+    }
+
+    /**
+     * What an admin actually SEES matches the legacy page, byte for byte in intent.
+     *
+     * The details template guards on vendor ownership itself
+     * (`templates/orders/details.php`), and that guard has no admin bypass — so an
+     * admin opening the legacy order details URL is shown a not-yours notice rather
+     * than the order. The endpoint reproduces that exactly.
+     *
+     * This is asserted rather than left implicit because a status-code-only test reads
+     * as "admins can view order details" when they cannot. Granting admins more than
+     * the legacy page grants them would be a behaviour change to the permission model,
+     * not a UI migration.
+     *
+     * @return void
+     */
+    public function test_admin_sees_exactly_what_the_legacy_page_shows_them(): void {
+        wp_set_current_user( $this->admin_id );
+
+        $fragment_html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        ob_start();
+        dokan_get_template_part( 'orders/details', '', [ 'order_id' => $this->order_id ] );
+        $legacy_html = ob_get_clean();
+
+        $this->assertStringContainsString( $legacy_html, $fragment_html, 'The fragment shows an admin the same thing the legacy template does' );
+    }
+
+    /**
+     * A Vendor sees the real order, not the ownership notice.
+     *
+     * Guards the inverse of the admin case: it would be easy to "fix" the admin path
+     * in a way that silently swaps every Vendor's details view for an error too.
+     *
+     * @return void
+     */
+    public function test_vendor_sees_the_order_not_an_ownership_notice(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $html = $this->get_request( $this->fragment_route( $this->order_id ) )->get_data()['html'];
+
+        $this->assertStringContainsString( 'dokan-order-details-wrap', $html );
+        $this->assertStringNotContainsString( 'dokan-alert-danger', $html );
     }
 
     /**
@@ -291,8 +335,10 @@ class OrderDetailsFragmentTest extends DokanTestCase {
         $this->assertNotFalse( $observed['nonce_valid'], 'A valid order-view nonce should be present' );
 
         $this->assertFalse( dokan_is_seller_dashboard(), 'Dashboard detection should be restored after the render' );
+        // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Asserting the superglobal was cleaned up is the point.
         $this->assertArrayNotHasKey( 'order_id', $_GET );
         $this->assertArrayNotHasKey( '_wpnonce', $_GET );
+        // phpcs:enable WordPress.Security.NonceVerification.Recommended
     }
 
     /**

--- a/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
+++ b/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
@@ -28,3 +28,41 @@ add_filter(
         return '1' === sanitize_text_field( wp_unslash( $_GET['dokan_panel_order_details'] ) );
     }
 );
+
+/**
+ * Stand-in for a third-party extension, enabled with `?dokan_fragment_fixture=1`.
+ *
+ * Exercises the two things only a browser can confirm: that render-time inline data
+ * attached to an `init`-registered handle reaches the page as a real global, and that a
+ * script tag embedded in the rendered markup actually executes once injected (HTML
+ * assigned as a string never runs its scripts).
+ */
+add_action(
+    'init',
+    static function () {
+        if ( ! isset( $_GET['dokan_fragment_fixture'] ) ) {
+            return;
+        }
+
+        // Registered on `init`, not `wp_enqueue_scripts` — a REST request never reaches
+        // the latter, and wp_add_inline_script() silently no-ops for unknown handles.
+        wp_register_script( 'dokan-fragment-fixture', 'data:text/javascript,', [], '1.0.0', true );
+    }
+);
+
+add_action(
+    'dokan_order_detail_after_order_items',
+    static function ( $order ) {
+        if ( ! isset( $_GET['dokan_fragment_fixture'] ) ) {
+            return;
+        }
+
+        wp_add_inline_script(
+            'dokan-fragment-fixture',
+            'window.dokanFragmentFixture = ' . wp_json_encode( [ 'orderId' => $order->get_id() ] ) . ';',
+            'before'
+        );
+
+        echo '<script>window.dokanFragmentRawScriptRan = true;</script>';
+    }
+);

--- a/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
+++ b/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
@@ -30,17 +30,24 @@ add_filter(
 );
 
 /**
- * Stand-in for a third-party extension, enabled with `?dokan_fragment_fixture=1`.
+ * Stand-in for a third-party extension, enabled by the `dokan_fragment_fixture` cookie.
  *
  * Exercises the two things only a browser can confirm: that render-time inline data
  * attached to an `init`-registered handle reaches the page as a real global, and that a
  * script tag embedded in the rendered markup actually executes once injected (HTML
  * assigned as a string never runs its scripts).
+ *
+ * A cookie rather than a query argument, because the fragment is rendered by a *separate*
+ * REST request. Query arguments on the panel page URL never reach it; cookies do.
  */
+function dokan_test_fragment_fixture_enabled(): bool {
+    return isset( $_COOKIE['dokan_fragment_fixture'] );
+}
+
 add_action(
     'init',
     static function () {
-        if ( ! isset( $_GET['dokan_fragment_fixture'] ) ) {
+        if ( ! dokan_test_fragment_fixture_enabled() ) {
             return;
         }
 
@@ -53,7 +60,7 @@ add_action(
 add_action(
     'dokan_order_detail_after_order_items',
     static function ( $order ) {
-        if ( ! isset( $_GET['dokan_fragment_fixture'] ) ) {
+        if ( ! dokan_test_fragment_fixture_enabled() ) {
             return;
         }
 

--- a/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
+++ b/tests/pw/mu-plugins/dokan-panel-order-details-toggle.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Dokan — Vendor panel order details toggle (E2E)
+ * Description: TEST-ONLY. Drives the `dokan_vendor_panel_order_details_enabled`
+ *              kill-switch from a query argument so a spec can exercise both
+ *              states deterministically:
+ *
+ *                ?dokan_panel_order_details=1  → in-panel order details
+ *                ?dokan_panel_order_details=0  → legacy full-page navigation
+ *
+ *              Anything else leaves the shipped default alone. Driving this from
+ *              the request rather than an option means there is no global state
+ *              to reset between tests and no ordering coupling between specs.
+ *              NOT for production use.
+ *
+ * @package Dokan\Tests
+ */
+
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+
+add_filter(
+    'dokan_vendor_panel_order_details_enabled',
+    static function ( $enabled ) {
+        if ( ! isset( $_GET['dokan_panel_order_details'] ) ) {
+            return $enabled;
+        }
+
+        return '1' === sanitize_text_field( wp_unslash( $_GET['dokan_panel_order_details'] ) );
+    }
+);

--- a/tests/pw/tests/e2e/orders/newOrders.spec.ts
+++ b/tests/pw/tests/e2e/orders/newOrders.spec.ts
@@ -186,6 +186,129 @@ test.describe('Orders (React) functionality', () => {
         });
     });
 
+    // ============================================
+    // VENDOR — panel order details (server-rendered HTML fragment)
+    //
+    // This is the only seam that can observe re-binding after injection. The HTML is
+    // perfect either way; a server-side test cannot tell whether the handlers are
+    // actually attached. The kill-switch ships OFF, so every case states which side of
+    // it it wants (see tests/pw/mu-plugins/dokan-panel-order-details-toggle.php).
+    // ============================================
+    test.describe('vendor order details in the panel', () => {
+        let ctx: BrowserContext;
+        let page: Page;
+        let orders: NewOrdersPage;
+
+        test.beforeEach(async ({ browser }) => {
+            ctx = await browser.newContext({ storageState: v1 });
+            page = await ctx.newPage();
+            orders = new NewOrdersPage(page);
+        });
+
+        test.afterEach(async () => {
+            await page?.close();
+            await ctx?.close();
+        });
+
+        test('vendor opens order details in-panel without a document reload', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelList(true);
+
+            const { reloaded } = await orders.openFirstOrderInPanel();
+
+            expect(reloaded, 'opening an order does not reload the document').toBe(false);
+            await expect(orders.detailsFragment, 'server-rendered details markup is on the page').toBeVisible();
+            expect(page.url(), 'URL is the panel details route').toMatch(/#\/orders\/\d+/);
+            expect(await orders.hasNoPhpFatal(), 'no PHP fatal').toBe(true);
+        });
+
+        test('vendor deep-links straight to the panel details route', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelDetails(seededOrderId, true);
+
+            await expect(orders.detailsFragment).toBeVisible();
+            expect(await orders.hasNoPhpFatal(), 'no PHP fatal').toBe(true);
+        });
+
+        test('panel header shows the order number and status', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelDetails(seededOrderId, true);
+
+            await expect(orders.headerTitle).toContainText(`#${seededOrderId}`);
+            await expect(orders.headerBadge, 'header carries a status badge').toBeVisible();
+        });
+
+        test('the re-init event fires on both channels after injection', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            const fired = await orders.captureReInitEvent(seededOrderId);
+
+            expect(fired.viaHooks, 'fired through the JS hooks system').toBe(true);
+            expect(fired.viaJQuery, 'fired as a jQuery event on the body').toBe(true);
+        });
+
+        test('vendor changes status inline and the header badge follows', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            const [, , orderId] = await new ApiUtils(await request.newContext()).createOrderWithStatus(
+                process.env.PRODUCT_ID as string,
+                { ...payloads.createOrder, line_items: [{ product_id: process.env.PRODUCT_ID, quantity: 1 }] },
+                'wc-processing',
+                payloads.vendorAuth,
+            );
+
+            await orders.gotoPanelDetails(orderId, true);
+            const before = (await orders.headerBadge.textContent())?.trim();
+
+            await orders.changeStatusInFragment('wc-completed');
+
+            await expect(orders.statusLabel, 'the fragment reflects the new status').toContainText(/completed/i);
+            await expect
+                .poll(async () => (await orders.headerBadge.textContent())?.trim(), {
+                    message: 'the panel header badge follows the inline change',
+                    timeout: 10000,
+                })
+                .not.toBe(before);
+        });
+
+        test('vendor adds and deletes an order note in-panel', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelDetails(seededOrderId, true);
+
+            const before = await orders.orderNotes.count();
+            await orders.addOrderNoteInFragment(`Panel fragment note ${Date.now()}`);
+            expect(await orders.orderNotes.count(), 'note was added').toBeGreaterThan(before);
+
+            const afterAdd = await orders.orderNotes.count();
+            await orders.deleteFirstOrderNoteInFragment();
+            expect(await orders.orderNotes.count(), 'note was deleted').toBeLessThan(afterAdd);
+        });
+
+        test('back returns to the list and another order still opens', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelList(true);
+            await orders.openFirstOrderInPanel();
+
+            await orders.headerBackButton.click();
+            await page.waitForURL(/#\/orders$/, { timeout: 15000 });
+            await orders.waitForReady();
+            expect(await orders.getRowCount(), 'the list is back').toBeGreaterThan(0);
+
+            // Re-opening must not double-bind or leave a stale fragment behind.
+            const { reloaded } = await orders.openFirstOrderInPanel();
+            expect(reloaded).toBe(false);
+            await expect(orders.detailsFragment).toBeVisible();
+        });
+
+        test('with the kill-switch off the list navigates to the legacy page', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelList(false);
+            await orders.viewFirstOrder();
+
+            expect(page.url(), 'landed on the legacy order details URL').toContain('order_id=');
+            expect(page.url(), 'did not enter the panel details route').not.toMatch(/#\/orders\/\d+/);
+            expect(await orders.hasNoPhpFatal(), 'legacy page has no PHP fatal').toBe(true);
+        });
+
+        test('the legacy order details URL still renders unchanged', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelList(false);
+            await orders.viewFirstOrder();
+
+            await expect(page.locator('.dokan-order-details-wrap').first(), 'legacy details markup renders').toBeVisible();
+            expect(await orders.hasNoPhpFatal(), 'no PHP fatal').toBe(true);
+        });
+    });
+
     // Bulk status change mutates real orders, so each case seeds its own orders
     // and operates only on those (selected by id), never select-all.
     test.describe('vendor bulk actions', () => {

--- a/tests/pw/tests/e2e/orders/newOrders.spec.ts
+++ b/tests/pw/tests/e2e/orders/newOrders.spec.ts
@@ -267,28 +267,44 @@ test.describe('Orders (React) functionality', () => {
         test('vendor adds and deletes an order note in-panel', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
             await orders.gotoPanelDetails(seededOrderId, true);
 
-            const before = await orders.orderNotes.count();
-            await orders.addOrderNoteInFragment(`Panel fragment note ${Date.now()}`);
-            expect(await orders.orderNotes.count(), 'note was added').toBeGreaterThan(before);
-
-            const afterAdd = await orders.orderNotes.count();
+            // The page object asserts the count moved, so reaching here is the result.
+            await orders.addOrderNoteInFragment(`Panel fragment note ${seededOrderId}`);
             await orders.deleteFirstOrderNoteInFragment();
-            expect(await orders.orderNotes.count(), 'note was deleted').toBeLessThan(afterAdd);
         });
 
-        test('back returns to the list and another order still opens', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+        test('back returns to the list with its filters still applied', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
             await orders.gotoPanelList(true);
-            await orders.openFirstOrderInPanel();
 
+            // Put the list into a non-default state, so "Back" restoring it is
+            // observable rather than indistinguishable from a fresh load.
+            await orders.fillSearch(String(seededOrderId));
+            const searchBefore = await orders.getAppliedSearchTerm();
+            expect(searchBefore, 'the list is in a filtered state to begin with').not.toBe('');
+
+            await orders.openFirstOrderInPanel();
             await orders.headerBackButton.click();
             await page.waitForURL(/#\/orders$/, { timeout: 15000 });
             await orders.waitForReady();
+
+            expect(await orders.getAppliedSearchTerm(), 'the search term survived the round trip').toBe(searchBefore);
             expect(await orders.getRowCount(), 'the list is back').toBeGreaterThan(0);
 
             // Re-opening must not double-bind or leave a stale fragment behind.
             const { reloaded } = await orders.openFirstOrderInPanel();
             expect(reloaded).toBe(false);
             await expect(orders.detailsFragment).toBeVisible();
+        });
+
+        test('render-time inline data reaches the browser as a real global', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
+            await orders.gotoPanelDetails(seededOrderId, true, { withInlineDataFixture: true });
+
+            // The fixture handle is registered on `init` and attaches its data during
+            // the render — the exact path the register-on-init rule exists to protect.
+            const injected = await page.evaluate(() => ( window as any ).dokanFragmentFixture);
+            expect(injected?.orderId, 'inline data is visible as a global').toBeTruthy();
+
+            const fromRawTag = await page.evaluate(() => ( window as any ).dokanFragmentRawScriptRan);
+            expect(fromRawTag, 'a script tag embedded in the rendered HTML executed').toBe(true);
         });
 
         test('with the kill-switch off the list navigates to the legacy page', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
@@ -304,7 +320,7 @@ test.describe('Orders (React) functionality', () => {
             await orders.gotoPanelList(false);
             await orders.viewFirstOrder();
 
-            await expect(page.locator('.dokan-order-details-wrap').first(), 'legacy details markup renders').toBeVisible();
+            await expect(orders.legacyDetailsWrap, 'legacy details markup renders').toBeVisible();
             expect(await orders.hasNoPhpFatal(), 'no PHP fatal').toBe(true);
         });
     });

--- a/tests/pw/tests/e2e/orders/newOrders.spec.ts
+++ b/tests/pw/tests/e2e/orders/newOrders.spec.ts
@@ -296,7 +296,8 @@ test.describe('Orders (React) functionality', () => {
         });
 
         test('render-time inline data reaches the browser as a real global', { tag: ['@lite', '@vendor', '@new-ui'] }, async () => {
-            await orders.gotoPanelDetails(seededOrderId, true, { withInlineDataFixture: true });
+            await orders.enableInlineDataFixture();
+            await orders.gotoPanelDetails(seededOrderId, true);
 
             // The fixture handle is registered on `init` and attaches its data during
             // the render — the exact path the register-on-init rule exists to protect.

--- a/tests/pw/tests/e2e/orders/newOrdersPage.ts
+++ b/tests/pw/tests/e2e/orders/newOrdersPage.ts
@@ -1,5 +1,5 @@
 import { Locator, Page, expect } from '@playwright/test';
-import { closeAnnouncementModal, toPath } from '@utils/helpers';
+import { BASE_URL, closeAnnouncementModal, toPath } from '@utils/helpers';
 import {
     REACT_ROOT,
     ROW_ACTIONS_BTN,
@@ -99,15 +99,6 @@ export const statusChangeActions = [
 // come from @utils/dataViews; the REST-gated search/tab/settle orchestration
 // below is orders-specific and stays local.
 // ============================================
-/** Extra server-side fixtures a panel-details navigation can switch on. */
-export interface PanelDetailsOpts {
-    /**
-     * Register a stand-in extension that attaches render-time inline data and embeds a
-     * raw script tag — see tests/pw/mu-plugins/dokan-panel-order-details-toggle.php.
-     */
-    withInlineDataFixture?: boolean;
-}
-
 export class NewOrdersPage {
     readonly page: Page;
     readonly url = toPath('dashboard/new/#/orders');
@@ -467,9 +458,18 @@ export class NewOrdersPage {
         return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders`);
     }
 
-    panelDetailsUrl(orderId: string | number, fragmentEnabled = true, opts: PanelDetailsOpts = {}): string {
-        const fixture = opts.withInlineDataFixture ? '&dokan_fragment_fixture=1' : '';
-        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}${fixture}#/orders/${orderId}`);
+    panelDetailsUrl(orderId: string | number, fragmentEnabled = true): string {
+        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders/${orderId}`);
+    }
+
+    /**
+     * Switch on the stand-in extension that emits render-time inline data.
+     *
+     * A cookie, not a query argument: the fragment is rendered by a *separate* REST
+     * request, and query arguments on the panel page URL never reach it.
+     */
+    async enableInlineDataFixture(): Promise<void> {
+        await this.page.context().addCookies([{ name: 'dokan_fragment_fixture', value: '1', url: BASE_URL }]);
     }
 
     get detailsFragment(): Locator { return this.page.locator(newOrdersSelectors.detailsFragment).first(); }
@@ -488,8 +488,8 @@ export class NewOrdersPage {
     }
 
     /** Deep-link straight to the panel details route. */
-    async gotoPanelDetails(orderId: string | number, fragmentEnabled = true, opts: PanelDetailsOpts = {}): Promise<void> {
-        await this.page.goto(this.panelDetailsUrl(orderId, fragmentEnabled, opts));
+    async gotoPanelDetails(orderId: string | number, fragmentEnabled = true): Promise<void> {
+        await this.page.goto(this.panelDetailsUrl(orderId, fragmentEnabled));
         await this.page.waitForLoadState('domcontentloaded');
         await this.waitForFragment();
     }

--- a/tests/pw/tests/e2e/orders/newOrdersPage.ts
+++ b/tests/pw/tests/e2e/orders/newOrdersPage.ts
@@ -52,6 +52,33 @@ export const newOrdersSelectors = {
     // The orders list REST endpoint the React hook fetches from
     // (useOrders → apiFetch '/dokan/v1/orders'). Used to wait on refetches.
     ordersRestPath: '/dokan/v1/orders',
+
+    // ============================================
+    // PANEL ORDER DETAILS
+    // The details view is server-rendered PHP injected into the SPA as an HTML
+    // fragment, so these selectors are the LEGACY markup's — deliberately the
+    // same ones the legacy page uses. If they drift, the compatibility promise
+    // has been broken.
+    // ============================================
+    detailsFragment: '.dokan-order-details-fragment',
+    detailsWrapper: '.dokan-react-order-details',
+    detailsRestPath: '/details-html',
+    // Panel-owned chrome (src/dashboard/orders/OrderDetailsHeader.tsx).
+    headerTitle: '.dokan-header-title-section h3',
+    headerBadge: '.dokan-header-title-section [class*="dokan-badge"]',
+    headerBackButton: '.dokan-header-actions button:has-text("Back")',
+    // Inline status change.
+    editStatusLink: 'a.dokan-edit-status',
+    statusForm: 'form#dokan-order-status-form',
+    statusSelect: 'form#dokan-order-status-form #order_status',
+    statusSubmit: 'form#dokan-order-status-form input[type="submit"]',
+    statusLabel: 'ul.order-status label.dokan-label',
+    // Order notes.
+    addNoteForm: 'form#add-order-note',
+    addNoteContent: '#add-note-content',
+    addNoteSubmit: 'form#add-order-note input[name="add_order_note"]',
+    orderNote: '#dokan-order-notes ul.order_notes li.note',
+    deleteNote: '#dokan-order-notes a.delete_note',
 } as const;
 
 // Status-change menu items DataViews exposes (depend on the current status).
@@ -413,6 +440,147 @@ export class NewOrdersPage {
             await this.confirmDialog.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => undefined);
         }
         await this.waitForListSettled();
+    }
+
+    // ============================================
+    // PANEL ORDER DETAILS
+    //
+    // The `dokan_vendor_panel_order_details_enabled` kill-switch ships OFF, so every
+    // helper here states which side of it it wants. The E2E mu-plugin
+    // (tests/pw/mu-plugins/dokan-panel-order-details-toggle.php) reads
+    // `?dokan_panel_order_details=` and drives the filter from it, so the two states
+    // are exercised per-navigation with no global state to reset between tests.
+    // ============================================
+    panelListUrl(fragmentEnabled = true): string {
+        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders`);
+    }
+
+    panelDetailsUrl(orderId: string | number, fragmentEnabled = true): string {
+        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders/${orderId}`);
+    }
+
+    get detailsFragment(): Locator { return this.page.locator(newOrdersSelectors.detailsFragment).first(); }
+    get headerTitle(): Locator { return this.page.locator(newOrdersSelectors.headerTitle).first(); }
+    get headerBadge(): Locator { return this.page.locator(newOrdersSelectors.headerBadge).first(); }
+    get headerBackButton(): Locator { return this.page.locator(newOrdersSelectors.headerBackButton).first(); }
+    get orderNotes(): Locator { return this.page.locator(newOrdersSelectors.orderNote); }
+    get statusLabel(): Locator { return this.page.locator(newOrdersSelectors.statusLabel).first(); }
+
+    /** Open the panel order list with the fragment route on (or off). */
+    async gotoPanelList(fragmentEnabled = true): Promise<void> {
+        await this.page.goto(this.panelListUrl(fragmentEnabled));
+        await this.page.waitForLoadState('domcontentloaded');
+        await this.waitForReady();
+    }
+
+    /** Deep-link straight to the panel details route. */
+    async gotoPanelDetails(orderId: string | number, fragmentEnabled = true): Promise<void> {
+        await this.page.goto(this.panelDetailsUrl(orderId, fragmentEnabled));
+        await this.page.waitForLoadState('domcontentloaded');
+        await this.waitForFragment();
+    }
+
+    /** Wait until the server-rendered details markup is actually on the page. */
+    async waitForFragment(timeoutMs = 30000): Promise<void> {
+        await this.reactRoot.waitFor({ state: 'visible', timeout: timeoutMs });
+        await this.detailsFragment.waitFor({ state: 'visible', timeout: timeoutMs });
+    }
+
+    /**
+     * Open the first order from the list without a document reload.
+     *
+     * Asserting "no reload" needs a marker that a navigation would destroy, so we
+     * stamp one on `window` and check it survived.
+     */
+    async openFirstOrderInPanel(): Promise<{ reloaded: boolean }> {
+        await this.page.evaluate(() => {
+            ( window as any ).__dokanNoReloadMarker = true;
+        });
+
+        await this.openRowActionMenuByIndex(0);
+        await Promise.all([
+            this.page.waitForURL(/#\/orders\/\d+/, { timeout: 15000 }).catch(() => undefined),
+            this.clickActionMenuItem('View'),
+        ]);
+        await this.waitForFragment();
+
+        const survived = await this.page.evaluate(() => Boolean(( window as any ).__dokanNoReloadMarker));
+        return { reloaded: !survived };
+    }
+
+    /**
+     * Change the order status from inside the fragment.
+     *
+     * This is the flow no server-side test can see: the handler has to be bound to
+     * markup that did not exist when the script ran.
+     */
+    async changeStatusInFragment(status: string): Promise<void> {
+        await this.page.locator(newOrdersSelectors.editStatusLink).first().click();
+        await this.page.locator(newOrdersSelectors.statusForm).first().waitFor({ state: 'visible', timeout: 10000 });
+        await this.page.locator(newOrdersSelectors.statusSelect).first().selectOption(status);
+
+        const request = this.page
+            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+            .catch(() => null);
+
+        await this.page.locator(newOrdersSelectors.statusSubmit).first().click();
+        await request;
+        await this.page.waitForTimeout(1000);
+    }
+
+    /** Add an order note from inside the fragment. */
+    async addOrderNoteInFragment(note: string): Promise<void> {
+        await this.page.locator(newOrdersSelectors.addNoteContent).first().fill(note);
+
+        const request = this.page
+            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+            .catch(() => null);
+
+        await this.page.locator(newOrdersSelectors.addNoteSubmit).first().click();
+        await request;
+        await this.page.waitForTimeout(1000);
+    }
+
+    /** Delete the first order note from inside the fragment. */
+    async deleteFirstOrderNoteInFragment(): Promise<void> {
+        const request = this.page
+            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+            .catch(() => null);
+
+        await this.page.locator(newOrdersSelectors.deleteNote).first().click();
+        await request;
+        await this.page.waitForTimeout(1000);
+    }
+
+    /** Whether the documented re-init event reached both channels. */
+    async captureReInitEvent(orderId: string | number): Promise<{ viaHooks: boolean; viaJQuery: boolean }> {
+        await this.page.goto(this.panelListUrl(true));
+        await this.page.waitForLoadState('domcontentloaded');
+
+        await this.page.evaluate(() => {
+            const w = window as any;
+            w.__dokanReInit = { viaHooks: false, viaJQuery: false };
+
+            w.wp?.hooks?.addAction?.(
+                'dokan-order-details-fragment-rendered',
+                'dokan-e2e/probe',
+                () => {
+                    w.__dokanReInit.viaHooks = true;
+                }
+            );
+
+            w.jQuery?.(document.body).on('dokan-order-details-fragment-rendered', () => {
+                w.__dokanReInit.viaJQuery = true;
+            });
+        });
+
+        await this.page.evaluate(( id ) => {
+            window.location.hash = `#/orders/${ id }`;
+        }, String(orderId));
+
+        await this.waitForFragment();
+
+        return this.page.evaluate(() => ( window as any ).__dokanReInit);
     }
 
     /** Click the first row's "View" action and wait for navigation away from the list. */

--- a/tests/pw/tests/e2e/orders/newOrdersPage.ts
+++ b/tests/pw/tests/e2e/orders/newOrdersPage.ts
@@ -63,6 +63,9 @@ export const newOrdersSelectors = {
     detailsFragment: '.dokan-order-details-fragment',
     detailsWrapper: '.dokan-react-order-details',
     detailsRestPath: '/details-html',
+    // The details markup itself — identical on the legacy page and in the panel,
+    // which is the point.
+    legacyDetailsWrap: '.dokan-order-details-wrap',
     // Panel-owned chrome (src/dashboard/orders/OrderDetailsHeader.tsx).
     headerTitle: '.dokan-header-title-section h3',
     headerBadge: '.dokan-header-title-section [class*="dokan-badge"]',
@@ -96,6 +99,15 @@ export const statusChangeActions = [
 // come from @utils/dataViews; the REST-gated search/tab/settle orchestration
 // below is orders-specific and stays local.
 // ============================================
+/** Extra server-side fixtures a panel-details navigation can switch on. */
+export interface PanelDetailsOpts {
+    /**
+     * Register a stand-in extension that attaches render-time inline data and embeds a
+     * raw script tag — see tests/pw/mu-plugins/dokan-panel-order-details-toggle.php.
+     */
+    withInlineDataFixture?: boolean;
+}
+
 export class NewOrdersPage {
     readonly page: Page;
     readonly url = toPath('dashboard/new/#/orders');
@@ -455,8 +467,9 @@ export class NewOrdersPage {
         return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders`);
     }
 
-    panelDetailsUrl(orderId: string | number, fragmentEnabled = true): string {
-        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}#/orders/${orderId}`);
+    panelDetailsUrl(orderId: string | number, fragmentEnabled = true, opts: PanelDetailsOpts = {}): string {
+        const fixture = opts.withInlineDataFixture ? '&dokan_fragment_fixture=1' : '';
+        return toPath(`dashboard/new/?dokan_panel_order_details=${fragmentEnabled ? 1 : 0}${fixture}#/orders/${orderId}`);
     }
 
     get detailsFragment(): Locator { return this.page.locator(newOrdersSelectors.detailsFragment).first(); }
@@ -465,6 +478,7 @@ export class NewOrdersPage {
     get headerBackButton(): Locator { return this.page.locator(newOrdersSelectors.headerBackButton).first(); }
     get orderNotes(): Locator { return this.page.locator(newOrdersSelectors.orderNote); }
     get statusLabel(): Locator { return this.page.locator(newOrdersSelectors.statusLabel).first(); }
+    get legacyDetailsWrap(): Locator { return this.page.locator(newOrdersSelectors.legacyDetailsWrap).first(); }
 
     /** Open the panel order list with the fragment route on (or off). */
     async gotoPanelList(fragmentEnabled = true): Promise<void> {
@@ -474,8 +488,8 @@ export class NewOrdersPage {
     }
 
     /** Deep-link straight to the panel details route. */
-    async gotoPanelDetails(orderId: string | number, fragmentEnabled = true): Promise<void> {
-        await this.page.goto(this.panelDetailsUrl(orderId, fragmentEnabled));
+    async gotoPanelDetails(orderId: string | number, fragmentEnabled = true, opts: PanelDetailsOpts = {}): Promise<void> {
+        await this.page.goto(this.panelDetailsUrl(orderId, fragmentEnabled, opts));
         await this.page.waitForLoadState('domcontentloaded');
         await this.waitForFragment();
     }
@@ -516,40 +530,53 @@ export class NewOrdersPage {
      */
     async changeStatusInFragment(status: string): Promise<void> {
         await this.page.locator(newOrdersSelectors.editStatusLink).first().click();
-        await this.page.locator(newOrdersSelectors.statusForm).first().waitFor({ state: 'visible', timeout: 10000 });
+        await expect(this.page.locator(newOrdersSelectors.statusForm).first()).toBeVisible({ timeout: 10000 });
         await this.page.locator(newOrdersSelectors.statusSelect).first().selectOption(status);
 
-        const request = this.page
-            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+        // The legacy handler POSTs to admin-ajax and swaps the status label in place,
+        // so the response landing IS the observable outcome — no fixed wait needed.
+        const response = this.page
+            .waitForResponse(r => r.url().includes('admin-ajax.php') && r.request().method() === 'POST', { timeout: 15000 })
             .catch(() => null);
 
         await this.page.locator(newOrdersSelectors.statusSubmit).first().click();
-        await request;
-        await this.page.waitForTimeout(1000);
+        await response;
     }
 
     /** Add an order note from inside the fragment. */
     async addOrderNoteInFragment(note: string): Promise<void> {
+        const before = await this.orderNotes.count();
+
         await this.page.locator(newOrdersSelectors.addNoteContent).first().fill(note);
 
-        const request = this.page
-            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+        const response = this.page
+            .waitForResponse(r => r.url().includes('admin-ajax.php') && r.request().method() === 'POST', { timeout: 15000 })
             .catch(() => null);
 
         await this.page.locator(newOrdersSelectors.addNoteSubmit).first().click();
-        await request;
-        await this.page.waitForTimeout(1000);
+        await response;
+
+        // The handler prepends the new <li>; wait on that rather than the clock.
+        await expect(this.orderNotes).toHaveCount(before + 1, { timeout: 10000 });
     }
 
     /** Delete the first order note from inside the fragment. */
     async deleteFirstOrderNoteInFragment(): Promise<void> {
-        const request = this.page
-            .waitForRequest(r => r.url().includes('admin-ajax.php') && r.method() === 'POST', { timeout: 15000 })
+        const before = await this.orderNotes.count();
+
+        const response = this.page
+            .waitForResponse(r => r.url().includes('admin-ajax.php') && r.request().method() === 'POST', { timeout: 15000 })
             .catch(() => null);
 
         await this.page.locator(newOrdersSelectors.deleteNote).first().click();
-        await request;
-        await this.page.waitForTimeout(1000);
+        await response;
+
+        await expect(this.orderNotes).toHaveCount(before - 1, { timeout: 10000 });
+    }
+
+    /** The search term currently applied to the list — used to prove Back preserved it. */
+    async getAppliedSearchTerm(): Promise<string> {
+        return (await this.searchInput.inputValue().catch(() => '')) ?? '';
     }
 
     /** Whether the documented re-init event reached both channels. */

--- a/types/externals.d.ts
+++ b/types/externals.d.ts
@@ -85,6 +85,8 @@ declare module '@dokan/components' {
   export const PriceInput: any;
   export const PriceHtml: any;
   export const CustomerFilter: any;
+  export const DateRangePicker: any;
+  export const DateTimeHtml: any;
   export const ShortContent: any;
   export const DokanTooltip: any;
 }
@@ -101,6 +103,7 @@ declare module '@dokan/hooks' {
   export const useWindowDimensions: any;
   export const useCurrentUser: any;
   export const useCustomerSearch: any;
+  export const usePermission: any;
   export const ViewportDimensions: any;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)
* [x] I've included developer documentation

### Changes proposed in this Pull Request:

Brings **Vendor order details into the Vendor panel without rewriting it in React**.

The details view stays 100% server-rendered PHP — so every Pro and third-party hook keeps firing — and is delivered to the React panel as an HTML fragment over a Dokan REST endpoint. This is a migration-sequencing change, not a redesign: nothing about *what* the details view shows changes, only *where it can be rendered*.

A React rewrite was rejected outright. The template fires 11 extension hooks plus WooCommerce's item hooks, and Pro injects shipments, delivery time, store pickup and the entire item/refund table through them. Rewriting would delete all of it silently — affected Vendors would get no error, just missing features.

**What's here**

* **REST endpoint** — `GET /dokan/v1/orders/<id>/details-html` renders the existing template and returns its markup. Lands on v1/v2/v3 automatically because the v2 controller re-registers its parent's routes and v3 extends v2.
* **Permission rule** — order-viewing capability plus ownership resolved through Dokan's staff-aware current-user helper, so Vendor staff get the access the legacy page grants them. The shared single-order rule is deliberately *not* reused: it compares against the raw current user id and refuses staff. Real bug, but fixing it changes already-shipped public routes and belongs in its own change.
* **Request-context simulation** — for the duration of the render only, dashboard detection reports true, the orders query var and order id are present, and a valid order-view nonce is fabricated. Restored in a `finally`, so a throwing callback cannot leak state into the next request. Authorization is established by the permission rule before any of this; CSRF is preserved by the REST nonce at the outer layer.
* **Re-init contract** — `dokan-order-details-fragment-rendered` fires after injection, published both through the JS hooks system and as a jQuery event on the body. The legacy order script subscribes to it exactly as a third party would.
* **Render-time inline data** — the endpoint harvests it from the script registry; the panel injects each entry as a real `<script>` element (never `eval` — the payloads declare top-level `let`, only globally visible at global scope).
* **Panel header** — order number, live status badge, back-with-filters-preserved, and an **Edit Order** action replacing the affordance Pro attaches to the status-filter bar, which the fragment deliberately does not render.
* **Kill-switch** — `dokan_vendor_panel_order_details_enabled`, on by default. The legacy URL keeps working indefinitely with no redirect, so reverting is a one-line snippet with no data or routing consequences.

**Prefactor** (first commit, independently revertible): the legacy order JavaScript becomes re-initialisable — handlers delegate from `document`, and one-time initialisation (tooltips, date picker, select2) moves into re-runnable functions.

### Related Pull Request(s)

* dokan-pro: https://github.com/getdokan/dokan-pro/pull/5958

### Closes

* Closes getdokan/plugin-internal-tasks#2136
* Closes getdokan/plugin-internal-tasks#2138
* Closes getdokan/plugin-internal-tasks#2139
* Closes getdokan/plugin-internal-tasks#2140
* Closes getdokan/plugin-internal-tasks#2141
* Closes getdokan/plugin-internal-tasks#2143
* Closes getdokan/plugin-internal-tasks#2144
* Spec: getdokan/plugin-internal-tasks#2133 · Umbrella: getdokan/plugin-internal-tasks#2134

### How to test the changes in this Pull Request:

1. As a Vendor, open **Dashboard → Orders** in the panel (`/dashboard/new/#/orders`) and click any order. Details open **in place, with no page reload**.
2. The panel header shows the order number and a status badge, plus **Back** and **Edit Order**.
3. Change the order status inline — the fragment *and* the header badge both update, without a reload.
4. Add an order note, then delete it.
5. Deep-link straight to `#/orders/<id>` — it renders.
6. Open the legacy URL `…/dashboard/orders/?order_id=<id>&_wpnonce=<nonce>` — unchanged, including the email-link entry path.
7. Add `add_filter( 'dokan_vendor_panel_order_details_enabled', '__return_false' );` — the list goes back to full-page navigation to the legacy page.
8. With Pro active, confirm the Delivery Time panel renders and its date picker opens.

**Automated:** `OrderDetailsFragmentTest` — 21 tests, 51 assertions, covering the permission matrix (own order, another Vendor's refused, staff granted, admin, missing capability, non-existent and trashed ids), the compatibility promise (a callback on each in-template hook has its marker in the returned HTML), context simulation asserted *during* the render and restored after including when a callback throws, inline-data harvesting, response shape, and the kill-switch in both directions.

Playwright: 10 cases added to the existing React orders spec, driving list → details with no document reload, the re-init event on both channels, inline status change reflected in the header, note add/delete, deep link, and both sides of the kill-switch.

### Changelog entry

*Vendor order details now open inside the Vendor panel*

**Previous behaviour:** clicking an order in the Vendor panel's order list triggered a full WordPress page load into the legacy dashboard — different chrome, different layout, and lost list state (filters, page, scroll).

**New behaviour:** order details open in place inside the panel, with the panel's own header, back button and status badge, and no page reload. The details view itself is unchanged — the same server-rendered template, so every Pro and third-party hook keeps firing and theme template overrides keep applying. The legacy order-details URL continues to work indefinitely, and `dokan_vendor_panel_order_details_enabled` returns the panel to full-page navigation for any store that needs it.

### Before Changes

Clicking an order in the panel left the panel entirely and loaded the legacy dashboard page.

### After Changes

Order details render inside the panel: the panel header carries the order number and a live status badge, with the server-rendered fragment below it and Pro's Delivery Time panel contributing into it. Verified end to end in a browser with Pro active — screenshots to be attached.

### Notes for the reviewer

Three things are deliberate and should not be "fixed":

1. **Page-level wrapper hooks do not fire in a fragment** (`dokan_dashboard_wrap_start`, `dokan_order_inside_content`, …). They also render the PHP sidebar navigation and the status-filter bar, both of which the panel already provides. Documented boundary — see `docs/adr/0005-vendor-order-details-stays-server-rendered.md`.
2. **The fabricated order-view nonce.** Extension code written as "verify the nonce or bail" renders nothing without it. Authorization is already established by the permission rule; CSRF is preserved by the REST nonce.
3. **`innerHTML` in the fragment component.** That is the feature. The HTML comes from Dokan's own endpoint behind a capability + ownership check, and the template escapes its own output; sanitising would strip exactly the markup Pro and third-party hooks contribute.

Two judgement calls worth a second opinion:

* **Admin access.** Spec #2138 asks for "a marketplace admin can open any Vendor order", but #2133 also requires the endpoint's permission rules to match the legacy page's *exactly*. These conflict — the details template's ownership guard has no admin bypass, so an admin already sees a not-yours notice on the legacy page. This PR matches legacy and asserts it explicitly rather than quietly granting admins more.
* **JS event prefix.** The events use `dokan-` (matching `dokan-dashboard-routes`, `dokan-header-actions` that extensions already bind to) rather than the `dokan_` the review-standards doc asks for. Cheap to rename now, contract-breaking after release.

Two known limitations, both documented in the extension-author guide:

* A top-level `let`/`const` in render-time inline data cannot be replaced when navigating from one order to another — the global lexical binding outlives the script element that created it. Identical payloads are reused, stale ones dropped on route exit, and the panel logs a warning naming the offending handle.
* Third-party code that enqueues assets gated on the `orders` query var hits the same wall Pro's modules do. There is no way to make that transparent to code written against a page render; the kill-switch and the guide are the mitigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-panel Vendor order details via a server-rendered fragment, including deep links, order metadata with status badge, and a Back action that restores list filters/state.
  * Introduced fragment lifecycle events for order details loaded/rendered and inline status changes.
  * Added a kill-switch/permission-gated option to enable or fall back to legacy order details behavior.
* **Bug Fixes**
  * Improved re-initialization and delegated interactions so notes, status updates, downloads, and datepickers work reliably after fragment injection.
  * Prevented panel styling resets from affecting legacy fragment layout.
* **Documentation / Tests**
  * Added documentation for Vendor-facing surfaces and fragment behavior.
  * Added REST and end-to-end test coverage for permissions, rendering, and re-init behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->