### PR TITLE
fix(product-editor): store downloadable files in the WooCommerce approved upload directory

### DIFF
--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -8,6 +8,7 @@ type UploadTypes = {
     as?: React.ElementType;
     title?: string;
     buttonText?: string;
+    uploaderParams?: Record< string, string >;
 };
 
 const Upload = ( {
@@ -17,6 +18,7 @@ const Upload = ( {
     className,
     title,
     buttonText,
+    uploaderParams,
     ...props
 }: UploadTypes ) => {
     const uploadHandler = () => {
@@ -28,6 +30,12 @@ const Upload = ( {
             },
             multiple, // Set to true to allow multiple selection
         } );
+        if ( uploaderParams ) {
+            // Extra plupload multipart params, e.g. `type: 'downloadable_product'` routes uploads into woocommerce_uploads.
+            mediaFrame.on( 'ready', () => {
+                mediaFrame.uploader.options.uploader.params = uploaderParams;
+            } );
+        }
         mediaFrame.on( 'select', () => {
             const attachment = mediaFrame.state().get( 'selection' );
             if ( multiple ) {

--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -33,7 +33,24 @@ const Upload = ( {
         if ( uploaderParams ) {
             // Extra plupload multipart params, e.g. `type: 'downloadable_product'` routes uploads into woocommerce_uploads.
             mediaFrame.on( 'ready', () => {
-                mediaFrame.uploader.options.uploader.params = uploaderParams;
+                // A frame has no uploader when the upload limit is exceeded or the browser is unsupported.
+                const uploaderWindow = mediaFrame.uploader;
+
+                if ( ! uploaderWindow ) {
+                    return;
+                }
+
+                // Once plupload is live only param() reaches it; before that the pending options are the only target.
+                if ( uploaderWindow.uploader ) {
+                    uploaderWindow.uploader.param( { ...uploaderParams } );
+                    return;
+                }
+
+                // Merge so WordPress' own params (nonce, post_id) survive alongside ours.
+                uploaderWindow.options.uploader.params = {
+                    ...uploaderWindow.options.uploader.params,
+                    ...uploaderParams,
+                };
             } );
         }
         mediaFrame.on( 'select', () => {

--- a/src/dashboard/product-editor/components/FileUploadEdit.tsx
+++ b/src/dashboard/product-editor/components/FileUploadEdit.tsx
@@ -7,6 +7,8 @@ import { __ } from '@wordpress/i18n';
 import { Plus, Upload, X } from 'lucide-react';
 import CustomField, { getValidationError } from './CustomField';
 
+const DOWNLOADABLE_UPLOADER_PARAMS = { type: 'downloadable_product' };
+
 const FileUploadEdit = ( { field, onChange, validity }: any ) => {
     const [ files, setFiles ] = useState(
         field.value?.length > 0
@@ -35,6 +37,13 @@ const FileUploadEdit = ( { field, onChange, validity }: any ) => {
             field
         )
     );
+
+    // Downloadable files carry the `downloadable_product` upload type so WooCommerce stores them in woocommerce_uploads.
+    const uploaderParams = applyFilters(
+        'dokan_product_editor_file_field_uploader_params',
+        field?.id === 'downloads' ? DOWNLOADABLE_UPLOADER_PARAMS : undefined,
+        field
+    ) as Record< string, string > | undefined;
 
     const onAddRow = () => {
         const newFiles = [
@@ -138,6 +147,7 @@ const FileUploadEdit = ( { field, onChange, validity }: any ) => {
                             </div>
                             <div className="flex gap-2 shrink-0 items-center">
                                 <MediaUploader
+                                    uploaderParams={ uploaderParams }
                                     onSelect={ ( val: any ) =>
                                         onSelectFile( val, index )
                                     }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Downloadable product files uploaded from the vendor dashboard (new React product editor) were stored in the default WordPress uploads directory (`/wp-content/uploads/YYYY/MM/`) instead of WooCommerce's approved `woocommerce_uploads/` directory. When WooCommerce's **Approved Download Directories** feature is enforcing (its default), the product save was then rejected because the file path is not inside an approved directory.

**Root cause:** the media frame opened by `MediaUploader` (`src/components/Upload.tsx`) never sent the `type=downloadable_product` plupload multipart param. WooCommerce's `WC_Admin_Upload_Downloadable_Product::upload_dir()` keys off exactly this param to route the upload into `woocommerce_uploads/` — the same mechanism wp-admin and Dokan's legacy jQuery product form (`assets/src/js/product-editor.js`) already use.

**Fix:**

* `src/components/Upload.tsx` — `MediaUploader` accepts an optional `uploaderParams` prop and assigns it to the frame's plupload multipart params on `ready` (verbatim the WooCommerce-core idiom from `meta-boxes-product.js`).
* `src/dashboard/product-editor/components/FileUploadEdit.tsx` — passes `{ type: 'downloadable_product' }` for the core `downloads` field, overridable via the new `dokan_product_editor_file_field_uploader_params` filter (mirrors the existing `dokan_product_editor_file_field_read_only` filter in the same file).

Since Dokan Pro's variation editor reuses the same `downloads` field and `FileUploadEdit` component, this single change also fixes variation downloadable files in Pro.

### Closes

* Closes #https://github.com/getdokan/dokan-pro/issues/5972

### How to test the changes in this Pull Request:

1. WooCommerce → Settings → Products → Approved download directories: ensure rules are being enforced (default).
2. Log in as a vendor → Vendor Dashboard → Products → Add New Product.
3. Enable **Downloadable**, and in Downloadable Files click **Choose** and upload a file (e.g. a PDF).
4. Verify the inserted file URL points inside `/wp-content/uploads/woocommerce_uploads/YYYY/MM/` (with a random filename suffix when "Append a unique string to filename" is enabled).
5. Fill the remaining required fields and save — the product saves successfully.
6. Cross-check: upload a downloadable file on the wp-admin product edit screen — both surfaces produce the same directory and filename behavior.

### Changelog entry

*Fix downloadable product file uploads ignoring the WooCommerce approved download directory*

Downloadable files uploaded from the vendor dashboard product form were saved to the default WordPress uploads folder, so vendors could not save downloadable products while WooCommerce's Approved Download Directories protection was active. Uploads from the Downloadable Files field are now tagged as downloadable-product uploads, so WooCommerce stores them in `woocommerce_uploads/` and applies its filename obfuscation — matching wp-admin behavior exactly.

### Before Changes

Vendor uploads a downloadable file from the dashboard and tries to save the product:

| Behavior | Vendor dashboard (before) | wp-admin (expected) |
|---|---|---|
| Upload destination | `/wp-content/uploads/2026/07/file.pdf` ❌ | `/wp-content/uploads/woocommerce_uploads/2026/07/` |
| Unique-filename hash (setting on) | Not applied ❌ | `file-zbbqny.pdf` |
| Approved-directory validation | Fails ❌ | Passes |
| Product save | **HTTP 400** — `product_invalid_download`: *"The downloadable file could not be saved. Please pick a file from upload directory approved by the store admin."* ❌ | Saves |

Side effect: every failed vendor attempt auto-added a disabled `uploads/YYYY/MM/` rule to the Approved Download Directories list, polluting it over time.

### After Changes

Same flow with this fix — vendor uploads now behave identically to wp-admin:

| Behavior | Vendor dashboard (after) | Impact |
|---|---|---|
| Upload destination | `/wp-content/uploads/woocommerce_uploads/2026/07/` ✅ | Files land in the access-protected, pre-approved WooCommerce directory |
| Unique-filename hash (setting on) | Applied, e.g. `file-xdrqso.pdf` ✅ | Vendors get the same download-URL obfuscation security as admins |
| Approved-directory validation | Passes (`Register::is_valid_path()` → `true`) ✅ | No more admin intervention needed to approve stray directories |
| Product save | **HTTP 200** — product publishes with the download attached ✅ | Vendors can sell downloadable products with the WooCommerce protection left on |
| Other `MediaUploader` uses (images, galleries) | Unchanged — param only sent for the `downloads` field | No regression surface |

### PR Self Review Checklist:

* [x] Code follows the surrounding style and the file's existing filter convention
* [x] KISS / DRY — extends the one shared `MediaUploader` instead of forking a wrapper; reuses WooCommerce's own routing mechanism instead of adding a custom `upload_dir` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for passing custom parameters with media uploads.
  * Downloadable product files are now uploaded using WooCommerce’s expected storage handling.
  * Added a filter to customize uploader parameters for downloadable product file uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->