### PR TITLE
fix(security): verify download permission belongs to order before revoking (IDOR, L8)

### DIFF
--- a/includes/REST/OrderControllerV2.php
+++ b/includes/REST/OrderControllerV2.php
@@ -390,8 +390,18 @@ class OrderControllerV2 extends OrderController {
     public function revoke_order_downloads( $requests ) {
         $download_id   = $requests->get_param( 'download_id' );
         $product_id    = $requests->get_param( 'product_id' );
-        $order_id      = $requests->get_param( 'id' );
+        $order_id      = absint( $requests->get_param( 'id' ) );
         $permission_id = $requests->get_param( 'permission_id' );
+
+        // Only revoke a permission that belongs to the ownership-checked order, so a foreign permission_id can't be deleted.
+        $download = new WC_Customer_Download( $permission_id );
+        if ( ! $download->get_id() || $download->get_order_id() !== $order_id ) {
+            return new WP_Error(
+                'dokan_rest_download_permission_invalid_order',
+                esc_html__( 'Download permission does not belong to this order.', 'dokan-lite' ),
+                [ 'status' => 400 ]
+            );
+        }
 
         try {
             $data_store = WC_Data_Store::load( 'customer-download' );

--- a/includes/REST/OrderControllerV2.php
+++ b/includes/REST/OrderControllerV2.php
@@ -391,11 +391,17 @@ class OrderControllerV2 extends OrderController {
         $download_id   = $requests->get_param( 'download_id' );
         $product_id    = $requests->get_param( 'product_id' );
         $order_id      = absint( $requests->get_param( 'id' ) );
-        $permission_id = $requests->get_param( 'permission_id' );
+        $permission_id = absint( $requests->get_param( 'permission_id' ) );
 
-        // Only revoke a permission that belongs to the ownership-checked order, so a foreign permission_id can't be deleted.
-        $download = new WC_Customer_Download( $permission_id );
-        if ( ! $download->get_id() || $download->get_order_id() !== $order_id ) {
+        // Only this order's own permission may be revoked; a foreign or unknown id is rejected (WC throws on an unknown id, caught here).
+        try {
+            $download         = new WC_Customer_Download( $permission_id );
+            $belongs_to_order = $download->get_id() && $download->get_order_id() === $order_id;
+        } catch ( \Exception $e ) {
+            $belongs_to_order = false;
+        }
+
+        if ( ! $belongs_to_order ) {
             return new WP_Error(
                 'dokan_rest_download_permission_invalid_order',
                 esc_html__( 'Download permission does not belong to this order.', 'dokan-lite' ),

--- a/tests/php/src/REST/OrderDownloadsRevokeOwnershipTest.php
+++ b/tests/php/src/REST/OrderDownloadsRevokeOwnershipTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as DownloadApprovedDirectories;
+use WeDevs\Dokan\REST\OrderControllerV2;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WC_Customer_Download;
+use WC_Data_Store;
+use WC_Product_Download;
+use WP_REST_Request;
+
+/**
+ * Authorization test for the REST download-revoke endpoint.
+ *
+ * Covers the cross-vendor IDOR (audit L8 / plugin-internal-tasks#2150): revoke_order_downloads()
+ * deleted a permission by attacker-supplied permission_id without checking it belonged to the
+ * route order. The endpoint now rejects a permission that belongs to a different order.
+ *
+ * @group dokan-order-downloads
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\REST\OrderControllerV2::revoke_order_downloads
+ */
+class OrderDownloadsRevokeOwnershipTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v2';
+
+    /**
+     * Order owned by the caller (vendor A).
+     *
+     * @var int
+     */
+    protected int $own_order;
+
+    /**
+     * Order owned by another vendor (vendor B).
+     *
+     * @var int
+     */
+    protected int $foreign_order;
+
+    /**
+     * Downloadable product id (with a file).
+     *
+     * @var int
+     */
+    protected int $product_id;
+
+    public function set_up() {
+        parent::set_up();
+
+        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
+
+        ( new OrderControllerV2() )->register_routes();
+
+        $download = new WC_Product_Download();
+        $download->set_name( 'Test File' );
+        $download->set_id( wp_generate_uuid4() );
+        $download->set_file( 'https://example.com/' . uniqid() . '.pdf' );
+
+        $product = $this->factory()->product->create_downloadable_product( [ $download ] );
+        $this->product_id = $product->get_id();
+
+        $this->own_order     = $this->create_single_vendor_order( $this->seller_id1 );
+        $this->foreign_order = $this->create_single_vendor_order( $this->seller_id2 );
+    }
+
+    /**
+     * Vendor A cannot delete a permission that belongs to another vendor's order.
+     */
+    public function test_vendor_cannot_revoke_foreign_order_permission() {
+        $foreign_permission = $this->grant_permission( $this->foreign_order );
+
+        wp_set_current_user( $this->seller_id1 );
+        $response = $this->revoke_request( $this->own_order, $foreign_permission );
+
+        $this->assertSame( 400, $response->get_status(), 'Revoking a foreign order\'s permission must be rejected.' );
+        $this->assertSame( $foreign_permission, ( new WC_Customer_Download( $foreign_permission ) )->get_id(), 'The foreign permission must still exist.' );
+    }
+
+    /**
+     * Vendor A can delete a permission that belongs to their own order.
+     */
+    public function test_vendor_can_revoke_own_order_permission() {
+        $own_permission = $this->grant_permission( $this->own_order );
+
+        wp_set_current_user( $this->seller_id1 );
+        $response = $this->revoke_request( $this->own_order, $own_permission );
+
+        $this->assertSame( 200, $response->get_status(), 'Revoking a permission on the caller\'s own order should succeed.' );
+        $remaining = WC_Data_Store::load( 'customer-download' )->get_downloads( [ 'order_id' => $this->own_order ] );
+        $this->assertCount( 0, $remaining, 'The own permission must be deleted.' );
+    }
+
+    /**
+     * Grant one download permission on the given order and return its permission id.
+     */
+    protected function grant_permission( int $order_id ): int {
+        $downloads   = wc_get_product( $this->product_id )->get_downloads();
+        $download_id = array_key_first( $downloads );
+
+        return (int) wc_downloadable_file_permission( $download_id, $this->product_id, wc_get_order( $order_id ) );
+    }
+
+    /**
+     * Dispatch a DELETE against the downloads endpoint.
+     */
+    protected function revoke_request( int $order_id, int $permission_id ) {
+        $request = new WP_REST_Request( 'DELETE', "/dokan/v2/orders/{$order_id}/downloads" );
+        $request->set_body_params( [ 'permission_id' => $permission_id ] );
+
+        return $this->server->dispatch( $request );
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/OrderDownloadsRevokeOwnershipTest.php
+++ b/tests/php/src/REST/OrderDownloadsRevokeOwnershipTest.php
@@ -8,7 +8,6 @@ use WeDevs\Dokan\Test\DokanTestCase;
 use WC_Customer_Download;
 use WC_Data_Store;
 use WC_Product_Download;
-use WP_REST_Request;
 
 /**
  * Authorization test for the REST download-revoke endpoint.
@@ -16,6 +15,8 @@ use WP_REST_Request;
  * Covers the cross-vendor IDOR (audit L8 / plugin-internal-tasks#2150): revoke_order_downloads()
  * deleted a permission by attacker-supplied permission_id without checking it belonged to the
  * route order. The endpoint now rejects a permission that belongs to a different order.
+ *
+ * @since DOKAN_SINCE
  *
  * @group dokan-order-downloads
  * @group dokan-authorization
@@ -53,10 +54,20 @@ class OrderDownloadsRevokeOwnershipTest extends DokanTestCase {
      */
     protected int $product_id;
 
+    /**
+     * Approved-directories mode captured in set_up() and restored in tear_down().
+     *
+     * @var string
+     */
+    protected string $previous_download_mode;
+
     public function set_up() {
         parent::set_up();
 
-        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
+        // Disable the approved-directories gate so the test's example.com files validate; restored in tear_down().
+        $approved_directories         = wc_get_container()->get( DownloadApprovedDirectories::class );
+        $this->previous_download_mode = $approved_directories->get_mode();
+        $approved_directories->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
 
         ( new OrderControllerV2() )->register_routes();
 
@@ -100,6 +111,16 @@ class OrderDownloadsRevokeOwnershipTest extends DokanTestCase {
     }
 
     /**
+     * An unknown permission id is rejected with 400 rather than a 500 fatal (WC_Customer_Download throws on unknown ids).
+     */
+    public function test_revoke_rejects_unknown_permission() {
+        wp_set_current_user( $this->seller_id1 );
+        $response = $this->revoke_request( $this->own_order, 999999 );
+
+        $this->assertSame( 400, $response->get_status(), 'An unknown permission id must be rejected, not cause a fatal.' );
+    }
+
+    /**
      * Grant one download permission on the given order and return its permission id.
      */
     protected function grant_permission( int $order_id ): int {
@@ -113,14 +134,15 @@ class OrderDownloadsRevokeOwnershipTest extends DokanTestCase {
      * Dispatch a DELETE against the downloads endpoint.
      */
     protected function revoke_request( int $order_id, int $permission_id ) {
-        $request = new WP_REST_Request( 'DELETE', "/dokan/v2/orders/{$order_id}/downloads" );
-        $request->set_body_params( [ 'permission_id' => $permission_id ] );
-
-        return $this->server->dispatch( $request );
+        return $this->delete_request( "/orders/{$order_id}/downloads", [ 'permission_id' => $permission_id ] );
     }
 
     public function tear_down() {
         wp_set_current_user( 0 );
+
+        // Restore the shared approved-directories mode so disabling it here doesn't leak into later tests.
+        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( $this->previous_download_mode );
+
         parent::tear_down();
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

`revoke_order_downloads()` — the callback for `DELETE /wp-json/dokan/v2/orders/<id>/downloads` (and `dokan/v3`) — deleted a download permission straight from the caller-supplied `permission_id` (`WC_Data_Store::load('customer-download')->delete_by_id()`) with **no check that the permission belongs to the route order**. The route's permission callback only verifies order ownership, so a vendor owning any single order could enumerate small sequential `permission_id`s and delete **another vendor's / customer's** download permission (cross-vendor denial of download access).

The sibling `update_order_download()` in the same controller already guards this (`$download->get_order_id() !== $order_id`); this PR applies the same check to the revoke path.

### Related Pull Request(s)

* Related to getdokan/dokan#3338 (L7) — same endpoint group

### Closes

* Closes getdokan/plugin-internal-tasks#2150

### How to test the changes in this Pull Request:

1. As Vendor A (owning order `A`), create a download permission on Vendor B's order `B`.
2. `DELETE /wp-json/dokan/v2/orders/A/downloads` with `{"permission_id":<B's permission id>}`.
3. Confirm the response is **400** and Vendor B's permission still exists.
4. Confirm Vendor A can still revoke a permission that belongs to their own order `A`.
5. Automated: `npm run phpunit -- --filter OrderDownloadsRevokeOwnershipTest` → passes (2 tests, 4 assertions).

### Changelog entry

**Fix — Cross-vendor download-permission deletion via the REST orders/downloads endpoint (IDOR)**

Previously, `DELETE dokan/v2|v3/orders/<id>/downloads` deleted a download permission by id without confirming it belonged to that order, letting a vendor delete other vendors' download permissions. The endpoint now rejects a permission that does not belong to the (ownership-checked) route order.

### Before Changes

A vendor could delete any download permission by passing its `permission_id` to a `DELETE` on one of their own orders.

### After Changes

A permission whose `order_id` does not match the route order is rejected with a 400.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download revocation validation by confirming the permission belongs to the specified order.
  - Invalid, unknown, or mismatched download permissions now return a clear error instead of being removed incorrectly.
  - Vendors can continue to revoke valid downloads associated with their own orders.

- **Tests**
  - Added coverage for authorized revocations, unauthorized cross-order attempts, and unknown permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->