### PR TITLE
fix(dashboard): stop building vendor dashboard layout config on background requests

### DIFF
--- a/includes/Shortcodes/FullWidthVendorLayout.php
+++ b/includes/Shortcodes/FullWidthVendorLayout.php
@@ -30,7 +30,10 @@ class FullWidthVendorLayout implements Hookable {
         // Register vendor dashboard assets if the vendor layout is not legacy.
         $vendor_layout = dokan_get_option( 'vendor_layout_style', 'dokan_appearance', 'legacy' );
         if ( 'latest' === $vendor_layout ) {
-            add_action( 'init', [ $this, 'register_vendor_dashboard_assets' ], 99 );
+            // On wp_enqueue_scripts (not init): it only fires on front-end page
+            // renders — never for cron, Action Scheduler, AJAX, REST or admin —
+            // and the seller-dashboard check inside needs the parsed query.
+            add_action( 'wp_enqueue_scripts', [ $this, 'register_vendor_dashboard_assets' ], 5 );
             add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_vendor_dashboard_assets' ] );
             add_filter( 'template_include', [ $this, 'rewrite_vendor_dashboard_template' ] );
         }
@@ -94,6 +97,10 @@ class FullWidthVendorLayout implements Hookable {
      * @return void
      */
     public function register_vendor_dashboard_assets() {
+        if ( ! is_user_logged_in() || ! dokan_is_seller_dashboard() ) {
+            return;
+        }
+
         $admin_dashboard_file = DOKAN_DIR . '/assets/js/vendor-dashboard/layout/index.asset.php';
         if ( file_exists( $admin_dashboard_file ) ) {
             $dashboard_script = require $admin_dashboard_file;


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)

Closes: https://github.com/getdokan/dokan-pro/issues/5580
### Changes proposed in this Pull Request:

`FullWidthVendorLayout::register_vendor_dashboard_assets()` was hooked to `init`, which runs on **every** request — WP-Cron, Action Scheduler pings (every ~30s on any WooCommerce site), admin-ajax, REST and admin screens. On each of those it built the entire vendor dashboard layout config: vendor lookup, header nav, and a full `dokan_get_dashboard_nav()` pass (~50 navigation URL builds), then attached it as inline data to a script that is never enqueued outside the seller dashboard — so all of that work was discarded.

Measured on a plugin-heavy dev site: ~55 wasted `dokan_get_navigation_url()` calls per background request, ~150,000+ per day on an idle site. With WPML active each of those multiplies further (every URL translation re-enters the dashboard nav builder).

**The fix (9-line diff):**

1. Hook the registration to `wp_enqueue_scripts` (priority 5, before the enqueue callback at 10) instead of `init` — it only fires on front-end page renders, so background requests never reach the code at all.
2. Bail unless `is_user_logged_in() && dokan_is_seller_dashboard()` — the same condition the existing enqueue callback already uses. This check is unreliable on `init` (query not parsed yet) but valid on `wp_enqueue_scripts`, which is what makes the hook move necessary rather than just adding a guard.

Verified: zero calls from cron/AJAX/REST/admin/non-dashboard pages after the change; the dashboard page itself registers, localizes and enqueues exactly as before. Translated (WPML) dashboard pages keep working since dokan-wpml maps the page ID via the existing `dokan_get_current_page_id` filter.

### Related Pull Request(s)

* Companion (independent, same investigation) Pro PR: https://github.com/getdokan/dokan-pro/pull/5959

### How to test the changes in this Pull Request:

1. Enable the new vendor dashboard layout (`dokan_appearance.vendor_layout_style = latest`).
2. Add `error_log()` inside `dokan_get_navigation_url()` (or use Query Monitor's hook panel) and hit `wp-cron.php`, `admin-ajax.php` or any `/wp-json/` route: **before** this PR each hit logs dozens of navigation URL builds, **after** it logs none.
3. Open the vendor dashboard as a vendor: the React app, sidebar nav and header must load exactly as before (`vendorDashboardLayoutConfig` present in page source).

### Changelog entry

*Stop building vendor dashboard assets and layout config on background requests*

Previously the full-width vendor dashboard registered its assets and built its entire layout configuration on every request to the site, including WP-Cron, Action Scheduler, AJAX and REST API calls, where the result was always discarded. Now the work only happens on an actual logged-in seller dashboard page view, removing constant background overhead on every WooCommerce site running Dokan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vendor dashboard asset loading to run only on the seller dashboard.
  * Prevented unnecessary dashboard scripts, styles, and configuration from loading on other pages.
  * Updated asset loading behavior for the latest vendor layout to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->