### PR TITLE
fix(security): enforce product ownership when granting order downloads via REST (IDOR, L7)

### DIFF
--- a/includes/REST/OrderControllerV2.php
+++ b/includes/REST/OrderControllerV2.php
@@ -281,7 +281,9 @@ class OrderControllerV2 extends OrderController {
 
         foreach ( $product_ids as $product_id ) {
             $product = dokan()->product->get( $product_id );
-            if ( ! $product ) {
+
+            // Only grant downloads for the vendor's own products, never another vendor's files (admins/shop managers exempt).
+            if ( ! $product || ( ! current_user_can( 'manage_woocommerce' ) && ! dokan_is_product_author( $product_id ) ) ) {
                 continue;
             }
 

--- a/tests/php/src/REST/OrderDownloadsGrantOwnershipTest.php
+++ b/tests/php/src/REST/OrderDownloadsGrantOwnershipTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as DownloadApprovedDirectories;
+use WeDevs\Dokan\REST\OrderControllerV2;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WC_Data_Store;
+use WC_Product_Download;
+use WP_REST_Request;
+
+/**
+ * Authorization test for the REST download-grant endpoint.
+ *
+ * Covers the cross-vendor IDOR (audit L7 / plugin-internal-tasks#2149): the REST
+ * twin of L4 (getdokan/dokan#3293). A vendor granting downloads on their own order
+ * must not be able to grant access to another vendor's downloadable files.
+ *
+ * @group dokan-order-downloads
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\REST\OrderControllerV2::grant_order_downloads
+ */
+class OrderDownloadsGrantOwnershipTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v2';
+
+    /**
+     * Downloadable product owned by the caller (vendor A).
+     *
+     * @var int
+     */
+    protected int $own_product;
+
+    /**
+     * Downloadable product owned by another vendor (vendor B).
+     *
+     * @var int
+     */
+    protected int $foreign_product;
+
+    /**
+     * Order owned by vendor A.
+     *
+     * @var int
+     */
+    protected int $order_id;
+
+    public function set_up() {
+        parent::set_up();
+
+        // Let the test's example.com download files validate without the approved-directories gate.
+        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
+
+        ( new OrderControllerV2() )->register_routes();
+
+        $this->own_product     = $this->create_downloadable_product_for( $this->seller_id1 );
+        $this->foreign_product = $this->create_downloadable_product_for( $this->seller_id2 );
+        $this->order_id        = $this->create_single_vendor_order( $this->seller_id1 );
+    }
+
+    /**
+     * Vendor A cannot grant downloads for Vendor B's product; their own product is still granted.
+     */
+    public function test_vendor_cannot_grant_downloads_for_foreign_product() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $request = new WP_REST_Request( 'POST', "/dokan/v2/orders/{$this->order_id}/downloads" );
+        $request->set_body_params( [ 'ids' => [ $this->own_product, $this->foreign_product ] ] );
+        $response = $this->server->dispatch( $request );
+
+        $this->assertSame( 200, $response->get_status() );
+
+        $granted = $this->granted_product_ids( $this->order_id );
+        $this->assertContains( $this->own_product, $granted, 'Vendor should grant downloads for their own product.' );
+        $this->assertNotContains( $this->foreign_product, $granted, 'Vendor must not grant downloads for another vendor\'s product.' );
+    }
+
+    /**
+     * Create a downloadable product (with one file) owned by the given seller.
+     */
+    protected function create_downloadable_product_for( int $seller_id ): int {
+        $download = new WC_Product_Download();
+        $download->set_name( 'Test File' );
+        $download->set_id( wp_generate_uuid4() );
+        $download->set_file( 'https://example.com/' . uniqid() . '.pdf' );
+
+        $product = $this->factory()->product->create_downloadable_product( [ $download ] );
+        wp_update_post(
+            [
+                'ID'          => $product->get_id(),
+                'post_author' => $seller_id,
+            ]
+        );
+
+        return $product->get_id();
+    }
+
+    /**
+     * Product ids that currently have a download permission on the order.
+     */
+    protected function granted_product_ids( int $order_id ): array {
+        $permissions = WC_Data_Store::load( 'customer-download' )->get_downloads( [ 'order_id' => $order_id ] );
+
+        return array_map(
+            static function ( $permission ) {
+                return (int) $permission->get_product_id();
+            },
+            $permissions
+        );
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/OrderDownloadsGrantOwnershipTest.php
+++ b/tests/php/src/REST/OrderDownloadsGrantOwnershipTest.php
@@ -16,6 +16,8 @@ use WP_REST_Request;
  * twin of L4 (getdokan/dokan#3293). A vendor granting downloads on their own order
  * must not be able to grant access to another vendor's downloadable files.
  *
+ * @since DOKAN_SINCE
+ *
  * @group dokan-order-downloads
  * @group dokan-authorization
  * @group security
@@ -52,11 +54,20 @@ class OrderDownloadsGrantOwnershipTest extends DokanTestCase {
      */
     protected int $order_id;
 
+    /**
+     * Approved-directories mode captured in set_up() and restored in tear_down().
+     *
+     * @var string
+     */
+    protected string $previous_download_mode;
+
     public function set_up() {
         parent::set_up();
 
-        // Let the test's example.com download files validate without the approved-directories gate.
-        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
+        // Disable the approved-directories gate so the test's example.com files validate; restored in tear_down().
+        $approved_directories         = wc_get_container()->get( DownloadApprovedDirectories::class );
+        $this->previous_download_mode = $approved_directories->get_mode();
+        $approved_directories->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
 
         ( new OrderControllerV2() )->register_routes();
 
@@ -80,6 +91,23 @@ class OrderDownloadsGrantOwnershipTest extends DokanTestCase {
         $granted = $this->granted_product_ids( $this->order_id );
         $this->assertContains( $this->own_product, $granted, 'Vendor should grant downloads for their own product.' );
         $this->assertNotContains( $this->foreign_product, $granted, 'Vendor must not grant downloads for another vendor\'s product.' );
+    }
+
+    /**
+     * An admin / shop manager is exempt from the ownership guard and may grant any vendor's product downloads.
+     */
+    public function test_admin_can_grant_downloads_for_any_product() {
+        wp_set_current_user( $this->admin_id );
+
+        $request = new WP_REST_Request( 'POST', "/dokan/v2/orders/{$this->order_id}/downloads" );
+        $request->set_body_params( [ 'ids' => [ $this->own_product, $this->foreign_product ] ] );
+        $response = $this->server->dispatch( $request );
+
+        $this->assertSame( 200, $response->get_status() );
+
+        $granted = $this->granted_product_ids( $this->order_id );
+        $this->assertContains( $this->own_product, $granted, 'Admin should grant downloads for any product.' );
+        $this->assertContains( $this->foreign_product, $granted, 'Admin (manage_woocommerce) is exempt from the vendor ownership guard.' );
     }
 
     /**
@@ -118,6 +146,10 @@ class OrderDownloadsGrantOwnershipTest extends DokanTestCase {
 
     public function tear_down() {
         wp_set_current_user( 0 );
+
+        // Restore the shared approved-directories mode so disabling it here doesn't leak into later tests.
+        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( $this->previous_download_mode );
+
         parent::tear_down();
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

`grant_order_downloads()` — the callback for `POST /wp-json/dokan/v2/orders/<id>/downloads` (and `dokan/v3`, since `OrderControllerV3 extends OrderControllerV2` without overriding it) — is authorized only by `get_single_order_permissions_check()`, which verifies the caller owns the **order** in `<id>`. It then loops over the caller-supplied `ids[]` (product ids) and calls `wc_downloadable_file_permission()` for each with only an `if ( ! $product ) continue;` guard — **no product-ownership check**. A vendor placing an order they control can grant that order's customer working download permissions for **another vendor's** downloadable files.

This is the REST twin of **L4** (getdokan/plugin-internal-tasks#2002 / getdokan/dokan#3293), which only fixed the AJAX handler `grant_access_to_download()`.

The fix skips any product the caller does not own — `dokan_is_product_author()` — with `manage_woocommerce` exempt so admins/shop managers are unaffected, mirroring #3293.

### Related Pull Request(s)

* Mirrors getdokan/dokan#3293 (audit finding L4) for the REST path

### Closes

* Closes getdokan/plugin-internal-tasks#2149

### How to test the changes in this Pull Request:

1. As Vendor A (owning order `O`), `POST /wp-json/dokan/v2/orders/O/downloads` with `{"ids":[<Vendor B's downloadable product id>]}`.
2. Confirm **no** download permission is created for Vendor B's product.
3. Confirm granting Vendor A's **own** downloadable product on `O` still works.
4. Automated: `npm run phpunit -- --filter OrderDownloadsGrantOwnershipTest` → passes (1 test, 3 assertions).

### Changelog entry

**Fix — Cross-vendor download-permission granting via the REST orders/downloads endpoint (IDOR)**

Previously, a vendor could grant download access to another vendor's downloadable files through `POST dokan/v2|v3/orders/<id>/downloads`, because the endpoint checked only order ownership, not product ownership. The endpoint now grants only the caller's own products (admins/shop managers exempt), mirroring the earlier AJAX fix (#3293).

### Before Changes

`POST dokan/v2/orders/<own-order>/downloads` with another vendor's product ids granted that customer access to the victim's files.

### After Changes

Foreign product ids are skipped; only the caller's own products are granted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk “grant downloads” behavior so vendors can’t grant download permissions for products owned by other vendors.
  * Store administrators and managers can still grant downloads across vendors.
  * Added eligibility checks to ensure only valid, permitted product downloads receive granted permissions.
* **Tests**
  * Added REST authorization coverage to verify cross-vendor protections on the order downloads grant endpoint, including admin/shop manager override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->