### PR TITLE
fix(security): enforce product ownership in catalog-mode bulk edit (IDOR, L9)

### DIFF
--- a/includes/CatalogMode/Dashboard/ProductBulkEdit.php
+++ b/includes/CatalogMode/Dashboard/ProductBulkEdit.php
@@ -72,6 +72,11 @@ class ProductBulkEdit {
         // loop through the products and update the status
         if ( ! empty( $product_ids ) ) {
             foreach ( $product_ids as $product_id ) {
+                // Only edit the vendor's own products; skip foreign ids, mirroring the sibling bulk-delete handler.
+                if ( ! dokan_is_product_author( $product_id ) ) {
+                    continue;
+                }
+
                 // get existing product data
                 $catalog_mode_data = Helper::get_catalog_mode_data_by_product( $product_id );
                 $count++;

--- a/tests/php/src/CatalogMode/CatalogModeBulkEditOwnershipTest.php
+++ b/tests/php/src/CatalogMode/CatalogModeBulkEditOwnershipTest.php
@@ -12,6 +12,8 @@ use WeDevs\Dokan\Test\DokanTestCase;
  * bulk edit wrote `_dokan_catalog_mode` meta to caller-supplied product ids with no ownership
  * check, while the sibling bulk-delete handler already guards each id.
  *
+ * @since DOKAN_SINCE
+ *
  * @group catalog-mode
  * @group dokan-authorization
  * @group security
@@ -47,11 +49,21 @@ class CatalogModeBulkEditOwnershipTest extends DokanTestCase {
 
         $this->own_product = $this->factory()->product
             ->set_seller_id( $this->seller_id1 )
-            ->create( [ 'name' => 'Own Product', 'regular_price' => '10' ] );
+            ->create(
+                [
+                    'name'          => 'Own Product',
+                    'regular_price' => '10',
+                ]
+            );
 
         $this->foreign_product = $this->factory()->product
             ->set_seller_id( $this->seller_id2 )
-            ->create( [ 'name' => 'Foreign Product', 'regular_price' => '20' ] );
+            ->create(
+                [
+                    'name'          => 'Foreign Product',
+                    'regular_price' => '20',
+                ]
+            );
     }
 
     /**

--- a/tests/php/src/CatalogMode/CatalogModeBulkEditOwnershipTest.php
+++ b/tests/php/src/CatalogMode/CatalogModeBulkEditOwnershipTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace WeDevs\Dokan\Test\CatalogMode;
+
+use WeDevs\Dokan\CatalogMode\Dashboard\ProductBulkEdit;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Ownership guard for the catalog-mode product bulk-edit handler.
+ *
+ * Covers the cross-vendor IDOR (audit L9 / plugin-internal-tasks#2151): the vendor-dashboard
+ * bulk edit wrote `_dokan_catalog_mode` meta to caller-supplied product ids with no ownership
+ * check, while the sibling bulk-delete handler already guards each id.
+ *
+ * @group catalog-mode
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\CatalogMode\Dashboard\ProductBulkEdit::save_bulk_edit_catalog_mode_data
+ */
+class CatalogModeBulkEditOwnershipTest extends DokanTestCase {
+
+    /**
+     * Product owned by the caller (vendor A).
+     *
+     * @var int
+     */
+    protected int $own_product;
+
+    /**
+     * Product owned by another vendor (vendor B).
+     *
+     * @var int
+     */
+    protected int $foreign_product;
+
+    public function set_up() {
+        parent::set_up();
+
+        update_option(
+            'dokan_selling',
+            [
+                'catalog_mode_hide_add_to_cart_button' => 'on',
+                'catalog_mode_hide_product_price'      => 'on',
+            ]
+        );
+
+        $this->own_product = $this->factory()->product
+            ->set_seller_id( $this->seller_id1 )
+            ->create( [ 'name' => 'Own Product', 'regular_price' => '10' ] );
+
+        $this->foreign_product = $this->factory()->product
+            ->set_seller_id( $this->seller_id2 )
+            ->create( [ 'name' => 'Foreign Product', 'regular_price' => '20' ] );
+    }
+
+    /**
+     * Vendor A cannot toggle catalog mode on Vendor B's product; their own product is still toggled.
+     */
+    public function test_vendor_cannot_toggle_catalog_mode_on_foreign_product() {
+        wp_set_current_user( $this->seller_id1 );
+
+        // The handler ends in wp_safe_redirect()+exit(); throw from the redirect filter to catch it.
+        add_filter( 'wp_redirect', [ $this, 'block_redirect' ] );
+        try {
+            ( new ProductBulkEdit() )->save_bulk_edit_catalog_mode_data(
+                'enable_catalog_mode',
+                [ $this->own_product, $this->foreign_product ]
+            );
+            $this->fail( 'The handler should have redirected (and exited).' );
+        } catch ( \RuntimeException $e ) {
+            $this->assertSame( 'dokan_test_redirect', $e->getMessage() );
+        } finally {
+            remove_filter( 'wp_redirect', [ $this, 'block_redirect' ] );
+        }
+
+        $this->assertNotEmpty(
+            get_post_meta( $this->own_product, '_dokan_catalog_mode', true ),
+            'Vendor should toggle catalog mode on their own product.'
+        );
+        $this->assertEmpty(
+            get_post_meta( $this->foreign_product, '_dokan_catalog_mode', true ),
+            'Vendor must not toggle catalog mode on another vendor\'s product.'
+        );
+    }
+
+    /**
+     * Stand-in for the handler's wp_safe_redirect()+exit(), so the test can assert afterwards.
+     */
+    public function block_redirect( $location ) {
+        throw new \RuntimeException( 'dokan_test_redirect' );
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+        parent::tear_down();
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

`ProductBulkEdit::save_bulk_edit_catalog_mode_data()` — hooked on `dokan_bulk_product_status_change`, fired by the vendor-dashboard bulk form (`Product\Hooks::bulk_product_status_change()` on `template_redirect`) — wrote `_dokan_catalog_mode` post meta for every caller-supplied `$_POST['bulk_products']` id, gated only by the generic `dokan_edit_product` capability. It performed **no ownership check and no post-type check**, so a vendor could enable/disable Catalog Mode (hide add-to-cart button / price) on **another vendor's products** (competitive sabotage), and could write the meta to arbitrary post ids.

The sibling listener on the same action, `Product\Hooks::bulk_product_delete()`, already guards each id with `dokan_is_product_author()`. This PR applies the same guard to the catalog-mode handler.

### Related Pull Request(s)

* N/A

### Closes

* Closes getdokan/plugin-internal-tasks#2151

### How to test the changes in this Pull Request:

1. Enable Catalog Mode in Dokan selling settings.
2. As Vendor A, submit the product-listing bulk form with `status=enable_catalog_mode` and `bulk_products[]` containing a product owned by Vendor B.
3. Confirm Vendor B's product `_dokan_catalog_mode` meta is **unchanged**.
4. Confirm Vendor A can still toggle catalog mode on their own products.
5. Automated: `npm run phpunit -- --filter CatalogModeBulkEditOwnershipTest` → passes (1 test, 3 assertions).

### Changelog entry

**Fix — Cross-vendor Catalog Mode toggling via product bulk-edit (IDOR)**

Previously, the vendor-dashboard "Enable/Disable Catalog Mode" bulk action wrote catalog-mode meta to any submitted product id, letting a vendor hide another vendor's add-to-cart button or price. The bulk action now edits only the vendor's own products.

### Before Changes

A vendor could POST another vendor's product ids to the catalog-mode bulk action and hide their add-to-cart button / price.

### After Changes

Foreign product ids are skipped; only the vendor's own products are edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk catalog-mode updates now apply only to products owned by the current vendor.
  * Products belonging to other vendors are skipped, preventing unauthorized changes.

* **Tests**
  * Added coverage to verify ownership restrictions during catalog-mode bulk editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->