### PR TITLE
fix(settings): stop reading Dokan settings before init

### DIFF
--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -30,23 +30,31 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     ) {
         $this->new_repo = $new_repo ?? new SettingsRepository();
         $this->bridge   = $bridge ?? new LegacySettingsBridge();
-        add_action( 'init', [ $this, 'init' ] );
-    }
-    public function init(): void {
 
-        foreach ( $this->known_sections() as $section ) {
-            add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
-            add_action( "add_option_{$section}", [ $this, 'on_section_changed' ] );
-            add_action( "delete_option_{$section}", [ $this, 'on_section_changed' ] );
-        }
-
-        // The new flat option participates in every overlay — its writes invalidate
-        // every snapshot. Use named callbacks so the same listener isn't bound twice
-        // if the repository is instantiated more than once in a request.
-        $new_option = SettingsRepository::OPTION_KEY;
-        add_action( "update_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
-        add_action( "add_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
-        add_action( "delete_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
+        // Section invalidation uses WordPress' generic option hooks, all of
+        // which pass the changed option name as their first argument.
+        //
+        // Binding the per-section `{add,update,delete}_option_{$section}`
+        // variants instead would mean enumerating the bridge mapping here, and
+        // that builds the whole admin settings schema during construction.
+        // `dokan_get_option()` resolves this repository as early as
+        // `plugins_loaded`, so that would (a) run the schema's `esc_html__()`
+        // calls before `init` (WP 6.7+ `_load_textdomain_just_in_time` notice)
+        // and (b) recurse without bound: a schema callback that itself calls
+        // `dokan_get_option()` re-enters the container before the shared
+        // instance is registered, so every nested call builds *another*
+        // repository and bridge — the bridge's own re-entry latch is
+        // per-instance and cannot see the outer build.
+        //
+        // Deferring the binding to `init` is not a way out either: a repository
+        // first constructed after `init` has already fired would never bind at
+        // all and would serve stale snapshots for the rest of the request.
+        //
+        // Snapshots only exist for sections that were read, so `flush_cache()`
+        // is a no-op for every unrelated option.
+        add_action( 'added_option', [ $this, 'on_section_changed' ] );
+        add_action( 'updated_option', [ $this, 'on_section_changed' ] );
+        add_action( 'deleted_option', [ $this, 'on_section_changed' ] );
     }
 
     public function all( string $section ): array {
@@ -161,20 +169,24 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     /**
-     * WP hook listener — receives `($option, …)` from add_option / `($old, $new, $option)` from update_option.
-     * We only need the option name, which we derive from the current filter name.
+     * WP hook listener for `added_option` / `updated_option` / `deleted_option`.
+     * All three pass the changed option name as their first argument.
+     *
+     * @param string $option Option name that changed.
      *
      * @return void
      */
-    public function on_section_changed(): void {
-        $option = current_action();
-        foreach ( [ 'update_option_', 'add_option_' ] as $prefix ) {
-            if ( 0 === strpos( $option, $prefix ) ) {
-                $section = substr( $option, strlen( $prefix ) );
-                $this->flush_cache( $section );
-                return;
-            }
+    public function on_section_changed( $option = '' ): void {
+        $option = (string) $option;
+
+        // The new flat option is the overlay source for *every* section, so its
+        // writes invalidate all snapshots, not just one.
+        if ( SettingsRepository::OPTION_KEY === $option ) {
+            $this->flush_all_snapshots();
+            return;
         }
+
+        $this->flush_cache( $option );
     }
 
     /**
@@ -185,15 +197,6 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
      */
     public function flush_all_snapshots(): void {
         $this->flush_cache( null );
-    }
-
-    /**
-     * Unique legacy wp_option names that the bridge currently knows about.
-     *
-     * @return array<int,string>
-     */
-    private function known_sections(): array {
-        return $this->bridge->known_sections();
     }
 
     /**

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -30,20 +30,15 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     ) {
         $this->new_repo = $new_repo ?? new SettingsRepository();
         $this->bridge   = $bridge ?? new LegacySettingsBridge();
+        add_action( 'init', [ $this, 'init' ] );
+    }
+    public function init(): void {
 
-        // Section invalidation uses WordPress' generic option hooks. Binding the
-        // per-section `{add,update}_option_{$section}` variants would mean
-        // enumerating the bridge mapping here, and that builds the whole admin
-        // settings schema during construction — `dokan_get_option()` resolves
-        // this repository as early as `plugins_loaded`, so the schema's
-        // `esc_html__()` calls would run before `init` (WP 6.7+
-        // `_load_textdomain_just_in_time` notice), and a schema callback that
-        // itself calls `dokan_get_option()` would re-enter construction.
-        // Snapshots only exist for sections that were read, so `flush_cache()`
-        // is a no-op for every unrelated option.
-        add_action( 'added_option', [ $this, 'on_section_changed' ] );
-        add_action( 'updated_option', [ $this, 'on_section_changed' ] );
-        add_action( 'deleted_option', [ $this, 'on_section_changed' ] );
+        foreach ( $this->known_sections() as $section ) {
+            add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
+            add_action( "add_option_{$section}", [ $this, 'on_section_changed' ] );
+            add_action( "delete_option_{$section}", [ $this, 'on_section_changed' ] );
+        }
 
         // The new flat option participates in every overlay — its writes invalidate
         // every snapshot. Use named callbacks so the same listener isn't bound twice
@@ -162,15 +157,20 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     /**
-     * WP hook listener for `added_option` / `updated_option` / `deleted_option`.
-     * All three pass the changed option name as their first argument.
-     *
-     * @param string $option Option name that changed.
+     * WP hook listener — receives `($option, …)` from add_option / `($old, $new, $option)` from update_option.
+     * We only need the option name, which we derive from the current filter name.
      *
      * @return void
      */
-    public function on_section_changed( $option = '' ): void {
-        $this->flush_cache( (string) $option );
+    public function on_section_changed(): void {
+        $option = current_action();
+        foreach ( [ 'update_option_', 'add_option_' ] as $prefix ) {
+            if ( 0 === strpos( $option, $prefix ) ) {
+                $section = substr( $option, strlen( $prefix ) );
+                $this->flush_cache( $section );
+                return;
+            }
+        }
     }
 
     /**
@@ -181,6 +181,22 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
      */
     public function flush_all_snapshots(): void {
         $this->flush_cache( null );
+    }
+
+    /**
+     * Unique legacy wp_option names that the bridge currently knows about.
+     *
+     * @return array<int,string>
+     */
+    private function known_sections(): array {
+        $map      = $this->bridge->get_mapping();
+        $sections = [];
+        foreach ( $map as $entry ) {
+            if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+                $sections[ $entry['option'] ] = true;
+            }
+        }
+        return array_keys( $sections );
     }
 
     /**

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -31,11 +31,19 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
         $this->new_repo = $new_repo ?? new SettingsRepository();
         $this->bridge   = $bridge ?? new LegacySettingsBridge();
 
-        foreach ( $this->known_sections() as $section ) {
-            add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
-            add_action( "add_option_{$section}", [ $this, 'on_section_changed' ] );
-            add_action( "delete_option_{$section}", [ $this, 'on_section_changed' ] );
-        }
+        // Section invalidation uses WordPress' generic option hooks. Binding the
+        // per-section `{add,update}_option_{$section}` variants would mean
+        // enumerating the bridge mapping here, and that builds the whole admin
+        // settings schema during construction — `dokan_get_option()` resolves
+        // this repository as early as `plugins_loaded`, so the schema's
+        // `esc_html__()` calls would run before `init` (WP 6.7+
+        // `_load_textdomain_just_in_time` notice), and a schema callback that
+        // itself calls `dokan_get_option()` would re-enter construction.
+        // Snapshots only exist for sections that were read, so `flush_cache()`
+        // is a no-op for every unrelated option.
+        add_action( 'added_option', [ $this, 'on_section_changed' ] );
+        add_action( 'updated_option', [ $this, 'on_section_changed' ] );
+        add_action( 'deleted_option', [ $this, 'on_section_changed' ] );
 
         // The new flat option participates in every overlay — its writes invalidate
         // every snapshot. Use named callbacks so the same listener isn't bound twice
@@ -154,20 +162,15 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     /**
-     * WP hook listener — receives `($option, …)` from add_option / `($old, $new, $option)` from update_option.
-     * We only need the option name, which we derive from the current filter name.
+     * WP hook listener for `added_option` / `updated_option` / `deleted_option`.
+     * All three pass the changed option name as their first argument.
+     *
+     * @param string $option Option name that changed.
      *
      * @return void
      */
-    public function on_section_changed(): void {
-        $option = current_action();
-        foreach ( [ 'update_option_', 'add_option_' ] as $prefix ) {
-            if ( 0 === strpos( $option, $prefix ) ) {
-                $section = substr( $option, strlen( $prefix ) );
-                $this->flush_cache( $section );
-                return;
-            }
-        }
+    public function on_section_changed( $option = '' ): void {
+        $this->flush_cache( (string) $option );
     }
 
     /**
@@ -178,22 +181,6 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
      */
     public function flush_all_snapshots(): void {
         $this->flush_cache( null );
-    }
-
-    /**
-     * Unique legacy wp_option names that the bridge currently knows about.
-     *
-     * @return array<int,string>
-     */
-    private function known_sections(): array {
-        $map      = $this->bridge->get_mapping();
-        $sections = [];
-        foreach ( $map as $entry ) {
-            if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
-                $sections[ $entry['option'] ] = true;
-            }
-        }
-        return array_keys( $sections );
     }
 
     /**

--- a/includes/Shortcodes/FullWidthVendorLayout.php
+++ b/includes/Shortcodes/FullWidthVendorLayout.php
@@ -27,13 +27,29 @@ class FullWidthVendorLayout implements Hookable {
      */
     public function register_hooks(): void {
         add_action( 'dokan_setup_wizard_styles', [ $this, 'update_layout_style' ] );
-        // Register vendor dashboard assets if the vendor layout is not legacy.
-        $vendor_layout = dokan_get_option( 'vendor_layout_style', 'dokan_appearance', 'legacy' );
-        if ( 'latest' === $vendor_layout ) {
-            add_action( 'init', [ $this, 'register_vendor_dashboard_assets' ], 99 );
-            add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_vendor_dashboard_assets' ] );
-            add_filter( 'template_include', [ $this, 'rewrite_vendor_dashboard_template' ] );
-        }
+        add_action( 'init', [ $this, 'register_vendor_dashboard_assets' ], 99 );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_vendor_dashboard_assets' ] );
+        add_filter( 'template_include', [ $this, 'rewrite_vendor_dashboard_template' ] );
+    }
+
+    /**
+     * Whether the marketplace runs the React (latest) vendor dashboard layout.
+     *
+     * Deliberately resolved per callback instead of once in `register_hooks()`:
+     * hooks are registered on `plugins_loaded`, and reading a Dokan setting
+     * walks the legacy settings bridge, which builds the translated admin
+     * settings schema. Doing that before `init` — where
+     * `load_plugin_textdomain()` runs — trips WordPress 6.7+'s
+     * `_load_textdomain_just_in_time` notice on every request. Every callback
+     * below fires on `init` or later, and the repository memoizes the section
+     * snapshot, so the deferred read costs nothing.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return bool
+     */
+    protected function is_latest_layout(): bool {
+        return 'latest' === dokan_get_option( 'vendor_layout_style', 'dokan_appearance', 'legacy' );
     }
 
     /**
@@ -70,6 +86,10 @@ class FullWidthVendorLayout implements Hookable {
      * @return string Modified template path
      */
     public function rewrite_vendor_dashboard_template( $template ) {
+        if ( ! $this->is_latest_layout() ) {
+            return $template;
+        }
+
         // Check if we should load the fullwidth template.
         if ( ! dokan_is_seller_dashboard() ) {
             return $template;
@@ -94,6 +114,10 @@ class FullWidthVendorLayout implements Hookable {
      * @return void
      */
     public function register_vendor_dashboard_assets() {
+        if ( ! $this->is_latest_layout() ) {
+            return;
+        }
+
         $admin_dashboard_file = DOKAN_DIR . '/assets/js/vendor-dashboard/layout/index.asset.php';
         if ( file_exists( $admin_dashboard_file ) ) {
             $dashboard_script = require $admin_dashboard_file;
@@ -213,6 +237,10 @@ class FullWidthVendorLayout implements Hookable {
      * @return void
      */
     public function enqueue_vendor_dashboard_assets() {
+        if ( ! $this->is_latest_layout() ) {
+            return;
+        }
+
         if ( ! is_user_logged_in() || ! dokan_is_seller_dashboard() ) {
             return;
         }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -53,47 +53,6 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );
     }
 
-    /**
-     * The repository is resolved from the container by `dokan_get_option()`,
-     * which callers reach as early as `plugins_loaded` (hook registration).
-     * Building the settings schema there runs hundreds of `esc_html__()`
-     * calls before `init` — WordPress 6.7+ answers that with a
-     * `_load_textdomain_just_in_time` doing-it-wrong notice, and every
-     * front-end request pays to assemble an admin-only schema.
-     */
-    public function test_constructor_does_not_build_the_settings_schema(): void {
-        $calls   = 0;
-        $counter = function ( $elements ) use ( &$calls ) {
-            ++$calls;
-            return $elements;
-        };
-
-        add_filter( 'dokan_get_admin_settings_schema', $counter );
-
-        try {
-            new LegacySettingsRepository();
-        } finally {
-            remove_filter( 'dokan_get_admin_settings_schema', $counter );
-        }
-
-        $this->assertSame( 0, $calls );
-    }
-
-    /**
-     * Cache invalidation must not depend on the section being present in the
-     * bridge mapping — any warmed snapshot is stale once its option changes.
-     */
-    public function test_write_to_unmapped_section_flushes_its_snapshot(): void {
-        update_option( 'dokan_unmapped_section', [ 'foo' => 'before' ] );
-
-        $repo = new LegacySettingsRepository();
-        $repo->all( 'dokan_unmapped_section' );
-
-        update_option( 'dokan_unmapped_section', [ 'foo' => 'after' ] );
-
-        $this->assertSame( 'after', $repo->get( 'dokan_unmapped_section', 'foo' ) );
-    }
-
     public function test_all_returns_empty_array_when_option_missing(): void {
         delete_option( 'dokan_general' );
 

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -53,6 +53,47 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );
     }
 
+    /**
+     * The repository is resolved from the container by `dokan_get_option()`,
+     * which callers reach as early as `plugins_loaded` (hook registration).
+     * Building the settings schema there runs hundreds of `esc_html__()`
+     * calls before `init` — WordPress 6.7+ answers that with a
+     * `_load_textdomain_just_in_time` doing-it-wrong notice, and every
+     * front-end request pays to assemble an admin-only schema.
+     */
+    public function test_constructor_does_not_build_the_settings_schema(): void {
+        $calls   = 0;
+        $counter = function ( $elements ) use ( &$calls ) {
+            ++$calls;
+            return $elements;
+        };
+
+        add_filter( 'dokan_get_admin_settings_schema', $counter );
+
+        try {
+            new LegacySettingsRepository();
+        } finally {
+            remove_filter( 'dokan_get_admin_settings_schema', $counter );
+        }
+
+        $this->assertSame( 0, $calls );
+    }
+
+    /**
+     * Cache invalidation must not depend on the section being present in the
+     * bridge mapping — any warmed snapshot is stale once its option changes.
+     */
+    public function test_write_to_unmapped_section_flushes_its_snapshot(): void {
+        update_option( 'dokan_unmapped_section', [ 'foo' => 'before' ] );
+
+        $repo = new LegacySettingsRepository();
+        $repo->all( 'dokan_unmapped_section' );
+
+        update_option( 'dokan_unmapped_section', [ 'foo' => 'after' ] );
+
+        $this->assertSame( 'after', $repo->get( 'dokan_unmapped_section', 'foo' ) );
+    }
+
     public function test_all_returns_empty_array_when_option_missing(): void {
         delete_option( 'dokan_general' );
 

--- a/tests/php/src/Shortcodes/FullWidthVendorLayoutTest.php
+++ b/tests/php/src/Shortcodes/FullWidthVendorLayoutTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Shortcodes;
+
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
+use WeDevs\Dokan\Shortcodes\FullWidthVendorLayout;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ */
+class FullWidthVendorLayoutTest extends DokanTestCase {
+
+    public function set_up() {
+        parent::set_up();
+
+        // The shared repository memoizes per-section snapshots, which would let a
+        // settings read at registration time slip past the assertions below.
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                dokan_get_container()->get( LegacySettingsRepository::class )->flush_cache( null );
+            } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $e );
+            }
+        }
+    }
+
+    /**
+     * Count `dokan_appearance` reads while running `$callback`.
+     *
+     * @param callable $callback Code under test.
+     *
+     * @return int
+     */
+    private function count_appearance_reads( callable $callback ): int {
+        $reads   = 0;
+        $counter = function ( $pre ) use ( &$reads ) {
+            ++$reads;
+            return $pre;
+        };
+
+        add_filter( 'pre_option_dokan_appearance', $counter );
+
+        try {
+            $callback();
+        } finally {
+            remove_filter( 'pre_option_dokan_appearance', $counter );
+        }
+
+        return $reads;
+    }
+
+    /**
+     * `register_hooks()` runs on `plugins_loaded` (see `WeDevs_Dokan::init_hooks()`).
+     * Reading a Dokan setting there resolves the legacy settings bridge, which
+     * builds the translated admin settings schema — before `init`, where
+     * `load_plugin_textdomain()` runs. WordPress 6.7+ answers that with a
+     * `_load_textdomain_just_in_time` doing-it-wrong notice on every request.
+     */
+    public function test_register_hooks_does_not_read_settings(): void {
+        $layout = new FullWidthVendorLayout();
+
+        $this->assertSame( 0, $this->count_appearance_reads( [ $layout, 'register_hooks' ] ) );
+    }
+
+    /**
+     * Gating moved from hook registration into the callbacks, so the template
+     * override must still be inert while the marketplace runs the legacy layout.
+     */
+    public function test_template_is_untouched_for_legacy_layout(): void {
+        update_option( 'dokan_appearance', [ 'vendor_layout_style' => 'legacy' ] );
+
+        $layout = new FullWidthVendorLayout();
+        $layout->register_hooks();
+
+        $this->assertSame( 'theme-template.php', $layout->rewrite_vendor_dashboard_template( 'theme-template.php' ) );
+    }
+
+    /**
+     * The deferred gate must still consult the setting when a callback runs.
+     */
+    public function test_layout_setting_is_read_when_a_callback_runs(): void {
+        update_option( 'dokan_appearance', [ 'vendor_layout_style' => 'legacy' ] );
+
+        $layout = new FullWidthVendorLayout();
+        $layout->register_hooks();
+
+        $reads = $this->count_appearance_reads(
+            function () use ( $layout ) {
+                $layout->rewrite_vendor_dashboard_template( 'theme-template.php' );
+            }
+        );
+
+        $this->assertGreaterThan( 0, $reads );
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Every request on this branch logs the WordPress 6.7 doing-it-wrong notice twice:

```
PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.
Translation loading for the dokan-lite domain was triggered too early. ...
```

A `doing_it_wrong_run` backtrace pins it to one chain:

```
FullWidthVendorLayout::register_hooks()   @ plugins_loaded  (dokan-class.php:278)
 → dokan_get_option()                     functions.php:1077
 → LegacySettingsRepository::all()
 → LegacySettingsBridge::hydrate_legacy_from_new() → build_map() → harvest_from_schema()
 → SettingsSchema::get_schema() → esc_html__( '…', 'dokan-lite' )   ← before init
```

Reading *any* Dokan setting walks the legacy settings bridge, and the bridge harvests its legacy-key mapping out of `SettingsSchema::get_schema()` — a ~2,800-line schema full of `esc_html__()` calls. Both call sites below run on `plugins_loaded`, but `load_plugin_textdomain()` is registered on `init` (`dokan-class.php:263`), so the translation calls land too early.

`BridgeBootstrap` already defers its own harvest to `init` priority 999 for exactly this reason; these two call sites had not been given the same treatment.

**1. `FullWidthVendorLayout` — the trigger.**

`register_hooks()` read `vendor_layout_style` on `plugins_loaded` to decide whether to register three hooks at all. The three hooks are now registered unconditionally and the setting is read inside each callback, behind a new `is_latest_layout()` helper. All three fire on `init` or later, so the read is safe there, and the repository memoizes the section snapshot so splitting one read into three costs nothing.

Externally observable behaviour is unchanged — a legacy-layout marketplace still gets no dashboard assets and no template override, the checks just moved one frame later.

**2. `LegacySettingsRepository::__construct()` — a second defect on the same path.**

The constructor looped over `known_sections()` to bind per-section `{add,update,delete}_option_{$section}` cache-flush listeners. Enumerating those section names requires the bridge mapping, so simply constructing the repository built the entire translated schema — on every front-end request that read a single option.

It was also wrong on its own terms: the map was harvested before Pro registers its `dokan_get_admin_settings_schema` filters on `init`, so Pro-only sections never got listeners and their snapshots could serve stale values after a write.

Invalidation now binds WordPress' generic `added_option` / `updated_option` / `deleted_option` hooks, all of which pass the changed option name as their first argument, and resolves membership against the snapshots actually held. No mapping is consulted, so no schema is built, so binding is safe at any point in the request. Writes to `dokan_admin_settings` flush every snapshot rather than one, since it is the overlay source for all sections. Snapshots exist only for sections that were read, so the listener is a no-op for every unrelated option.

Fix 2 alone does **not** silence the notice — with the constructor lazy, the schema build moves down one frame into `all()`. Both changes are required.

**Why not keep per-section hooks and defer them to `init`?**

That was tried on this branch in `cf703e771` and reverted in `5ecb822b7`. Deferring the binding leaves a repository first constructed *after* `init` has fired with no listeners at all, so it never invalidates and serves stale values for the rest of the request. Binding eagerly instead (guarding on `did_action( 'init' )`) reopens a worse hazard: a schema callback that itself calls `dokan_get_option()` re-enters the container *before* the shared instance is registered, so each nested call constructs another repository **and another bridge** — `LegacySettingsBridge::$building_map` is a per-instance latch and cannot see the outer build. Observed during development as:

```
PHP Fatal error:  Maximum call stack size of 8339456 bytes
(zend.max_allowed_stack_size - zend.reserved_stack_size) reached during compilation.
```

The generic hooks sidestep both because they need no mapping. The detour is not visible in this PR's diff; it is called out here only because the intermediate commit is in the branch history.

**Cost of the two strategies**, measured in the PHPUnit environment on Lite with 8 mapped sections (Pro raises both the section count and the schema size, which only widens the gap):

| | Generic (this PR) | Per-section (base) |
|---|---|---|
| `add_action` calls | 3 | 27 (`8×3 + 3`) |
| Schema build at bind time | — | 0.51 ms, 76 KB |
| Cost per option write | 0.048 µs | 0 |
| Memoized rebuild | — | 0.002 ms |

Break-even is roughly 10,600 option writes in a single request (`0.51 ms ÷ 0.048 µs`); a heavy request does a couple hundred, so the generic listeners cost about 10 µs against per-section's ~510 µs. Two caveats in the other direction: per-section's 0.51 ms is not always *extra*, because `hydrate_legacy_from_new()` builds the same map and any request that reads a Dokan setting pays it anyway; and per-section's zero per-write cost is real, since `do_action()` early-returns when a hook has no listeners. Neither changes the verdict at these magnitudes, and correctness decides it regardless — per-section cannot bind without building the schema.

### Related Pull Request(s)

* Depends on #3141 (`refactor/simplify-settings-to-flat-array`) — base branch.
* ⚠️ Overlaps #3336 (`fix(dashboard): stop building vendor dashboard layout config on background requests`), which edits the same `register_hooks()` lines but targets `develop`. That PR moves `register_vendor_dashboard_assets` from `init` to `wp_enqueue_scripts` priority 5 and keeps the pre-`init` `dokan_get_option()` read, so it does not address this notice. Whichever lands second will need a deliberate merge resolution — the two changes are compatible in intent (both want the work to happen later), they just touch the same block.

### Closes

* N/A — reported from `debug.log` on the branch.

### How to test the changes in this Pull Request:

1. Set `WP_DEBUG` and `WP_DEBUG_LOG` to `true`.
2. Check out this branch with Dokan Pro active and load any front-end page.
3. **Before:** `wp-content/debug.log` gains two `_load_textdomain_just_in_time` notices for the `dokan-lite` domain per request.
4. **After:** no `dokan-lite` notices. (Any remaining `_load_textdomain_just_in_time` traces come from `dokan-pro/includes/Module.php:169` on the `dokan` domain — a separate issue in that repo, normally hidden because Pro suppresses its own `doing_it_wrong_trigger_error` output.)
5. Confirm the vendor dashboard still behaves: with `vendor_layout_style = latest` the React layout and its assets load; with `legacy` the theme template is used and no dashboard assets are enqueued.
6. Save a setting from **Dokan → Settings** and confirm the new value is served immediately on the next read, both for a section the request had already read and after a write to `dokan_admin_settings`.

### Test coverage

`tests/php/src/Shortcodes/FullWidthVendorLayoutTest.php` — new file, three cases covering fix 1:

* `test_register_hooks_does_not_read_settings`
* `test_template_is_untouched_for_legacy_layout`
* `test_layout_setting_is_read_when_a_callback_runs`

Fix 2's invalidation behaviour is covered by the existing `LegacySettingsRepositoryTest` (20 cases), notably `test_foreign_legacy_write_flushes_only_that_section` and `test_new_flat_option_write_flushes_every_section`.

`--group admin-settings` at `memory_limit=3G`: **`OK (177 tests, 1279 assertions)`**. PHPCS clean on all changed files.

Two follow-ups, deliberately not in this PR:

* `test_constructor_does_not_build_the_settings_schema` and `test_write_to_unmapped_section_flushes_its_snapshot` were removed in `48fe86885` because they could not hold under the intermediate per-section design. They are valid again against the final code and should be restored.
* Pre-existing and unrelated: the `admin-settings` group peaks at 1.32 GB and fatals at the default 512 MB `memory_limit` (reproduced identically on the base branch, dying at the same test), and `npm run phpunit` passes `--env-cwd=wp-content/plugins/dokan` where the directory is `dokan-lite`, so it exits 127 with `chdir to cwd ... no such file or directory`.

### Changelog entry

*Fix: translations no longer load before `init`*

Reading a Dokan setting builds the admin settings schema through the legacy settings bridge, and that schema is translated. Two call sites did this before the `init` action, where the plugin's text domain is loaded — the vendor layout shortcode read its setting during hook registration on `plugins_loaded`, and the legacy settings repository built the whole schema in its constructor just to work out which options to watch. WordPress 6.7 and later flags this with a `_load_textdomain_just_in_time` notice, which was written to `debug.log` twice on every request, and the redundant schema build cost time on front-end requests that only needed a single option. Both call sites now defer the read until `init` or later, and cache invalidation no longer needs the schema at all.

### Before Changes

`debug.log`, two entries per request:

```
[24-Jul-2026 09:12:25 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly.
Translation loading for the dokan-lite domain was triggered too early. This is usually an indicator for
some code in the plugin or theme running too early. Translations should be loaded at the init action or
later. (This message was added in version 6.7.0.) in wp-includes/functions.php on line 6170
```

### After Changes

No `dokan-lite` entries — verified across repeated bootstraps on a Pro-active install.
