### PR TITLE
fix(dashboard): stop double page load and remove duplicated JS bundles

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -742,6 +742,35 @@ class Assets {
                 'deps'    => $stores_asset['dependencies'],
             ];
         }
+        /*
+         * Shared third-party UI bundles.
+         *
+         * These packages are imported by several entries (components, frontend, product editor,
+         * admin dashboard). They are built once into their own bundles and externalised in
+         * webpack-dependency-mapping.js, so each is downloaded and parsed a single time instead
+         * of being inlined into every consuming bundle.
+         */
+        $shared_ui_bundles = [
+            'dokan-plugin-ui' => 'plugin-ui',
+            'dokan-ui'        => 'dokan-ui',
+        ];
+
+        foreach ( $shared_ui_bundles as $handle => $bundle ) {
+            $shared_ui_asset_file = DOKAN_DIR . '/assets/js/' . $bundle . '.asset.php';
+
+            if ( ! file_exists( $shared_ui_asset_file ) ) {
+                continue;
+            }
+
+            $shared_ui_asset = require $shared_ui_asset_file;
+
+            $scripts[ $handle ] = [
+                'version' => $shared_ui_asset['version'],
+                'src'     => $asset_url . '/js/' . $bundle . '.js',
+                'deps'    => $shared_ui_asset['dependencies'],
+            ];
+        }
+
         $product_editor_utils_file = DOKAN_DIR . '/assets/js/product-editor-utils.asset.php';
         if ( file_exists( $product_editor_utils_file ) ) {
             $utils_asset = require $product_editor_utils_file;

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -759,6 +759,21 @@ class Assets {
             $shared_ui_asset_file = DOKAN_DIR . '/assets/js/' . $bundle . '.asset.php';
 
             if ( ! file_exists( $shared_ui_asset_file ) ) {
+                /*
+                 * Unlike the other bundles above, these handles are declared as dependencies of the
+                 * consuming bundles. A missing artifact therefore does not just drop this script —
+                 * WordPress refuses to enqueue every consumer too, taking the React UI down with it.
+                 * Log loudly so a broken build is diagnosable instead of failing silently.
+                 */
+                dokan_log(
+                    sprintf(
+                        'Missing shared UI asset file %1$s. The "%2$s" script handle will not be registered, so every bundle depending on it will be skipped by WordPress. Run the asset build.',
+                        $shared_ui_asset_file,
+                        $handle
+                    ),
+                    'error'
+                );
+
                 continue;
             }
 

--- a/src/externals/dokan-ui.js
+++ b/src/externals/dokan-ui.js
@@ -11,5 +11,7 @@
  *
  * Existing deep imports elsewhere (`@getdokan/dokan-ui/dist/components/*`) are left untouched:
  * they do not match the externalised bare specifier and remain bundled with their consumer.
+ *
+ * @since DOKAN_SINCE
  */
 export * from '@getdokan/dokan-ui/dist/index.js';

--- a/src/externals/dokan-ui.js
+++ b/src/externals/dokan-ui.js
@@ -1,0 +1,15 @@
+/**
+ * Shared bundle for `@getdokan/dokan-ui`.
+ *
+ * Same rationale as plugin-ui.js: the package was being inlined into every entry that imports
+ * it (~0.7MB a copy). Building it once and mapping the bare `@getdokan/dokan-ui` specifier to
+ * the `window.dokan.dokanUI` global lets all consumers share one copy via the `dokan-ui` handle.
+ *
+ * NOTE: the deep `dist/index.js` import is intentional — the bare specifier is externalised, so
+ * importing it here would make this bundle re-export itself. This package ships no `exports`
+ * map, so the deep path resolves fine.
+ *
+ * Existing deep imports elsewhere (`@getdokan/dokan-ui/dist/components/*`) are left untouched:
+ * they do not match the externalised bare specifier and remain bundled with their consumer.
+ */
+export * from '@getdokan/dokan-ui/dist/index.js';

--- a/src/externals/plugin-ui.js
+++ b/src/externals/plugin-ui.js
@@ -13,5 +13,7 @@
  * bare specifier. The bare specifier is externalised, so importing it here would make this
  * bundle re-export itself; the package's `exports` map also does not expose `./dist/*`, which
  * rules out a deep package import.
+ *
+ * @since DOKAN_SINCE
  */
 export * from '../../node_modules/@wedevs/plugin-ui/dist/index.js';

--- a/src/externals/plugin-ui.js
+++ b/src/externals/plugin-ui.js
@@ -1,0 +1,17 @@
+/**
+ * Shared bundle for `@wedevs/plugin-ui`.
+ *
+ * This package is imported by several entry points (components, frontend, product-editor-utils,
+ * dokan-admin-dashboard). Without a shared bundle webpack inlines a full ~3.5MB copy into each
+ * one, so the vendor dashboard downloads and parses the same code three times over.
+ *
+ * Building it once here — and mapping the bare `@wedevs/plugin-ui` specifier to the
+ * `window.dokan.pluginUI` global in webpack-dependency-mapping.js — means every consumer shares
+ * a single copy, loaded via the `dokan-plugin-ui` script handle.
+ *
+ * NOTE: the import below deliberately uses a relative path into node_modules rather than the
+ * bare specifier. The bare specifier is externalised, so importing it here would make this
+ * bundle re-export itself; the package's `exports` map also does not expose `./dist/*`, which
+ * rules out a deep package import.
+ */
+export * from '../../node_modules/@wedevs/plugin-ui/dist/index.js';

--- a/src/vendor-dashboard/reports/helper.ts
+++ b/src/vendor-dashboard/reports/helper.ts
@@ -69,8 +69,11 @@ export const shouldBlockNavigation = () => {
             ( rule ) => rule.path === currentURLPath
         );
 
+    // On a dashboard root with no analytics `path` query, render the default report inline
+    // (handled by the `/` route in controller.js) instead of hard-redirecting the browser.
+    // This keeps the URL at the dashboard root and avoids a second full page load.
     if ( isAnalyticsExcluded && matchingRedirectRule ) {
-        document.location.href = matchingRedirectRule.redirect;
+        return applyFilters( BLOCK_NAVIGATION_FILTER, false );
     }
 
     return applyFilters( BLOCK_NAVIGATION_FILTER, isAnalyticsExcluded );

--- a/src/vendor-dashboard/reports/helper.ts
+++ b/src/vendor-dashboard/reports/helper.ts
@@ -69,11 +69,17 @@ export const shouldBlockNavigation = () => {
             ( rule ) => rule.path === currentURLPath
         );
 
-    // On a dashboard root with no analytics `path` query, render the default report inline
-    // (handled by the `/` route in controller.js) instead of hard-redirecting the browser.
-    // This keeps the URL at the dashboard root and avoids a second full page load.
     if ( isAnalyticsExcluded && matchingRedirectRule ) {
-        return applyFilters( BLOCK_NAVIGATION_FILTER, false );
+        // On the dashboard root the `/` route registered in controller.js renders the default
+        // report inline, so no hard redirect is needed. That redirect cost a second full page
+        // load; skipping it keeps the URL at the dashboard root and loads the page once.
+        if ( currentURLPath === vendorAnalyticsDokanConfig.dashboardPath ) {
+            return applyFilters( BLOCK_NAVIGATION_FILTER, false );
+        }
+
+        // Every other rule (e.g. the reports page) keeps its original redirect fallback,
+        // since no inline route is registered for those paths.
+        document.location.href = matchingRedirectRule.redirect;
     }
 
     return applyFilters( BLOCK_NAVIGATION_FILTER, isAnalyticsExcluded );

--- a/src/vendor-dashboard/reports/layout/controller.js
+++ b/src/vendor-dashboard/reports/layout/controller.js
@@ -43,7 +43,7 @@ export const getPages = () => {
   const initialBreadcrumbs = [["", __( 'Dashboard', 'dokan-lite' )]];
 
   if ( getAdminSetting( 'isAnalyticsEnabled' ) ) {
-    pages.push({
+    const overviewPage = {
       container   : Dashboard,
       path        : "/analytics/overview",
       breadcrumbs : [
@@ -54,7 +54,13 @@ export const getPages = () => {
       wpOpenMenu  : "toplevel_page_wc-admin-path--analytics-overview",
       navArgs     : { id : "woocommerce-analytics-overview" },
       capability  : "dokandar",
-    });
+    };
+
+    pages.push( overviewPage );
+
+    // Default route: render the Overview inline at the dashboard root (empty `path` query),
+    // so hitting `/dashboard/` shows Overview without a redirect — avoiding the double page load.
+    pages.push({ ...overviewPage, path: "/" });
   }
 
   /**

--- a/src/vendor-dashboard/reports/layout/navigation.js
+++ b/src/vendor-dashboard/reports/layout/navigation.js
@@ -21,6 +21,8 @@ import getReports from "../analytics/report/get-reports";
 import { getPages } from "./controller";
 import Navigation from "reports/navigation";
 
+const isSameNavItem = (page) => (item) => item.navArgs.id === page.navArgs.id;
+
 const NavigationPlugin = () => {
   const { persistedQuery } = useSelect((select) => {
     return {
@@ -49,6 +51,10 @@ const NavigationPlugin = () => {
 
   const pages = getPages()
     .filter((page) => page.navArgs)
+    // Overview is routed at both `/analytics/overview` and the dashboard root
+    // `/`. Aliases share a `navArgs.id`, so keep the first (canonical) one to
+    // avoid duplicate navigation items and duplicate React keys.
+    .filter((page, i, all) => all.findIndex(isSameNavItem(page)) === i)
     .map((page) => {
       if (page.path === "/analytics/settings") {
         return {

--- a/webpack-dependency-mapping.js
+++ b/webpack-dependency-mapping.js
@@ -9,6 +9,25 @@ const { kebabCase } = require( 'lodash' );
 
 const WOOCOMMERCE_NAMESPACE = '@woocommerce/';
 
+/**
+ * Third-party UI packages that are shared across multiple entry points.
+ *
+ * Each is built once as a standalone bundle exposed on a `window.dokan.*` global, so consuming
+ * bundles reference the global instead of inlining their own copy of the package.
+ *
+ * @type {Object.<string, {external: string[], handle: string}>}
+ */
+const SHARED_UI_EXTERNALS = {
+    '@wedevs/plugin-ui': {
+        external: [ 'dokan', 'pluginUI' ],
+        handle: 'dokan-plugin-ui',
+    },
+    '@getdokan/dokan-ui': {
+        external: [ 'dokan', 'dokanUI' ],
+        handle: 'dokan-ui',
+    },
+};
+
 const packages = [
     // wc-admin packages
     '@woocommerce/admin-layout',
@@ -127,6 +146,14 @@ const requestToExternal = ( request ) => {
         return false;
     }
 
+    // Shared UI packages: built once as their own bundles (see webpack.config.js) so they are
+    // not inlined into every entry that imports them. Only the bare specifier is mapped —
+    // deep imports such as `@getdokan/dokan-ui/dist/components/Button` stay bundled, and the
+    // shim entries in src/externals/ rely on that to avoid re-exporting themselves.
+    if ( SHARED_UI_EXTERNALS[ request ] ) {
+        return SHARED_UI_EXTERNALS[ request ].external;
+    }
+
     const dokanStores = request.match( /^@dokan\/stores\/(.+)$/ );
     const wc = request.match( /^@woocommerce\/(.+)$/ );
     const dokan = request.match( /^@dokan\/([^/]+)$/ );
@@ -162,6 +189,9 @@ const requestToExternal = ( request ) => {
  * @return {string} Handle name for the package.
  */
 const requestToHandle = ( request ) => {
+    if ( SHARED_UI_EXTERNALS[ request ] ) {
+        return SHARED_UI_EXTERNALS[ request ].handle;
+    }
 
     const dokan = request.match( /^@dokan\/stores\/(.+)$/ );
     const wc = request.match( /^@woocommerce\/(.+)$/ );

--- a/webpack-dependency-mapping.js
+++ b/webpack-dependency-mapping.js
@@ -15,6 +15,8 @@ const WOOCOMMERCE_NAMESPACE = '@woocommerce/';
  * Each is built once as a standalone bundle exposed on a `window.dokan.*` global, so consuming
  * bundles reference the global instead of inlining their own copy of the package.
  *
+ * @since DOKAN_SINCE
+ *
  * @type {Object.<string, {external: string[], handle: string}>}
  */
 const SHARED_UI_EXTERNALS = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,23 @@ const updatedConfig = {
     },
     entry: {
         ...entryPoints,
+        // Shared third-party UI bundles. These are imported by several entries; building them
+        // once and externalising the bare specifiers (see webpack-dependency-mapping.js) keeps
+        // webpack from inlining a full copy of each into every consuming bundle.
+        'plugin-ui': {
+            import: './src/externals/plugin-ui.js',
+            library: {
+                name: [ 'dokan', 'pluginUI' ],
+                type: 'window',
+            },
+        },
+        'dokan-ui': {
+            import: './src/externals/dokan-ui.js',
+            library: {
+                name: [ 'dokan', 'dokanUI' ],
+                type: 'window',
+            },
+        },
         components: {
             import: './src/components/index.tsx',
             library: {


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the WordPress' coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Two vendor-dashboard performance fixes.

**1. `fix(analytics)` — dashboard root loaded the page twice**

The dashboard root (`/dashboard/`) has no analytics `path` query param, so `shouldBlockNavigation()` in `helper.ts` hard-redirected via `document.location.href` to `?path=%2Fanalytics%2FOverview`. That is a full browser navigation, so the entire page — PHP render, React bundle download/parse, app mount — loaded **twice** before Overview settled.

Now a default route maps the empty path (`/`) to the Overview container, and the dashboard root no longer blocks or redirects. `/dashboard/` renders Overview on a single load with the URL unchanged.

**2. `perf(assets)` — shared UI packages were inlined into every bundle**

`@wedevs/plugin-ui` and `@getdokan/dokan-ui` were not declared as webpack externals, so webpack inlined a full copy of each into **every entry that imports them**. The vendor dashboard downloaded and parsed byte-identical code three times over.

Each package is now built once as its own bundle exposed on a `window.dokan.*` global, with the bare specifiers mapped to those globals via a new `SHARED_UI_EXTERNALS` table, loaded through the new `dokan-plugin-ui` and `dokan-ui` script handles.

Only bare specifiers are externalised — deep imports (`@getdokan/dokan-ui/dist/components/*`) stay bundled, and the `src/externals/` shims rely on that to avoid re-exporting themselves.

Because `dokan-pro/webpack.config.js` imports this same dependency mapping from Lite, dokan-pro picks the fix up on its next rebuild with no Pro-side change.

### Related Pull Request(s)

* N/A

### Closes

* Closes getdokan/plugin-internal-tasks#2160 — dashboard loads twice
* Closes getdokan/plugin-internal-tasks#2162 — duplicated shared UI bundles

_(cross-repo — close manually on merge; GitHub does not auto-close across repositories)_

### How to test the changes in this Pull Request:

**Double load**

1. Log in as a vendor, go to `https://<site>/dashboard/`.
2. Overview renders, URL stays `/dashboard/` (no `?path=`), a **single** document load — `performance.getEntriesByType('navigation').length === 1`.
3. Deep-link `?path=%2Fanalytics%2Foverview` still renders Overview (backward compatible).
4. Click into a sub-report (Products/Orders) — renders, URL gains `?path=`, no page reload.

**Shared bundles**

5. `npm run build`, confirm `assets/js/plugin-ui.js` and `assets/js/dokan-ui.js` are emitted.
6. In the browser console on the dashboard: `window.dokan.pluginUI` and `window.dokan.dokanUI` are objects.
7. Exercise the vendor dashboard, product list, quick-create modal, and product editor — all UI must render normally.
8. Console shows no router or missing-export errors.

### Changelog entry

*Title*

Fix vendor dashboard loading twice and remove duplicated JS bundles.

**Before:** Visiting `/dashboard/` hard-redirected to `?path=%2Fanalytics%2FOverview`, causing two full page loads. Shared UI packages were copied into every JS bundle, so the dashboard shipped ~8.5 MB of duplicated code.

**After:** `/dashboard/` renders Overview inline on a single load with the URL unchanged, and the shared UI packages are downloaded and parsed once.

### Before Changes

* `/dashboard/` → hard redirect → two full page loads.
* `@wedevs/plugin-ui` and `@getdokan/dokan-ui` bundled 4x each (10.56 MB + 2.16 MB wasted).

### After Changes

| metric | before | after |
|---|---|---|
| Dashboard JS parsed | 15.93 MB | **7.47 MB** (−53%) |
| Dashboard JS gzipped | 3.55 MB | **1.68 MB** (−53%) |
| Registered script closure | 29,793 KB | **20,348 KB** |
| `@wedevs/plugin-ui` copies | 4 | **1** |
| `@getdokan/dokan-ui` copies | 4 | **1** |
| dokan-lite zip | 37.94 MB | **34.21 MB** (−9.8%) |
| dokan-pro zip (on rebuild) | 46.65 MB | **35.13 MB** (−24.7%) |

Per bundle: `components.js` 6.58→2.34 MB, `frontend.js` 4.76→0.51 MB, `product-editor-utils.js` 4.59→0.35 MB, `dokan-admin-dashboard.js` 5.67→1.42 MB.

### :warning: Release coordination required

dokan-pro built after this change declares `dokan-plugin-ui` / `dokan-ui` as script dependencies — handles that only exist in Lite from this PR onward. WordPress silently skips enqueuing a script whose dependency is unregistered, so **a new Pro running on an older Lite would drop those scripts and break Pro's React UI.**

Pro's minimum required Lite version must be bumped, or the two shipped together.

### Reviewer notes

* Verified: jsdom smoke test — both shared bundles execute clean, `pluginUI` exposes 276 exports and `dokanUI` 43, with **0 missing** of the 6 + 19 named imports the source uses. Both handles register in PHP with correct dependency chains. PHPCS clean; ESLint 14 → 13 problems (none introduced).
* **Not yet verified:** manual browser click-through (Chrome automation was unavailable during development). Steps 1–8 above still need a human pass before merge.
* Known remainder, deliberately out of scope: `quill` is still duplicated 4x (0.20 MB) via `src/components/richtext/RichText.tsx`; `@wordpress/dataviews` (1.11 MB) cannot be externalised because `wp-dataviews` is not a registered WP script handle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The dashboard root now shows the Analytics Overview directly (the existing `/analytics/overview` route remains available).
* **Bug Fixes**
  * Prevented unnecessary hard redirects from the dashboard root when navigation rules apply, keeping the current URL in place.
  * Removed duplicate navigation items when multiple pages share the same identifier.
* **Performance Improvements**
  * Shared third-party UI bundles are now reused across bundles via shared loading/externals mapping.
  * Shared UI bundles are only registered when available; missing bundles now log an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->