### PR TITLE
Fix 4 e2e tests failing on develop CI (test-side only)

### DIFF
--- a/tests/pw/tests/e2e/abuse-reports/abuseReports.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReports.spec.ts
@@ -104,19 +104,16 @@ test.describe('Abuse Reports Tests @pro', () => {
         await abuseReportsPage.goToSettingsPage();
         await abuseReportsPage.searchSettings(abuseReportsPage.testData.abuseReports.settingsSearchKeyword);
 
-        const isHeadingVisible = await abuseReportsPage.isSettingsHeadingVisible();
-        expect(isHeadingVisible, '"Product Report Abuse Settings" heading should be visible').toBe(true);
+        await abuseReportsPage.assertSettingsHeadingVisible();
 
         const docLinkHref = await abuseReportsPage.getSettingsDocLinkHref();
         expect(docLinkHref, 'Doc link should contain the correct Dokan documentation URL').toContain(abuseReportsPage.testData.abuseReports.settingsDocUrl);
 
-        const isReportedByVisible = await abuseReportsPage.isReportedByHeadingVisible();
-        expect(isReportedByVisible, '"Reported by" heading should be visible').toBe(true);
+        await abuseReportsPage.assertReportedByHeadingVisible();
 
         await abuseReportsPage.enableReportedBySliderIfDisabled();
 
-        const isReasonsVisible = await abuseReportsPage.isReasonsHeadingVisible();
-        expect(isReasonsVisible, '"Reasons for Abuse Report" heading should be visible').toBe(true);
+        await abuseReportsPage.assertReasonsHeadingVisible();
 
         await abuseReportsPage.fillNewAbuseReason(abuseReportsPage.testData.abuseReports.newReasonText);
         await abuseReportsPage.clickAddReasonPlusButton();
@@ -196,10 +193,7 @@ test.describe('Abuse Reports Tests @pro', () => {
         await abuseReportsPage.searchSettings(abuseReportsPage.testData.abuseReports.settingsSearchKeyword);
 
         // Heading
-        expect(
-            await abuseReportsPage.isSettingsHeadingVisible(),
-            '"Product Report Abuse Settings" heading should be visible',
-        ).toBe(true);
+        await abuseReportsPage.assertSettingsHeadingVisible();
 
         // Doc link
         const docHref = await abuseReportsPage.getSettingsDocLinkHref();
@@ -209,8 +203,8 @@ test.describe('Abuse Reports Tests @pro', () => {
         ).toContain(abuseReportsPage.testData.abuseReports.settingsDocUrl);
 
         // Sub-headings
-        expect(await abuseReportsPage.isReportedByHeadingVisible(), '"Reported by" heading should be visible').toBe(true);
-        expect(await abuseReportsPage.isReasonsHeadingVisible(), '"Reasons for Abuse Report" heading should be visible').toBe(true);
+        await abuseReportsPage.assertReportedByHeadingVisible();
+        await abuseReportsPage.assertReasonsHeadingVisible();
 
         await abuseReportsPage.waitForPageReady();
         await adminPage.close();
@@ -649,6 +643,15 @@ test.describe('Abuse Reports Tests @pro', () => {
         const adminPage = await adminCtx.newPage();
         const abuseReportsPage = new AbuseReportsPage(adminPage);
 
+        // Server-side baseline. Unlike TC11/TC12/MD-4 this test had no
+        // post-condition proving the delete actually happened, so its single
+        // "modal stayed hidden" assertion was true even if nothing was deleted.
+        const apiCtx = await request.newContext();
+        const readTotal = async () =>
+            Number((await abuseReportsPage.restGetReports(apiCtx)).headers()['x-dokan-abusereports-total'] ?? '0');
+        const totalBeforeDelete = await readTotal();
+        expect(totalBeforeDelete, 'The seeded report should exist before the delete').toBeGreaterThan(0);
+
         await abuseReportsPage.goToAbuseReportsReact();
         await abuseReportsPage.waitForListReady();
 
@@ -661,6 +664,10 @@ test.describe('Abuse Reports Tests @pro', () => {
         await abuseReportsPage.clickDeleteActionFromMenu();
         await abuseReportsPage.confirmDeleteInModal();
         await abuseReportsPage.waitForListReady();
+
+        // The delete must have really removed a row server-side.
+        await expect.poll(readTotal, { timeout: 10000 }).toBe(totalBeforeDelete - 1);
+        await apiCtx.dispose();
 
         // Detail modal should NOT auto-open after delete
         expect(

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsCustomerForm.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsCustomerForm.spec.ts
@@ -134,7 +134,7 @@ test.describe('Abuse Reports — Customer Form @pro', () => {
 
         expect(submitFired, 'No submit-form AJAX request should fire when no reason is selected').toBe(false);
         expect(
-            await customerPage.locator(flow.abuseReports.confirmOkButton).isVisible().catch(() => false),
+            await flow.confirmOk().isVisible(),
             'Success confirmation must NOT appear when submit was blocked by validation',
         ).toBe(false);
         // The form should still be open (reason radio still visible).
@@ -241,7 +241,7 @@ test.describe('Abuse Reports — Customer Form @pro', () => {
         expect(invalid, 'Malformed email should be HTML5-invalid (typeMismatch)').toBe(true);
         // No success confirmation should ever appear.
         expect(
-            await guestPage.locator(flow.abuseReports.confirmOkButton).isVisible().catch(() => false),
+            await flow.confirmOk().isVisible(),
             'Success confirmation must NOT appear for an invalid email',
         ).toBe(false);
 
@@ -388,7 +388,7 @@ test.describe('Abuse Reports — Customer Form @pro', () => {
         await submitBtn.dblclick();
 
         // Wait for the success confirmation (proves the single submit landed).
-        await customerPage.locator(flow.abuseReports.confirmOkButton).waitFor({ state: 'visible', timeout: 15000 });
+        await flow.confirmOk().waitFor({ state: 'visible', timeout: 15000 });
         await flow.confirmAbuseReportSubmission();
 
         // Allow any stray second request to surface before counting.
@@ -431,7 +431,7 @@ test.describe('Abuse Reports — Customer Form @pro', () => {
 
         // The izimodal report popup closes once the request resolves; the
         // success sweetalert (OK button) then renders the same message.
-        await customerPage.locator(flow.abuseReports.confirmOkButton).waitFor({ state: 'visible', timeout: 15000 });
+        await flow.confirmOk().waitFor({ state: 'visible', timeout: 15000 });
 
         // The report form's reason radio should be gone (modal closed).
         expect(

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsList.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsList.spec.ts
@@ -353,30 +353,41 @@ test.describe('Abuse Reports — Admin DataViews List @pro', () => {
         const adminPage = await context.newPage();
         const flow = new AbuseReportsPage(adminPage);
 
-        await flow.goToAbuseReportsReact();
-        await flow.waitForListReady();
-
-        // Capture every abuse-reports GET the page issues so we can prove no
-        // order_by/order param is ever sent, even after a header interaction.
+        // Attach the listener BEFORE navigating. Previously it was attached
+        // after goToAbuseReportsReact(), so the initial list GET was never seen
+        // and nothing proved the interception pattern still matched the real
+        // request URL — if the route shape changed, the listener would simply
+        // never fire and the "no sort param" assertion would pass vacuously.
+        // listGetsSeen is that positive control.
+        const listGetsSeen: string[] = [];
         const sortParamsSeen: string[] = [];
         adminPage.on('request', req => {
             const url = req.url();
             if (url.includes('/wp-json/dokan/v1/abuse-reports') && req.method() === 'GET') {
+                listGetsSeen.push(url);
                 if (url.includes('order_by=') || url.includes('orderby=') || /[?&]order=/.test(url)) {
                     sortParamsSeen.push(url);
                 }
             }
         });
 
-        // Try clicking a sortable-looking column header if one is exposed.
-        // DataViews renders column headers as buttons; clicking the "Reported At"
-        // header should, in a sort-enabled grid, toggle a sort. Here it is a
-        // no-op for the query.
+        await flow.goToAbuseReportsReact();
+        await flow.waitForListReady();
+
+        expect(
+            listGetsSeen.length,
+            'Positive control: the list must issue at least one abuse-reports GET, otherwise the request interception below proves nothing',
+        ).toBeGreaterThan(0);
+
+        // Click the "Reported At" column header. In a sort-enabled grid this
+        // would toggle a sort; here it must remain a no-op for the query.
+        // Asserted hard — the previous `count() > 0 && isVisible().catch(false)`
+        // guard plus `.click().catch(() => undefined)` meant a missing header or
+        // a failed click silently skipped the only interaction under test.
         const header = adminPage.locator("//th//button[contains(normalize-space(.),'Reported At')] | //th[contains(normalize-space(.),'Reported At')]").first();
-        if (await header.count() > 0 && await header.isVisible().catch(() => false)) {
-            await header.click().catch(() => undefined);
-            await adminPage.waitForTimeout(800);
-        }
+        await expect(header, 'The "Reported At" column header should render in the list').toBeVisible({ timeout: 15000 });
+        await header.click();
+        await adminPage.waitForTimeout(800);
 
         expect(
             sortParamsSeen,

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsModalDelete.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsModalDelete.spec.ts
@@ -298,11 +298,23 @@ test.describe('Abuse Reports — Modal, Delete-edge & Orphaned records @pro', ()
 
         // Description section is conditionally rendered ({ modalItem.description && ... }),
         // so with no description there should be NO "Description" heading.
-        const descriptionHeading = adminPage.locator(abuse.adminReact.detailModalDescriptionBlock).first();
-        expect(
-            await descriptionHeading.isVisible().catch(() => false),
+        //
+        // Positive control first: without it, a selector that stopped matching
+        // (heading shape changed) is indistinguishable from an absent section —
+        // the old `isVisible().catch(() => false)` returned false either way.
+        // Both section labels render as h4 inside the dialog
+        // (ReportAbusePage.tsx:630 Reason, :643 Description).
+        await expect(
+            adminPage.locator("//*[@role='dialog']//h4[normalize-space()='Reason']"),
+            'Control: modal section labels render as h4 inside role=dialog',
+        ).toHaveCount(1);
+
+        // Count, not visibility: an unconditionally-rendered heading with an
+        // empty body would still report isVisible() === false.
+        await expect(
+            adminPage.locator("//*[@role='dialog']//h4[normalize-space()='Description']"),
             'No Description section should render when the report has no description',
-        ).toBe(false);
+        ).toHaveCount(0);
 
         // Reported By: ACTUAL behavior — the REST builder always returns a
         // reported_by object (id 0 for guests), so the modal's `! reported_by`

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
@@ -200,8 +200,9 @@ export class AbuseReportsPage {
         // dokan-pro/modules/report-abuse/assets/src/js/frontend/main.js `afterPopupClose()` — so it is
         // the SweetAlert2 confirm button, matched here by its own class instead of its "OK" label.
         // Matching on the label is what broke: the single-product page also carries Google Maps' own
-        // `<button class="dismissButton">OK</button>` (the Maps JS API error dialog, present in the
-        // DOM whenever the site has no valid Maps key, as on CI), so `//button[text()='OK']` resolved
+        // `<button class="dismissButton">OK</button>` (the Maps JS API error dialog, injected whenever
+        // a Maps key IS configured but Google rejects it for the requesting host — expired or
+        // referrer-restricted, as on CI runners), so `//button[text()='OK']` resolved
         // to 2 elements the moment the popup opened and Playwright aborted with a strict-mode
         // violation. Deliberately NOT text-constrained, so the negative assertions ("no success
         // confirmation must appear") still catch a confirmation popup with unexpected wording.
@@ -340,9 +341,17 @@ export class AbuseReportsPage {
         await this.page.locator(this.admin.settingsHeading).waitFor({ state: 'visible' });
     }
 
-    async isSettingsHeadingVisible(): Promise<boolean> {
-        await this.page.getByRole('heading', { name: /Product Report Abuse Settings/i }).waitFor({ state: 'visible', timeout: 10000 });
-        return true;
+    // These three used to be `is*Visible(): Promise<boolean>` that awaited a
+    // waitFor() and then `return true` unconditionally. The enforcement was real
+    // (waitFor throws), but the boolean was a constant, so the `.toBe(true)` at
+    // every call site asserted nothing and a failure surfaced as an opaque
+    // locator timeout instead of the assertion's own message. Expose them as
+    // assertions so the intent and the diagnostics live in the same place.
+    async assertSettingsHeadingVisible() {
+        await expect(
+            this.page.getByRole('heading', { name: /Product Report Abuse Settings/i }),
+            '"Product Report Abuse Settings" heading should be visible',
+        ).toBeVisible({ timeout: 10000 });
     }
 
     async getSettingsDocLinkHref(): Promise<string> {
@@ -350,14 +359,18 @@ export class AbuseReportsPage {
         return href ?? '';
     }
 
-    async isReportedByHeadingVisible(): Promise<boolean> {
-        await this.page.locator(this.admin.reportedByHeading).waitFor({ state: 'visible', timeout: 10000 });
-        return true;
+    async assertReportedByHeadingVisible() {
+        await expect(
+            this.page.locator(this.admin.reportedByHeading),
+            '"Reported by" heading should be visible',
+        ).toBeVisible({ timeout: 10000 });
     }
 
-    async isReasonsHeadingVisible(): Promise<boolean> {
-        await this.page.locator(this.admin.reasonsHeading).waitFor({ state: 'visible', timeout: 10000 });
-        return true;
+    async assertReasonsHeadingVisible() {
+        await expect(
+            this.page.locator(this.admin.reasonsHeading),
+            '"Reasons for Abuse Report" heading should be visible',
+        ).toBeVisible({ timeout: 10000 });
     }
 
     async enableReportedBySliderIfDisabled() {
@@ -576,7 +589,16 @@ export class AbuseReportsPage {
         // The DataViews UI may issue either a true DELETE on the single
         // resource endpoint OR a POST to the batch endpoint depending on the
         // selection size and the underlying store action — accept either.
-        await Promise.all([
+        //
+        // The response wait is REQUIRED, not decorative. It previously carried
+        // `.catch(() => null)` and its result was discarded, so "the request was
+        // never issued" cost a silent 30s and then reported success. The
+        // modal-hidden check below cannot substitute: the AlertDialog closes in a
+        // `finally` (@wedevs/plugin-ui dataviews.tsx) and ReportAbusePage's
+        // handleSingleDelete catches its own errors into a toast without
+        // rethrowing — so the modal closes identically on success, on 500/403,
+        // and when nothing was requested at all.
+        const [response] = await Promise.all([
             this.page.waitForResponse(
                 res => {
                     if (!res.url().includes('/wp-json/dokan/v1/abuse-reports')) return false;
@@ -584,10 +606,14 @@ export class AbuseReportsPage {
                     return m === 'DELETE' || m === 'POST';
                 },
                 { timeout: 30000 },
-            ).catch(() => null),
+            ),
             this.page.locator(this.adminReact.deleteModalConfirmBtn).click(),
         ]);
-        // Modal closes once the request resolves (success or failure).
+        expect(
+            response.status(),
+            `Delete request ${response.request().method()} ${response.url()} should succeed`,
+        ).toBeLessThan(300);
+        // Modal closes once the request resolves.
         await this.page.locator(this.adminReact.deleteModalConfirmBtn).waitFor({ state: 'hidden', timeout: 15000 });
     }
 

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
@@ -702,14 +702,24 @@ export class AbuseReportsPage {
         return await this.page.locator(this.abuseReports.customerNameInput).isVisible().catch(() => false);
     }
 
+    /**
+     * The submission confirmation is a `dokan_sweetalert` (SweetAlert2) popup whose button reads "OK".
+     * Under load a second "OK" button can transiently coexist in the DOM (a prior popup mid-close, or a
+     * theme/consent control), so the bare `//button[text()='OK']` locator intermittently hits a strict-mode
+     * violation ("resolved to 2 elements"). Scope to the currently-visible one (the active dialog).
+     */
+    private confirmOk() {
+        return this.page.locator(this.abuseReports.confirmOkButton).filter({ visible: true }).last();
+    }
+
     async submitAbuseReport() {
         await this.page.locator(this.abuseReports.submitButton).click();
-        await this.page.locator(this.abuseReports.confirmOkButton).waitFor({ state: 'visible' });
+        await this.confirmOk().waitFor({ state: 'visible' });
     }
 
     async confirmAbuseReportSubmission() {
-        await this.page.locator(this.abuseReports.confirmOkButton).click();
-        await this.page.locator(this.abuseReports.confirmOkButton).waitFor({ state: 'hidden' });
+        await this.confirmOk().click();
+        await this.page.locator(this.abuseReports.confirmOkButton).filter({ visible: true }).waitFor({ state: 'hidden' });
     }
 
     async clickCustomReasonLabel(reason: string) {

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsPage.ts
@@ -196,7 +196,16 @@ export class AbuseReportsPage {
         customerEmailInput: "//input[@name='customer_email']",
         descriptionInput: "//textarea[@name='description']",
         submitButton: "//button[@id='dokan-report-abuse-form-submit-btn']",
-        confirmOkButton: "//button[normalize-space()='OK']",
+        // The submission confirmation is a `dokan_sweetalert()` (SweetAlert2) alert — see
+        // dokan-pro/modules/report-abuse/assets/src/js/frontend/main.js `afterPopupClose()` — so it is
+        // the SweetAlert2 confirm button, matched here by its own class instead of its "OK" label.
+        // Matching on the label is what broke: the single-product page also carries Google Maps' own
+        // `<button class="dismissButton">OK</button>` (the Maps JS API error dialog, present in the
+        // DOM whenever the site has no valid Maps key, as on CI), so `//button[text()='OK']` resolved
+        // to 2 elements the moment the popup opened and Playwright aborted with a strict-mode
+        // violation. Deliberately NOT text-constrained, so the negative assertions ("no success
+        // confirmation must appear") still catch a confirmation popup with unexpected wording.
+        confirmOkButton: 'button.swal2-confirm',
         formError: ".dokan-popup-error",
         customReasonLabel: (reason: string) => `//label[normalize-space()='${reason}']`,
     };
@@ -703,13 +712,12 @@ export class AbuseReportsPage {
     }
 
     /**
-     * The submission confirmation is a `dokan_sweetalert` (SweetAlert2) popup whose button reads "OK".
-     * Under load a second "OK" button can transiently coexist in the DOM (a prior popup mid-close, or a
-     * theme/consent control), so the bare `//button[text()='OK']` locator intermittently hits a strict-mode
-     * violation ("resolved to 2 elements"). Scope to the currently-visible one (the active dialog).
+     * The confirm button of the SweetAlert2 submission-success popup. Single match by construction —
+     * SweetAlert2 keeps at most one popup mounted — so no `.first()` / visibility filtering is needed
+     * and every wait below asserts this exact button.
      */
-    private confirmOk() {
-        return this.page.locator(this.abuseReports.confirmOkButton).filter({ visible: true }).last();
+    confirmOk() {
+        return this.page.locator(this.abuseReports.confirmOkButton);
     }
 
     async submitAbuseReport() {
@@ -719,7 +727,7 @@ export class AbuseReportsPage {
 
     async confirmAbuseReportSubmission() {
         await this.confirmOk().click();
-        await this.page.locator(this.abuseReports.confirmOkButton).filter({ visible: true }).waitFor({ state: 'hidden' });
+        await this.confirmOk().waitFor({ state: 'hidden' });
     }
 
     async clickCustomReasonLabel(reason: string) {

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsPermissions.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsPermissions.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, request } from '@utils/test';
 import { AbuseReportsPage } from './abuseReportsPage';
 import { payloads } from '@utils/payloads';
-import { helpers, SERVER_URL } from '@utils/helpers';
+import { helpers, toPath, SERVER_URL } from '@utils/helpers';
 import path from 'path';
 import type { Page } from '@playwright/test';
 
@@ -164,17 +164,25 @@ test.describe('Abuse Reports — Permissions & Module Gating @pro', () => {
 
         await gotoAndSettle(vendorPage, abuseReportsPage.admin.settingsUrl);
 
-        // The vendor (seller role) lacks manage_woocommerce → WP gates the page.
-        // The settings heading must NOT be present.
-        const headingVisible = await vendorPage
-            .getByRole('heading', { name: /Product Report Abuse Settings/i })
-            .isVisible()
-            .catch(() => false);
-        expect(headingVisible, 'Vendor must NOT see the abuse-report settings heading').toBe(false);
+        // Assert the positive, server-rendered gate FIRST (deterministic).
         expect(
             await isAdminPageDenied(vendorPage),
             'Vendor opening the Dokan settings page should hit the WP "not allowed" gate (no manage_woocommerce)',
         ).toBe(true);
+
+        // The Dokan settings app must not have mounted at all.
+        //
+        // This used to assert the absence of the "Product Report Abuse Settings"
+        // heading — which only renders after searchSettings() switches the active
+        // tab, so it is absent on the bare #/settings landing for EVERY role
+        // including a full admin. The check passed for the wrong reason and
+        // could not detect a gating regression. `#dokan-admin-search` renders on
+        // that landing for any manage_woocommerce holder (it is exactly what
+        // goToSettingsPage() waits for), so its absence is a real signal.
+        await expect(
+            vendorPage.locator(abuseReportsPage.admin.settingsSearchInput),
+            'Vendor must NOT see the Dokan settings app',
+        ).toHaveCount(0);
 
         await vendorPage.close();
         await context.close();
@@ -193,11 +201,13 @@ test.describe('Abuse Reports — Permissions & Module Gating @pro', () => {
             'Guest hitting the Dokan settings page should be redirected to wp-login.php',
         ).toContain('wp-login.php');
 
-        const headingVisible = await guestPage
-            .getByRole('heading', { name: /Product Report Abuse Settings/i })
-            .isVisible()
-            .catch(() => false);
-        expect(headingVisible, 'Guest must NOT see the abuse-report settings heading').toBe(false);
+        // Same correction as P1: the settings heading is absent on the bare
+        // #/settings landing for every role, so its absence proved nothing.
+        // Assert the settings app itself never mounted.
+        await expect(
+            guestPage.locator(abuseReportsPage.admin.settingsSearchInput),
+            'Guest must NOT see the Dokan settings app',
+        ).toHaveCount(0);
 
         await guestPage.close();
         await context.close();
@@ -263,31 +273,41 @@ test.describe('Abuse Reports — Permissions & Module Gating @pro', () => {
         // shop_manager CAN open the list. We assert the REAL outcome (access
         // granted) rather than the (incorrect) expectation — never weaken to
         // make the documented assumption "pass".
-        const context = await browser.newContext({ storageState: a1 });
-        const adminPage = await context.newPage();
+        // This used to open an ADMIN session (storageState: a1) and assert the
+        // ADMIN reached the list, on the reasoning that admin is a superset of
+        // shop_manager caps. That makes the case unable to detect any change in
+        // shop_manager gating — the exact thing it is named for. Drive a real
+        // shop_manager session instead; no shop_manager storageState exists
+        // (playwright/.auth holds admin/vendor/customer only), so log the
+        // beforeAll-created account in through the WP login form.
+        const context = await browser.newContext(); // fresh — no storageState
+        const smPage = await context.newPage();
 
-        // Switch this browser's cookies to the shop_manager by logging in via
-        // the WP login form would require its own storage state. Instead we
-        // verify the capability reality through the page object's admin session
-        // AND a REST probe with the shop_manager basic-auth header (below). For
-        // the UI half, we assert the cap is present at the WP level by checking
-        // the REST users/me capability set is out of scope here — the
-        // authoritative UI gate (manage_woocommerce) is exercised by the REST
-        // case P10 with the shop_manager token. Keep the UI portion minimal:
-        // confirm the admin (a superset of shop_manager caps) reaches the list,
-        // proving the route itself is reachable for manage_woocommerce holders.
-        const abuseReportsPage = new AbuseReportsPage(adminPage);
-        await abuseReportsPage.goToAbuseReportsReact();
-        const listHeadingVisible = await adminPage
-            .locator(abuseReportsPage.adminReact.pageHeading)
-            .isVisible()
-            .catch(() => false);
-        expect(
-            listHeadingVisible,
-            'The list route is reachable for manage_woocommerce holders (shop_manager has this cap + dokandar) — documents the gap that shop_manager is NOT blocked',
-        ).toBe(true);
+        await smPage.goto(toPath('wp-login.php'), { waitUntil: 'domcontentloaded' });
+        await smPage.locator('#user_login').fill(SHOP_MANAGER_USER);
+        await smPage.locator('#user_pass').fill(SHOP_MANAGER_PASS);
+        await smPage.locator('#wp-submit').dispatchEvent('click');
 
-        await adminPage.close();
+        // Fails loudly if beforeAll's swallowed `wp user create` never produced
+        // the account, rather than silently testing a logged-out session.
+        await expect
+            .poll(
+                async () => {
+                    const cookie = (await context.cookies()).find(c => c.name.startsWith('wordpress_logged_in_'));
+                    return cookie ? decodeURIComponent(cookie.value).split('|')[0] : undefined;
+                },
+                { timeout: 30000, message: `${SHOP_MANAGER_USER} should be logged in` },
+            )
+            .toBe(SHOP_MANAGER_USER);
+
+        const abuseReportsPage = new AbuseReportsPage(smPage);
+        await smPage.goto(abuseReportsPage.admin.abuseReportsUrl, { waitUntil: 'domcontentloaded' });
+        await expect(
+            smPage.locator(abuseReportsPage.adminReact.pageHeading),
+            'A shop_manager reaches the abuse-reports list (has manage_woocommerce + dokandar) — documents the gap that shop_manager is NOT blocked',
+        ).toBeVisible({ timeout: 30000 });
+
+        await smPage.close();
         await context.close();
     });
 
@@ -332,11 +352,22 @@ test.describe('Abuse Reports — Permissions & Module Gating @pro', () => {
         // Directly visiting the list route now renders nothing / a gated view —
         // the React route is not registered, so the list heading is absent.
         await adminFlow.navigateTo(adminFlow.admin.abuseReportsUrl);
-        await adminPage.waitForLoadState('load').catch(() => undefined);
-        const listHeadingVisible = await adminPage
-            .locator(adminFlow.adminReact.pageHeading)
-            .isVisible()
-            .catch(() => false);
+
+        // Wait for the SPA to actually settle before asserting an absence.
+        // navigateTo() is page.goto() (default waitUntil 'load'), so the
+        // waitForLoadState('load') that used to sit here was a no-op, and
+        // Locator.isVisible() does not wait. The admin shell mounts inside
+        // domReady() and React commits in a later task, so the heading could
+        // not possibly be painted at that instant — the assertion passed even
+        // when the route WAS registered. With the module off the route is
+        // unregistered and react-router falls through to the `path: '*'`
+        // catch-all (Dashboard.tsx), which renders AdminNotFound's
+        // "Sorry, the page can't be found" heading (src/layout/admin404.tsx).
+        // Anchor on that positive signal, THEN assert the list heading is gone.
+        await adminPage
+            .getByRole('heading', { name: /page can.t be found/i })
+            .waitFor({ state: 'visible', timeout: 30000 });
+        const listHeadingVisible = await adminPage.locator(adminFlow.adminReact.pageHeading).isVisible();
         expect(
             listHeadingVisible,
             'Abuse Reports list heading must be absent when the module is disabled',

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsSecurity.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsSecurity.spec.ts
@@ -421,11 +421,14 @@ test.describe('Abuse Reports — Security (XSS / CSRF / SQLi) @pro', () => {
             // reason, so the filter clause is dropped and we get the unfiltered
             // list back — but it is NEVER concatenated into SQL. We assert it
             // returns a valid JSON array and did not error 5xx.
-            expect(response.status(), `Injection reason "${reason}" should not 5xx the endpoint`).toBeLessThan(500);
-            if (response.status() === 200) {
-                const body = await response.json();
-                expect(Array.isArray(body), 'Body should be a JSON array (no SQL error leaked)').toBe(true);
-            }
+            // Asserted unconditionally at 200, not `< 500` with the body check
+            // nested behind `if (status === 200)`: any 4xx used to satisfy the
+            // outer tolerance AND skip the substantive JSON-shape check, so the
+            // only assertion proving no SQL error leaked was silently bypassed.
+            // 200 subsumes the `< 500` intent and matches abuseReportsList.spec.ts:474.
+            expect(response.status(), `Injection reason "${reason}" should be accepted as a plain string filter (200)`).toBe(200);
+            const body = await response.json();
+            expect(Array.isArray(body), 'Body should be a JSON array (no SQL error leaked)').toBe(true);
         }
 
         await ctx.dispose();
@@ -471,11 +474,18 @@ test.describe('Abuse Reports — Security (XSS / CSRF / SQLi) @pro', () => {
         // check_ajax_referer() dies with `-1` (HTTP 200 body "-1") or 403 when
         // the nonce is missing/invalid. Accept either: assert the body is NOT a
         // success envelope.
+        // The third disjunct used to be `!body.includes('"success":true')`, which
+        // is satisfied by a 500, an empty body, or admin-ajax's "0" for an action
+        // that is not registered at all — so this reported "CSRF correctly
+        // rejected" for outcomes proving no nonce check ever ran. Assert the
+        // check_ajax_referer signature specifically, with a positive control
+        // that the action exists.
         const noNonceBody = await noNonce.text();
-        const noNonceRejected =
-            noNonce.status() === 403 ||
-            noNonceBody.trim() === '-1' ||
-            !noNonceBody.includes('"success":true');
+        expect(
+            noNonceBody.trim(),
+            'admin-ajax returned "0": the dokan_report_abuse_submit_form action is not registered, so this probe proves nothing about nonce enforcement',
+        ).not.toBe('0');
+        const noNonceRejected = noNonce.status() === 403 || noNonceBody.trim() === '-1';
         expect(noNonceRejected, `Submit with NO nonce should be rejected (status ${noNonce.status()}, body ${noNonceBody.slice(0, 80)})`).toBe(true);
 
         // (b) Wrong/garbage nonce.
@@ -491,10 +501,11 @@ test.describe('Abuse Reports — Security (XSS / CSRF / SQLi) @pro', () => {
             },
         });
         const wrongNonceBody = await wrongNonce.text();
-        const wrongNonceRejected =
-            wrongNonce.status() === 403 ||
-            wrongNonceBody.trim() === '-1' ||
-            !wrongNonceBody.includes('"success":true');
+        expect(
+            wrongNonceBody.trim(),
+            'admin-ajax returned "0": the dokan_report_abuse_submit_form action is not registered, so this probe proves nothing about nonce enforcement',
+        ).not.toBe('0');
+        const wrongNonceRejected = wrongNonce.status() === 403 || wrongNonceBody.trim() === '-1';
         expect(wrongNonceRejected, `Submit with WRONG nonce should be rejected (status ${wrongNonce.status()}, body ${wrongNonceBody.slice(0, 80)})`).toBe(true);
 
         await ctx.dispose();

--- a/tests/pw/tests/e2e/abuse-reports/abuseReportsSettings.spec.ts
+++ b/tests/pw/tests/e2e/abuse-reports/abuseReportsSettings.spec.ts
@@ -238,6 +238,23 @@ test.describe('Abuse Reports — Admin Settings @pro', () => {
         // not a word-count one, so we can detect a true length cap.
         const longReason = `${REASON_BASE}-` + 'x'.repeat(300);
 
+        // POSITIVE CONTROL. The "rejected" branch below concludes that the
+        // settings layer refused an over-length reason — but "nothing was
+        // stored" is also what a totally broken add/save path looks like, and
+        // readReasonValues() degrades a failed option read to []. Persist a
+        // normal-length reason FIRST, in its own save cycle, so the rejection
+        // branch can prove the path was healthy rather than assert a constant.
+        const controlReason = `${REASON_BASE} Ctrl ${faker.string.nanoid(6)}`;
+        await abuseReportsPage.goToSettingsPage();
+        await abuseReportsPage.searchSettings(abuseReportsPage.testData.abuseReports.settingsSearchKeyword);
+        await abuseReportsPage.fillNewAbuseReason(controlReason);
+        await abuseReportsPage.clickAddReasonPlusButton();
+        await abuseReportsPage.clickSaveChanges();
+        expect(
+            await readReasonValues(),
+            'Control: a normal-length reason must persist, proving the add/save path works',
+        ).toContain(controlReason);
+
         await abuseReportsPage.goToSettingsPage();
         await abuseReportsPage.searchSettings(abuseReportsPage.testData.abuseReports.settingsSearchKeyword);
 
@@ -261,8 +278,14 @@ test.describe('Abuse Reports — Admin Settings @pro', () => {
         // the known gap (a >191-char reason can be selected on the form but is
         // truncated to 191 when a report is created).
         if (stored === undefined) {
-            // Reason was rejected outright — that satisfies the case.
-            expect(true, 'Over-length reason was rejected at the settings layer').toBe(true);
+            // Reason was rejected outright — that satisfies the case, but ONLY
+            // if the save path itself still works. Without this the branch was
+            // `expect(true).toBe(true)` and a total regression of the reason-add
+            // path (or a failed option read) reported green.
+            expect(
+                after,
+                'Over-length reason was rejected at the settings layer (control reason still persisted, so the save path is healthy)',
+            ).toContain(controlReason);
         } else {
             const noteGap = stored.length > REASON_TABLE_VARCHAR_LIMIT;
             // Assert the real, observable behaviour rather than weaken it: the
@@ -395,7 +418,14 @@ test.describe('Abuse Reports — Admin Settings @pro', () => {
         expect(await readSettingA(), 'Setting A should be ON for this guest-block test').toBe('on');
 
         // Baseline DB row count before the guest attempt.
-        const beforeRows = await dbUtils.getMaxId('id', 'dokan_report_abuse_reports').catch(() => 0);
+        // No `.catch(() => 0)` fallback on either read. Both sides used to
+        // collapse to the same literal 0 on a DB error, so a missing/renamed
+        // abuse-reports table turned the "no new row" assertion below into
+        // expect(0).toBe(0) — green exactly when the probe was broken. An
+        // un-guarded read is the established pattern (abuseReportsList.spec.ts:77)
+        // and the happy path is unaffected: an empty table yields null on both
+        // reads, which still compares equal.
+        const beforeRows = await dbUtils.getMaxId('id', 'dokan_report_abuse_reports');
 
         // Guest context.
         const guestCtx = await browser.newContext();
@@ -438,7 +468,7 @@ test.describe('Abuse Reports — Admin Settings @pro', () => {
         await guestCtx.close();
 
         // No new report row should have been created by the blocked guest.
-        const afterRows = await dbUtils.getMaxId('id', 'dokan_report_abuse_reports').catch(() => 0);
+        const afterRows = await dbUtils.getMaxId('id', 'dokan_report_abuse_reports');
         expect(
             afterRows,
             'A blocked guest must not create a new abuse-report row',
@@ -485,29 +515,30 @@ test.describe('Abuse Reports — Admin Settings @pro', () => {
         await abuseReportsPage.clickAddReasonPlusButton();
         await abuseReportsPage.clickSaveChanges();
 
-        // Success feedback: Dokan settings render a "Setting has been saved
-        // successfully." toast/notice. Match permissively (toast OR notice OR
-        // the canonical text), and treat the persisted change as the
-        // load-bearing success signal so a re-styled toast doesn't flake.
+        // Persistence — the change actually reached the option.
         const persisted = await readReasonValues();
         expect(
             persisted,
             'The saved reason should be present in the option (save succeeded)',
         ).toContain(feedbackReason);
 
-        const feedbackVisible = await adminPage
-            .locator(
-                "//*[contains(translate(normalize-space(.), 'SAVED', 'saved'), 'saved successfully') or contains(normalize-space(.), 'Setting has been saved')]",
-            )
-            .first()
-            .isVisible()
-            .catch(() => false);
-        // The toast is transient; persistence above is the hard assertion,
-        // this is a soft confirmation that the UI surfaced feedback at all.
-        expect(
-            feedbackVisible || persisted.includes(feedbackReason),
-            'Save should surface success feedback (toast/notice) or at minimum persist the change',
-        ).toBe(true);
+        // Success feedback — the behaviour this case is named for. Asserted
+        // hard, against the real element: src/admin/pages/Settings.vue:8 renders
+        // `#setting-message_updated` with `v-if="isSaved"` and the `updated`
+        // class when `isUpdated`. It is NOT transient — `isSaved` is only
+        // cleared by the user clicking dismiss (Settings.vue:10) — so waiting on
+        // it cannot flake.
+        //
+        // This previously read `expect(feedbackVisible || persisted.includes(...))`,
+        // whose right-hand side was already proven true by the assertion above,
+        // making the whole disjunction constant. Deleting the notice entirely
+        // still left this test green.
+        const saveNotice = adminPage.locator('#setting-message_updated.updated');
+        await expect(saveNotice, 'Save should surface the success notice').toBeVisible({ timeout: 15000 });
+        await expect(
+            saveNotice,
+            'Success notice should carry the "saved successfully" message',
+        ).toContainText(/saved successfully/i);
 
         // No console errors during the settings save flow.
         expect(

--- a/tests/pw/tests/e2e/request-for-quotes/requestForQuotes.spec.ts
+++ b/tests/pw/tests/e2e/request-for-quotes/requestForQuotes.spec.ts
@@ -152,6 +152,11 @@ test.describe('Request for quotation test customer', () => {
                 await apiUtils.updatePaymentGateway(id, { ...payload, enabled: false }, payloads.adminAuth);
             }
         }
+        // The converted order is paid via Direct Bank Transfer (bacs). It is enabled by default, but an
+        // earlier test in the shard can leave it disabled (the Docker DB is shared across the whole shard),
+        // and then its checkout radio never renders → a 30s locator.click timeout on the pay page. Assert
+        // the precondition instead of assuming it, symmetric with disabling the marketplace gateways above.
+        await apiUtils.updatePaymentGateway('bacs', { enabled: true }, payloads.adminAuth);
         await apiUtils.convertQuoteToOrder(quoteId, payloads.adminAuth);
         await customer.payConvertedQuote(quoteId);
     });

--- a/tests/pw/tests/e2e/stripe-express/stripeExpressGuest.spec.ts
+++ b/tests/pw/tests/e2e/stripe-express/stripeExpressGuest.spec.ts
@@ -25,7 +25,13 @@ import {
  * configures the global gateway. Checkout/charge tests self-skip without keys (`!hasCredentials`).
  */
 test.describe.serial('Stripe Express — SE-GUEST (guest checkout) @pro', () => {
-    test.describe.configure({ timeout: 150_000 });
+    // 240s (not 150s): on CI runner IPs Stripe Link's invisible hCaptcha escalates to a visible
+    // challenge that blocks the in-page card confirm, so the SPA never redirects to /order-received.
+    // The order still settles via the server-side PaymentIntent-confirm fallback (real payment,
+    // verified locally with SIMULATE_CONFIRM_BLOCK=1 ≈ 90s), but the wasted redirect wait + the
+    // fallback poll overran the old 150s budget on the slower shared runner (all 3 attempts hit
+    // exactly 150s). Match the sibling real-card+confirm+fallback specs (savedCards/settings/3ds).
+    test.describe.configure({ timeout: 240_000 });
 
     let productId: string;
 

--- a/tests/pw/tests/e2e/vendor-auction/newAuction.spec.ts
+++ b/tests/pw/tests/e2e/vendor-auction/newAuction.spec.ts
@@ -125,12 +125,16 @@ test.describe('Auction (React) functionality', () => {
             expect(await auctionProductNames(p.name), 'the product is gone from the auction REST list').not.toContain(p.name);
         });
 
-        test('the row Edit action leaves the SPA toward the legacy auction editor (React→legacy)', { tag: ['@pro', '@vendor', '@new-ui'] }, async () => {
+        test('the row Edit action opens the auction product in the React product editor (#/products/:id/edit)', { tag: ['@pro', '@vendor', '@new-ui'] }, async () => {
             const p = await seedAuction();
             await auction.gotoList();
             await auction.search(p.name);
             const target = await auction.editActionTarget(p.name);
-            expect(target, 'Edit navigates to the legacy auction editor (not a #/ SPA route)').toMatch(/product_id=|action=edit|\/auction\//i);
+            // Auctions are now editable inside the React product editor: the React product list
+            // deliberately keeps the `auction` type in the listing and the editor accepts
+            // `?type=auction`, so the backend returns a SPA `edit_url` (#/products/<id>/edit) and
+            // the row Edit action stays in the SPA instead of bouncing to the legacy auction editor.
+            expect(target, 'Edit opens the React product editor at #/products/<id>/edit').toMatch(/#\/?products\/\d+\/edit/i);
         });
 
         test('HashRouter survives a reload on /auction (React)', { tag: ['@pro', '@vendor', '@new-ui'] }, async () => {

--- a/tests/pw/tests/e2e/vendor-auction/newAuctionPage.ts
+++ b/tests/pw/tests/e2e/vendor-auction/newAuctionPage.ts
@@ -231,7 +231,7 @@ export class NewAuctionPage {
         await this.waitForSettle();
     }
 
-    /** Click the Edit row action and report the href/nav it targets (should be legacy). */
+    /** Click the Edit row action and report the URL it navigates to (the React product editor). */
     async editActionTarget(text: string): Promise<string> {
         await this.openRowMenu(text);
         const edit = this.page.getByRole('menuitem', { name: /^Edit$/i }).first();


### PR DESCRIPTION
- requestForQuotes: ensure Direct Bank Transfer (bacs) is enabled before paying the converted quote. An earlier test in the same shard can leave bacs disabled (shared Docker DB), so its checkout radio never renders and the click times out after 30s. Assert the precondition, symmetric with the marketplace gateways the test already disables.

- newAuction: the row Edit action now opens the React product editor at #/products/<id>/edit. Auctions are editable in the SPA (the React product list keeps the auction type and the editor accepts ?type=auction), so assert the SPA editor route instead of the stale legacy-editor expectation.

- stripeExpressGuest: raise the SE-GUEST describe timeout from 150s to 240s. On CI runner IPs Stripe Link's hCaptcha escalates and blocks the in-page confirm, so the order settles via the server-side PaymentIntent-confirm fallback; the wasted redirect wait plus the fallback poll overran 150s (all 3 attempts hit exactly 150s). 240s matches the sibling real-card specs.

- abuseReports: scope the confirmation OK locator to the visible dialog to avoid an intermittent strict-mode "resolved to 2 elements" violation when a second OK button transiently coexists with the SweetAlert2 confirm.

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes #


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

*Title*

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved abuse-report submission flows by scoping and stabilizing confirmation-modal interactions.
  * Refined abuse-report UI checks (settings headings, modal sections) to reduce false positives and race conditions.
  * Hardened abuse-report security tests with stricter HTTP/JSON and CSRF/nonce rejection criteria.
  * Strengthened abuse-report list and permissions gating assertions, including server-side verification around delete behavior.
  * Updated checkout prep for quote-to-order conversion by explicitly re-enabling the bank transfer option.
  * Adjusted Stripe express suite timeout and updated vendor auction “row Edit” navigation expectations.
* **Documentation**
  * Updated test guidance to reflect the React product editor navigation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->