### PR TITLE
fix(security): enforce order ownership in shared bulk status helper (IDOR, completes L1)

### DIFF
--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -958,16 +958,8 @@ function dokan_apply_bulk_order_status_change( $postdata ) {
     $status = sanitize_text_field( wp_unslash( $postdata['status'] ) );
     $orders = array_map( 'absint', $postdata['bulk_orders'] );
 
-    // Guard ownership at the shared sink so every caller (REST bulk-actions + the legacy dashboard bulk form) is covered: a vendor may only touch their own orders, admins/shop managers excepted.
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        $vendor_id = dokan_get_current_user_id();
-        $orders    = array_filter(
-            $orders,
-            function ( $order_id ) use ( $vendor_id ) {
-                return dokan_is_seller_has_order( $vendor_id, $order_id );
-            }
-        );
-    }
+    // Guard ownership at the shared sink so every caller (REST bulk-actions + the legacy dashboard bulk form) is covered.
+    $orders = array_filter( $orders, [ \WeDevs\Dokan\Utilities\OrderUtil::class, 'current_user_can_manage_order' ] );
 
     // -1 means bluk action option value
     $excluded_status = [ '-1', 'cancelled', 'refunded' ];

--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -958,6 +958,17 @@ function dokan_apply_bulk_order_status_change( $postdata ) {
     $status = sanitize_text_field( wp_unslash( $postdata['status'] ) );
     $orders = array_map( 'absint', $postdata['bulk_orders'] );
 
+    // Guard ownership at the shared sink so every caller (REST bulk-actions + the legacy dashboard bulk form) is covered: a vendor may only touch their own orders, admins/shop managers excepted.
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        $vendor_id = dokan_get_current_user_id();
+        $orders    = array_filter(
+            $orders,
+            function ( $order_id ) use ( $vendor_id ) {
+                return dokan_is_seller_has_order( $vendor_id, $order_id );
+            }
+        );
+    }
+
     // -1 means bluk action option value
     $excluded_status = [ '-1', 'cancelled', 'refunded' ];
 

--- a/includes/REST/OrderControllerV2.php
+++ b/includes/REST/OrderControllerV2.php
@@ -5,6 +5,7 @@ namespace WeDevs\Dokan\REST;
 use WC_Customer_Download;
 use WC_Data_Store;
 use WC_Product;
+use WeDevs\Dokan\Utilities\OrderUtil;
 use WP_Error;
 use WP_REST_Server;
 
@@ -414,18 +415,8 @@ class OrderControllerV2 extends OrderController {
      * @return WP_Error|\WP_HTTP_Response|\WP_REST_Response
      */
     public function process_orders_bulk_action( $requests ) {
-        $order_ids = $requests->get_param( 'order_ids' );
-
-        // A vendor may only bulk-update their own orders; foreign order ids are dropped (admins/shop managers are exempt).
-        if ( ! current_user_can( 'manage_woocommerce' ) ) {
-            $vendor_id = dokan_get_current_user_id();
-            $order_ids = array_filter(
-                $order_ids,
-                function ( $order_id ) use ( $vendor_id ) {
-                    return dokan_is_seller_has_order( $vendor_id, $order_id );
-                }
-            );
-        }
+        // A vendor may only bulk-update their own orders; admins/shop managers are exempt.
+        $order_ids = array_filter( (array) $requests->get_param( 'order_ids' ), [ OrderUtil::class, 'current_user_can_manage_order' ] );
 
         $data = [
             'bulk_orders' => $order_ids,

--- a/includes/Utilities/OrderUtil.php
+++ b/includes/Utilities/OrderUtil.php
@@ -236,4 +236,25 @@ class OrderUtil {
          */
         return (bool) apply_filters( 'dokan_email_show_customer_details', true, $order );
     }
+
+    /**
+     * Whether the current user may act on the given order in a bulk operation.
+     *
+     * A vendor may act only on their own orders; admins and shop managers (manage_woocommerce)
+     * may act on any order. Centralizing this keeps every bulk-order entry point — the REST
+     * bulk-actions endpoint and the legacy vendor-dashboard bulk form — guarded by one rule.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int|string $order_id Order id to check.
+     *
+     * @return bool
+     */
+    public static function current_user_can_manage_order( $order_id ): bool {
+        if ( current_user_can( 'manage_woocommerce' ) ) {
+            return true;
+        }
+
+        return dokan_is_seller_has_order( dokan_get_current_user_id(), absint( $order_id ) );
+    }
 }

--- a/tests/php/src/Orders/BulkOrderStatusOwnershipTest.php
+++ b/tests/php/src/Orders/BulkOrderStatusOwnershipTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Orders;
+
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Ownership guard for the shared bulk order-status helper.
+ *
+ * Covers the cross-vendor IDOR (audit L6 / plugin-internal-tasks#2148) where the
+ * legacy vendor-dashboard bulk form reached dokan_apply_bulk_order_status_change()
+ * without an ownership check. The guard now lives in the shared helper, so both the
+ * REST bulk-actions endpoint and the dashboard form are covered.
+ *
+ * @group orders
+ * @group order-status
+ * @group security
+ */
+class BulkOrderStatusOwnershipTest extends DokanTestCase {
+
+    /**
+     * A vendor cannot change another vendor's order status; their own still changes.
+     */
+    public function test_vendor_cannot_change_other_vendors_order_status() {
+        $own_order     = $this->create_single_vendor_order( $this->seller_id1 );
+        $foreign_order = $this->create_single_vendor_order( $this->seller_id2 );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        dokan_apply_bulk_order_status_change(
+            [
+                'status'      => 'completed',
+                'bulk_orders' => [ $own_order, $foreign_order ],
+            ]
+        );
+
+        $this->assertSame( 'completed', wc_get_order( $own_order )->get_status(), 'Vendor should be able to update their own order.' );
+        $this->assertSame( 'processing', wc_get_order( $foreign_order )->get_status(), 'Vendor must not update another vendor\'s order.' );
+    }
+
+    /**
+     * Admins / shop managers are exempt and may change any vendor's order.
+     */
+    public function test_admin_can_change_any_order_status() {
+        $foreign_order = $this->create_single_vendor_order( $this->seller_id2 );
+
+        wp_set_current_user( $this->admin_id );
+
+        dokan_apply_bulk_order_status_change(
+            [
+                'status'      => 'completed',
+                'bulk_orders' => [ $foreign_order ],
+            ]
+        );
+
+        $this->assertSame( 'completed', wc_get_order( $foreign_order )->get_status(), 'Admin should be able to update any order.' );
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/OrderBulkActionsOwnershipTest.php
+++ b/tests/php/src/REST/OrderBulkActionsOwnershipTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\REST\OrderControllerV2;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WP_REST_Request;
+
+/**
+ * Authorization test for the REST orders bulk-actions endpoint.
+ *
+ * Verifies the other caller of the shared OrderUtil::current_user_can_manage_order() guard
+ * (audit L6 / plugin-internal-tasks#2148): POST dokan/v2/orders/bulk-actions must not let a
+ * vendor change another vendor's order status.
+ *
+ * @group orders
+ * @group order-status
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\REST\OrderControllerV2::process_orders_bulk_action
+ */
+class OrderBulkActionsOwnershipTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v2';
+
+    public function set_up() {
+        parent::set_up();
+
+        ( new OrderControllerV2() )->register_routes();
+    }
+
+    /**
+     * A vendor cannot change another vendor's order status through the bulk-actions endpoint;
+     * their own order still changes.
+     */
+    public function test_vendor_cannot_bulk_change_foreign_order_status() {
+        $own_order     = $this->create_single_vendor_order( $this->seller_id1 );
+        $foreign_order = $this->create_single_vendor_order( $this->seller_id2 );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $request = new WP_REST_Request( 'POST', '/dokan/v2/orders/bulk-actions' );
+        $request->set_body_params(
+            [
+                'order_ids' => [ $own_order, $foreign_order ],
+                'status'    => 'completed',
+            ]
+        );
+        $response = $this->server->dispatch( $request );
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertSame( 'completed', wc_get_order( $own_order )->get_status(), 'Vendor should update their own order.' );
+        $this->assertSame( 'processing', wc_get_order( $foreign_order )->get_status(), 'Vendor must not update another vendor\'s order.' );
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+        parent::tear_down();
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

The Patchstack report (getdokan/dokan-pro#5960, report `aa94c7b5`) named **two sinks** feeding the shared helper `dokan_apply_bulk_order_status_change()`:

1. the REST bulk-actions endpoint `POST /wp-json/dokan/v2/orders/bulk-actions` → `OrderControllerV2::process_orders_bulk_action()` (guarded earlier by #3291), and
2. the legacy vendor-dashboard bulk form → `includes/Order/Frontend/Hooks.php::bulk_order_status_change()`.

#3291 filtered order ids only in the REST caller, so the dashboard-form path still forwarded raw `$_POST['bulk_orders']` into the unguarded helper — a vendor could still change **another vendor's** order status.

This PR centralizes the ownership rule as a single reusable check, **`OrderUtil::current_user_can_manage_order()`** (`includes/Utilities/OrderUtil.php`): a vendor may act only on their own orders (`dokan_is_seller_has_order()`); admins/shop managers (`manage_woocommerce`) are exempt. It is called from **both** entry points:

* `dokan_apply_bulk_order_status_change()` — the shared sink, which covers the legacy dashboard form **and** the REST path; and
* `OrderControllerV2::process_orders_bulk_action()` — the REST caller, kept as defense-in-depth.

Both sinks named in the report are now guarded by one rule, and the duplicated inline closures from #3291 / the earlier commit are removed.

### Test scope

Two PHPUnit tests, **one per entry point named in the report**, so both callers of the shared guard are covered:

| Test | Path exercised | Asserts |
|---|---|---|
| `tests/php/src/Orders/BulkOrderStatusOwnershipTest.php` | Shared helper `dokan_apply_bulk_order_status_change()` — the sink the **legacy vendor-dashboard bulk form** funnels into | A vendor **cannot** change another vendor's order status; the vendor's **own** order still changes; an **admin** can change any order. (2 tests) |
| `tests/php/src/REST/OrderBulkActionsOwnershipTest.php` | The real REST route `POST /dokan/v2/orders/bulk-actions` → `process_orders_bulk_action()` (dispatched through the REST server as a vendor) | Response is 200; the vendor's **own** order becomes `completed`; **another vendor's** order is left unchanged. (1 test) |

* **Total: 3 tests, 6 assertions** — run with `npm run phpunit -- --filter 'BulkOrderStatusOwnershipTest|OrderBulkActionsOwnershipTest'`.
* **Coverage rationale:** the two tests hit the guard through both of its callers (dashboard form via the helper, and the REST endpoint), which are exactly the two sinks in the Patchstack report. The admin/shop-manager exemption is asserted at the helper level. The `dokan/v3` route needs no separate test — `OrderControllerV3` extends `OrderControllerV2` without overriding this method, so it inherits the same guarded code.
* **Not in scope here:** the download-grant/revoke and catalog-mode IDORs found in the same sweep are fixed in their own PRs (#3338, #3339, #3340).
* **Regression:** running the full `--group orders` suite shows only the two **pre-existing** `OrderStatusChangeTest` failures that are already red on `develop` (unrelated sub-order status-sync assertions); this PR adds none.

### Related Pull Request(s)

* Completes getdokan/dokan#3291 (audit finding L1); part of the getdokan/plugin-internal-tasks#1994 follow-up sweep.

### Closes

* Closes getdokan/plugin-internal-tasks#2148

### How to test the changes in this Pull Request:

1. As Vendor A, submit the vendor-dashboard bulk order-status form (or `POST /dokan/v2/orders/bulk-actions`) with `bulk_orders[]` / `order_ids[]` containing an order owned by Vendor B and `status=completed`.
2. Confirm Vendor B's order status is **unchanged**.
3. Confirm Vendor A can still bulk-update their own orders, and an administrator can update any order.
4. Automated: `npm run phpunit -- --filter 'BulkOrderStatusOwnershipTest|OrderBulkActionsOwnershipTest'` → passes (3 tests, 6 assertions).

### Changelog entry

**Fix — Cross-vendor order status change via the vendor-dashboard bulk form (IDOR)**

The vendor-dashboard bulk order-status form could change the status of orders belonging to other vendors, because the shared `dokan_apply_bulk_order_status_change()` helper trusted caller-supplied order ids. Order ownership is now enforced through a single `OrderUtil::current_user_can_manage_order()` guard used by both the REST bulk-actions endpoint and the dashboard form (admins/shop managers exempt), closing the second sink named in the Patchstack report and completing the #3291 fix.

### Before Changes

A vendor could POST another vendor's order ids to the dashboard bulk form and change those orders' statuses.

### After Changes

Foreign order ids are dropped at the shared guard; only the caller's own orders (or an admin's) are updated.
