### PR TITLE
Vendor panel order details — first-party React view behind a server-side view marker

### DIFF
--- a/includes/DependencyManagement/Providers/CommonServiceProvider.php
+++ b/includes/DependencyManagement/Providers/CommonServiceProvider.php
@@ -23,6 +23,7 @@ class CommonServiceProvider extends BaseServiceProvider {
         \WeDevs\Dokan\VendorNavMenuChecker::class,
         \WeDevs\Dokan\Commission\RecalculateCommissions::class,
         \WeDevs\Dokan\Order\RefundHandler::class,
+        \WeDevs\Dokan\Order\VendorPanelOrderDetails::class,
         \WeDevs\Dokan\Exceptions\Handler::class,
         \WeDevs\Dokan\Shortcodes\FullWidthVendorLayout::class,
         \WeDevs\Dokan\Vendor\ApiMeta::class,

--- a/includes/Order/VendorPanelOrderDetails.php
+++ b/includes/Order/VendorPanelOrderDetails.php
@@ -67,10 +67,29 @@ class VendorPanelOrderDetails implements Hookable {
         }
 
         /**
-         * Filters the order-details marker payload for the Vendor panel.
+         * Filters which first-party order-details sections the panel renders.
          *
-         * Pro modules and extensions append their section flags here so the React
-         * view knows which sections exist on this store.
+         * Turning a flag off removes that section from the React view; the slot
+         * around it still renders, so an extension can replace a section rather
+         * than only hide it.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array $sections Section id => enabled.
+         */
+        $sections = apply_filters(
+            'dokan_vendor_panel_order_details_sections',
+            [
+                'notes'     => true,
+                'downloads' => true,
+            ]
+        );
+
+        /**
+         * Filters the whole order-details marker payload for the Vendor panel.
+         *
+         * Pro modules and extensions append their section flags and any data
+         * their panel bundle needs before the view mounts.
          *
          * @since DOKAN_SINCE
          *
@@ -82,12 +101,16 @@ class VendorPanelOrderDetails implements Hookable {
                 $existing,
                 [
                     'view'                  => $this->get_view(),
-                    'statuses'              => $statuses,
+                    /**
+                     * Filters the statuses offered by the panel's status control.
+                     *
+                     * @since DOKAN_SINCE
+                     *
+                     * @param array $statuses List of `[ 'value' => ..., 'label' => ... ]`.
+                     */
+                    'statuses'              => apply_filters( 'dokan_vendor_panel_order_details_statuses', $statuses ),
                     'status_change_allowed' => 'on' === dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ),
-                    'sections'              => [
-                        'notes'     => true,
-                        'downloads' => true,
-                    ],
+                    'sections'              => $sections,
                 ]
             )
         );

--- a/includes/Order/VendorPanelOrderDetails.php
+++ b/includes/Order/VendorPanelOrderDetails.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace WeDevs\Dokan\Order;
+
+use Closure;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionMethod;
+use WeDevs\Dokan\Contracts\Hookable;
+
+/**
+ * Server-side markers for the Vendor panel order details route.
+ *
+ * The panel renders order details with one of two renderers: the first-party React
+ * view, or the server-rendered fragment bridged over REST (ADR-0005). The server owns
+ * that decision — third-party code hooked into the details template only renders in the
+ * fragment, so those stores are sent there automatically — and publishes it, along with
+ * the first-party section flags, through the panel's localized config.
+ *
+ * Everything here is additive: the fragment renderer, the legacy page and every #2133
+ * contract stay untouched.
+ *
+ * @since DOKAN_SINCE
+ */
+class VendorPanelOrderDetails implements Hookable {
+
+    /**
+     * Renderer markers.
+     *
+     * @since DOKAN_SINCE
+     */
+    public const VIEW_REACT    = 'react';
+    public const VIEW_FRAGMENT = 'fragment';
+
+    /**
+     * Register hooks.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function register_hooks(): void {
+        add_filter( 'dokan_react_frontend_localized_args', [ $this, 'add_order_details_args' ] );
+        add_filter( 'dokan_rest_api_class_map', [ $this, 'register_rest_controllers' ] );
+    }
+
+    /**
+     * Publish the order-details markers to the Vendor panel.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array $args Localized args for the panel bundle.
+     *
+     * @return array
+     */
+    public function add_order_details_args( $args ): array {
+        $args = is_array( $args ) ? $args : [];
+
+        $existing = isset( $args['order_details'] ) && is_array( $args['order_details'] ) ? $args['order_details'] : [];
+
+        $statuses = [];
+        foreach ( wc_get_order_statuses() as $status_key => $status_label ) {
+            $statuses[] = [
+                'value' => $status_key,
+                'label' => $status_label,
+            ];
+        }
+
+        /**
+         * Filters the order-details marker payload for the Vendor panel.
+         *
+         * Pro modules and extensions append their section flags here so the React
+         * view knows which sections exist on this store.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array $payload Marker payload.
+         */
+        $args['order_details'] = apply_filters(
+            'dokan_vendor_panel_order_details_args',
+            array_merge(
+                $existing,
+                [
+                    'view'                  => $this->get_view(),
+                    'statuses'              => $statuses,
+                    'status_change_allowed' => 'on' === dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ),
+                    'sections'              => [
+                        'notes'     => true,
+                        'downloads' => true,
+                    ],
+                ]
+            )
+        );
+
+        return $args;
+    }
+
+    /**
+     * Register the downloads REST controller.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array $class_map Controller class map.
+     *
+     * @return array
+     */
+    public function register_rest_controllers( $class_map ): array {
+        $class_map = is_array( $class_map ) ? $class_map : [];
+
+        $class_map[ DOKAN_DIR . '/includes/REST/OrderDownloadController.php' ] = '\WeDevs\Dokan\REST\OrderDownloadController';
+
+        return $class_map;
+    }
+
+    /**
+     * Which renderer the Vendor panel uses for order details.
+     *
+     * Defaults to the fragment when third-party code hooks into the details template
+     * (its output only renders there) or when the session is a Vendor staff member —
+     * the fragment endpoint already grants staff the access the legacy page grants,
+     * while the React view's data routes do not yet.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return string self::VIEW_REACT or self::VIEW_FRAGMENT.
+     */
+    public function get_view(): string {
+        $default = self::VIEW_REACT;
+
+        if ( $this->has_third_party_template_hooks() ) {
+            $default = self::VIEW_FRAGMENT;
+        }
+
+        // A differing staff-aware id means the session acts for a Vendor it is not:
+        // a Vendor staff login. Their data access is only guaranteed by the fragment.
+        if ( get_current_user_id() !== dokan_get_current_user_id() ) {
+            $default = self::VIEW_FRAGMENT;
+        }
+
+        /**
+         * Filters which renderer the Vendor panel uses for order details.
+         *
+         * Best-effort third-party detection picks the default; this filter is the
+         * guaranteed override in both directions.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param string $view 'react' or 'fragment'.
+         */
+        $view = apply_filters( 'dokan_vendor_panel_order_details_view', $default );
+
+        return in_array( $view, [ self::VIEW_REACT, self::VIEW_FRAGMENT ], true ) ? $view : self::VIEW_FRAGMENT;
+    }
+
+    /**
+     * Whether third-party code hooks into the order details template.
+     *
+     * The React view renders first-party sections only; a theme or plugin injecting
+     * markup through the template's PHP hooks would silently lose it there. Detection
+     * is best-effort — closures and reflection failures count as third-party so the
+     * fallback errs toward compatibility.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return bool
+     */
+    public function has_third_party_template_hooks(): bool {
+        static $has_third_party = null;
+
+        if ( null !== $has_third_party ) {
+            return $has_third_party;
+        }
+
+        $template_hooks = [
+            'dokan_order_detail_after_order_items',
+            'dokan_order_details_after_customer_info',
+            'dokan_order_detail_after_order_general_details',
+            'dokan_order_detail_after_order_notes',
+            'dokan_order_details_fragment_before',
+            'dokan_order_details_fragment_after',
+        ];
+
+        $first_party_roots = [ dirname( DOKAN_FILE ) ];
+
+        if ( defined( 'DOKAN_PRO_FILE' ) ) {
+            $first_party_roots[] = dirname( DOKAN_PRO_FILE );
+        }
+
+        $has_third_party = false;
+
+        foreach ( $template_hooks as $hook ) {
+            if ( ! isset( $GLOBALS['wp_filter'][ $hook ] ) ) {
+                continue;
+            }
+
+            foreach ( $GLOBALS['wp_filter'][ $hook ]->callbacks as $priority_callbacks ) {
+                foreach ( $priority_callbacks as $callback ) {
+                    if ( ! $this->is_first_party_callback( $callback['function'], $first_party_roots ) ) {
+                        $has_third_party = true;
+
+                        return $has_third_party;
+                    }
+                }
+            }
+        }
+
+        return $has_third_party;
+    }
+
+    /**
+     * Whether a hook callback is defined inside one of the given plugin roots.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param callable|mixed $callback          Registered hook callback.
+     * @param string[]       $first_party_roots Absolute directories considered first-party.
+     *
+     * @return bool
+     */
+    protected function is_first_party_callback( $callback, array $first_party_roots ): bool {
+        try {
+            if ( is_string( $callback ) && function_exists( $callback ) ) {
+                $reflection = new ReflectionFunction( $callback );
+            } elseif ( is_array( $callback ) && 2 === count( $callback ) ) {
+                $reflection = new ReflectionMethod( $callback[0], $callback[1] );
+            } elseif ( $callback instanceof Closure ) {
+                // A closure's origin is not reliably attributable — treat as third-party.
+                return false;
+            } elseif ( is_object( $callback ) && method_exists( $callback, '__invoke' ) ) {
+                $reflection = new ReflectionMethod( $callback, '__invoke' );
+            } else {
+                return false;
+            }
+        } catch ( ReflectionException $e ) {
+            return false;
+        }
+
+        $file = $reflection->getFileName();
+
+        if ( ! $file ) {
+            return false;
+        }
+
+        $file = wp_normalize_path( $file );
+
+        foreach ( $first_party_roots as $root ) {
+            if ( 0 === strpos( $file, trailingslashit( wp_normalize_path( $root ) ) ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/includes/REST/OrderDownloadController.php
+++ b/includes/REST/OrderDownloadController.php
@@ -1,0 +1,470 @@
+<?php
+
+namespace WeDevs\Dokan\REST;
+
+use WC_Customer_Download;
+use WC_Data_Store;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Downloadable-product permissions for a Vendor order.
+ *
+ * REST twin of the legacy AJAX grant/revoke handlers so the Vendor panel's React
+ * order-details view can manage download permissions. The AJAX handlers and the
+ * legacy template stay untouched — both surfaces wrap the same WooCommerce
+ * permission store.
+ *
+ * @since DOKAN_SINCE
+ */
+class OrderDownloadController extends DokanBaseController {
+
+    /**
+     * Route base.
+     *
+     * @var string
+     */
+    protected $rest_base = 'orders';
+
+    /**
+     * Register routes.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function register_routes() {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<id>[\d]+)/downloads',
+            [
+                'args'   => [
+                    'id' => [
+                        'description' => __( 'Unique identifier for the order.', 'dokan-lite' ),
+                        'type'        => 'integer',
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_items' ],
+                    'permission_callback' => [ $this, 'get_items_permissions_check' ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => [ $this, 'create_item' ],
+                    'permission_callback' => [ $this, 'manage_items_permissions_check' ],
+                    'args'                => [
+                        'product_ids' => [
+                            'description' => __( 'Downloadable product ids to grant access for.', 'dokan-lite' ),
+                            'type'        => 'array',
+                            'required'    => true,
+                            'items'       => [
+                                'type' => 'integer',
+                            ],
+                        ],
+                    ],
+                ],
+                'schema' => [ $this, 'get_item_schema' ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<id>[\d]+)/downloads/(?P<permission_id>[\d]+)',
+            [
+                'args' => [
+                    'id'            => [
+                        'description' => __( 'Unique identifier for the order.', 'dokan-lite' ),
+                        'type'        => 'integer',
+                    ],
+                    'permission_id' => [
+                        'description' => __( 'Unique identifier for the download permission.', 'dokan-lite' ),
+                        'type'        => 'integer',
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => [ $this, 'update_item' ],
+                    'permission_callback' => [ $this, 'manage_items_permissions_check' ],
+                    'args'                => [
+                        'downloads_remaining' => [
+                            'description' => __( 'Remaining downloads, empty for unlimited.', 'dokan-lite' ),
+                            'type'        => 'string',
+                        ],
+                        'access_expires'      => [
+                            'description' => __( 'Access expiry date (Y-m-d), empty for never.', 'dokan-lite' ),
+                            'type'        => 'string',
+                        ],
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => [ $this, 'delete_item' ],
+                    'permission_callback' => [ $this, 'manage_items_permissions_check' ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Update a download permission's limit and expiry.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function update_item( $request ) {
+        $order_id      = absint( $request['id'] );
+        $permission_id = absint( $request['permission_id'] );
+
+        $permission = new WC_Customer_Download( $permission_id );
+
+        if ( ! $permission->get_id() || absint( $permission->get_order_id() ) !== $order_id ) {
+            return new WP_Error(
+                'dokan_rest_invalid_download_permission',
+                __( 'Invalid download permission.', 'dokan-lite' ),
+                [ 'status' => 404 ]
+            );
+        }
+
+        if ( null !== $request['downloads_remaining'] ) {
+            $remaining = trim( (string) $request['downloads_remaining'] );
+            $permission->set_downloads_remaining( '' === $remaining ? '' : absint( $remaining ) );
+        }
+
+        if ( null !== $request['access_expires'] ) {
+            $expires = trim( (string) $request['access_expires'] );
+            // Store the picked day as UTC midnight so the same Y-m-d comes back
+            // regardless of site timezone.
+            $permission->set_access_expires( '' === $expires ? null : strtotime( $expires . ' 00:00:00 UTC' ) );
+        }
+
+        $permission->save();
+
+        return $this->prepare_item_for_response( new WC_Customer_Download( $permission_id ), $request );
+    }
+
+    /**
+     * Whether the current user may view the order's download permissions.
+     *
+     * Staff-aware, modeled on the details-html fragment rule: capability check,
+     * marketplace-admin bypass, then ownership through the staff-aware current-user
+     * helper.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return true|WP_Error
+     */
+    public function get_items_permissions_check( $request ) {
+        return $this->check_order_access( $request, 'dokan_view_order' );
+    }
+
+    /**
+     * Whether the current user may grant or revoke download permissions.
+     *
+     * The legacy AJAX handlers gate on `dokandar`; the same capability applies here.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return true|WP_Error
+     */
+    public function manage_items_permissions_check( $request ) {
+        return $this->check_order_access( $request, 'dokandar' );
+    }
+
+    /**
+     * Shared capability + ownership rule.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request    Request object.
+     * @param string          $capability Required capability.
+     *
+     * @return true|WP_Error
+     */
+    protected function check_order_access( $request, $capability ) {
+        $forbidden = new WP_Error(
+            'dokan_rest_cannot_manage_order_downloads',
+            __( 'Sorry, you are not allowed to manage downloads for this order.', 'dokan-lite' ),
+            [ 'status' => rest_authorization_required_code() ]
+        );
+
+        if ( ! current_user_can( $capability ) ) {
+            return $forbidden;
+        }
+
+        $order = wc_get_order( absint( $request['id'] ) );
+
+        if ( ! $order || 'shop_order' !== $order->get_type() ) {
+            return new WP_Error(
+                'dokan_rest_invalid_order_id',
+                __( 'Invalid order ID.', 'dokan-lite' ),
+                [ 'status' => 404 ]
+            );
+        }
+
+        if ( current_user_can( 'manage_woocommerce' ) ) {
+            return true;
+        }
+
+        if ( dokan_is_seller_has_order( dokan_get_current_user_id(), $order->get_id() ) ) {
+            return true;
+        }
+
+        return $forbidden;
+    }
+
+    /**
+     * List the order's download permissions.
+     *
+     * Mirrors the legacy template: permissions whose product or file has since been
+     * removed are skipped rather than rendered dead.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response
+     */
+    public function get_items( $request ) {
+        $order_id   = absint( $request['id'] );
+        $data_store = WC_Data_Store::load( 'customer-download' );
+
+        $permissions = $data_store->get_downloads(
+            [
+                'order_id' => $order_id,
+                'orderby'  => 'product_id',
+            ]
+        );
+
+        $items   = [];
+        $product = null;
+
+        foreach ( $permissions as $permission ) {
+            if ( ! $product || $product->get_id() !== $permission->get_product_id() ) {
+                $product = wc_get_product( $permission->get_product_id() );
+            }
+
+            if ( ! $product || ! $product->exists() || ! $product->has_file( $permission->get_download_id() ) ) {
+                continue;
+            }
+
+            $items[] = $this->prepare_response_for_collection(
+                $this->prepare_item_for_response( $permission, $request )
+            );
+        }
+
+        return rest_ensure_response( $items );
+    }
+
+    /**
+     * Grant download access for the given products.
+     *
+     * Wraps the legacy AJAX grant logic: only the vendor's own downloadable products
+     * qualify, and one permission is created per file, per product.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function create_item( $request ) {
+        $order_id    = absint( $request['id'] );
+        $product_ids = array_filter( array_map( 'absint', (array) $request['product_ids'] ) );
+        $order       = wc_get_order( $order_id );
+
+        if ( empty( $product_ids ) ) {
+            return new WP_Error(
+                'dokan_rest_no_downloadable_products',
+                __( 'No downloadable products were given.', 'dokan-lite' ),
+                [ 'status' => 400 ]
+            );
+        }
+
+        if ( ! $order->get_billing_email() ) {
+            return new WP_Error(
+                'dokan_rest_order_missing_billing_email',
+                __( 'The order has no billing email, so download access cannot be granted.', 'dokan-lite' ),
+                [ 'status' => 400 ]
+            );
+        }
+
+        $created = [];
+
+        foreach ( $product_ids as $product_id ) {
+            $product = wc_get_product( $product_id );
+
+            // Only grant downloads for the vendor's own products, never another vendor's files.
+            if ( ! $product || ! dokan_is_product_author( $product_id ) ) {
+                continue;
+            }
+
+            foreach ( $product->get_downloads() as $download_id => $file ) {
+                $inserted_id = wc_downloadable_file_permission( $download_id, $product_id, $order );
+
+                if ( ! $inserted_id ) {
+                    continue;
+                }
+
+                $permission = new WC_Customer_Download( $inserted_id );
+
+                /**
+                 * Fires after the Vendor grants a download permission over REST.
+                 *
+                 * @since DOKAN_SINCE
+                 *
+                 * @param WC_Customer_Download $permission Created permission.
+                 * @param \WC_Order            $order      Order the permission belongs to.
+                 */
+                do_action( 'dokan_rest_order_download_access_granted', $permission, $order );
+
+                $created[] = $this->prepare_response_for_collection(
+                    $this->prepare_item_for_response( $permission, $request )
+                );
+            }
+        }
+
+        $response = rest_ensure_response( $created );
+        $response->set_status( 201 );
+
+        return $response;
+    }
+
+    /**
+     * Revoke a download permission.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WP_REST_Request $request Request object.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function delete_item( $request ) {
+        $order_id      = absint( $request['id'] );
+        $permission_id = absint( $request['permission_id'] );
+
+        $permission = new WC_Customer_Download( $permission_id );
+
+        if ( ! $permission->get_id() || absint( $permission->get_order_id() ) !== $order_id ) {
+            return new WP_Error(
+                'dokan_rest_invalid_download_permission',
+                __( 'Invalid download permission.', 'dokan-lite' ),
+                [ 'status' => 404 ]
+            );
+        }
+
+        $previous = $this->prepare_item_for_response( $permission, $request );
+
+        $data_store = WC_Data_Store::load( 'customer-download' );
+        $data_store->delete_by_id( $permission_id );
+
+        /** This action is documented in WooCommerce and fired by the legacy revoke handler. */
+        do_action( 'woocommerce_ajax_revoke_access_to_product_download', $permission->get_download_id(), $permission->get_product_id(), $order_id, $permission_id );
+
+        return rest_ensure_response(
+            [
+                'deleted'  => true,
+                'previous' => $previous->get_data(),
+            ]
+        );
+    }
+
+    /**
+     * Shape a download permission for the response.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WC_Customer_Download $item    Download permission.
+     * @param WP_REST_Request      $request Request object.
+     *
+     * @return WP_REST_Response
+     */
+    public function prepare_item_for_response( $item, $request ) {
+        $product   = wc_get_product( $item->get_product_id() );
+        $file      = $product && $product->has_file( $item->get_download_id() ) ? $product->get_file( $item->get_download_id() ) : null;
+        $file_name = $file && ! empty( $file['name'] ) ? $file['name'] : '';
+
+        $access_expires = $item->get_access_expires();
+        $image_id       = $product ? $product->get_image_id() : 0;
+
+        $data = [
+            'permission_id'       => absint( $item->get_id() ),
+            'product_id'          => absint( $item->get_product_id() ),
+            'product_name'        => $product ? $product->get_name() : '',
+            'product_image'       => $image_id ? (string) wp_get_attachment_image_url( $image_id, 'thumbnail' ) : (string) wc_placeholder_img_src(),
+            'download_id'         => (string) $item->get_download_id(),
+            'file_name'           => $file_name,
+            'download_count'      => absint( $item->get_download_count() ),
+            'downloads_remaining' => '' === (string) $item->get_downloads_remaining() ? '' : (string) $item->get_downloads_remaining(),
+            'access_expires'      => $access_expires ? $access_expires->date( 'Y-m-d' ) : null,
+        ];
+
+        $data = apply_filters( 'dokan_rest_prepare_order_download_data', $data, $item, $request );
+
+        return rest_ensure_response( $data );
+    }
+
+    /**
+     * Schema for a download permission.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return array
+     */
+    public function get_item_schema() {
+        $schema = [
+            '$schema'    => 'http://json-schema.org/draft-04/schema#',
+            'title'      => 'order-download',
+            'type'       => 'object',
+            'properties' => [
+                'permission_id'       => [
+                    'description' => __( 'Unique identifier for the download permission.', 'dokan-lite' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view' ],
+                    'readonly'    => true,
+                ],
+                'product_id'          => [
+                    'description' => __( 'Downloadable product id.', 'dokan-lite' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view' ],
+                ],
+                'product_name'        => [
+                    'description' => __( 'Downloadable product name.', 'dokan-lite' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view' ],
+                ],
+                'download_id'         => [
+                    'description' => __( 'Downloadable file id.', 'dokan-lite' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view' ],
+                ],
+                'file_name'           => [
+                    'description' => __( 'Downloadable file name.', 'dokan-lite' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view' ],
+                ],
+                'downloads_remaining' => [
+                    'description' => __( 'Remaining downloads, empty for unlimited.', 'dokan-lite' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view' ],
+                ],
+                'access_expires'      => [
+                    'description' => __( 'Access expiry date, null for never.', 'dokan-lite' ),
+                    'type'        => [ 'string', 'null' ],
+                    'context'     => [ 'view' ],
+                ],
+            ],
+        ];
+
+        return $this->add_additional_fields_schema( $schema );
+    }
+}

--- a/src/dashboard/orders/OrderDetailsHeader.tsx
+++ b/src/dashboard/orders/OrderDetailsHeader.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Slot } from '@wordpress/components';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
-import { ArrowLeft, Pencil } from 'lucide-react';
+import { ArrowLeft, ChevronLeft, Pencil } from 'lucide-react';
+import { Button } from '@wedevs/plugin-ui';
 import { DokanBadge, DokanButton } from '@dokan/components';
 import { usePermission } from '@dokan/hooks';
 import {
@@ -11,6 +12,9 @@ import {
     onOrderDetailsEvent,
 } from './events';
 import { getStatusBadgeVariant, getStatusLabel } from './status';
+import { isReactOrderDetailsView } from './details/marker';
+import StatusDropdown from './details/StatusDropdown';
+import StatusPill from './details/StatusPill';
 import type { OrderDetailsMeta } from './types';
 
 /**
@@ -38,7 +42,22 @@ const OrderDetailsHeader = () => {
     const [ order, setOrder ] = useState< OrderDetailsMeta | null >( null );
     const [ status, setStatus ] = useState< string >( '' );
 
-    const canEditOrder = usePermission( 'dokan_manage_manual_order' );
+    // Match the legacy page: Pro only offers Edit Order when the manual-order
+    // feature is enabled for this vendor, which is exactly when its bundle
+    // publishes `dokanManualOrder`. Capability alone is not enough — the edit
+    // screen refuses vendors the feature is disabled for.
+    const isManualOrderAvailable = Boolean(
+        ( window as unknown as { dokanManualOrder?: unknown } ).dokanManualOrder
+    );
+    // The React view's meta says whether this specific order is editable
+    // (vendor-created only); the fragment meta doesn't carry it, so fragment
+    // mode keeps the legacy always-offer behaviour.
+    const isOrderEditable = order?.manual_order_editable ?? true;
+    const canEditOrder =
+        usePermission( 'dokan_manage_manual_order' ) &&
+        isManualOrderAvailable &&
+        isOrderEditable;
+    const isReactView = isReactOrderDetailsView();
 
     useEffect( () => {
         const unsubscribeLoaded = onOrderDetailsEvent(
@@ -98,42 +117,78 @@ const OrderDetailsHeader = () => {
             <div className="@container/before-header grid grid-cols-4 gap-4">
                 <Slot name="dokan-before-header" />
             </div>
+            { isReactView && (
+                // !important utilities: front-end theme button CSS paints
+                // default backgrounds/borders that wp-admin screens never
+                // face — this must read as a plain breadcrumb link.
+                <button
+                    type="button"
+                    onClick={ goBackToList }
+                    className="flex w-fit items-center gap-1 border-0! bg-transparent! p-0! shadow-none! text-sm text-gray-500! hover:text-dokan-link!"
+                >
+                    <ChevronLeft size={ 16 } />
+                    { __( 'All Orders', 'dokan-lite' ) }
+                </button>
+            ) }
             <div className="dokan-header-title-section @container/header-title-section flex gap-y-4 justify-between items-center flex-wrap">
                 <div className="dokan-header-title w-full md:!w-1/2 flex flex-wrap items-center gap-3">
                     <h3 className="text-2xl font-semibold text-gray-800 md:text-4xl lg:text-3xl">
                         { title }
                     </h3>
-                    { status && (
-                        <DokanBadge
-                            variant={ getStatusBadgeVariant( status ) }
-                            label={ getStatusLabel( status ) }
-                        />
-                    ) }
+                    { status &&
+                        ( isReactView ? (
+                            <StatusPill status={ status } />
+                        ) : (
+                            <DokanBadge
+                                variant={ getStatusBadgeVariant( status ) }
+                                label={ getStatusLabel( status ) }
+                            />
+                        ) ) }
                     <Slot
                         name="dokan-header-after-title"
                         fillProps={ { title, navigate, params, location } }
                     />
                 </div>
                 <div className="dokan-header-actions w-full md:!w-1/2 flex flex-wrap gap-2.5 md:!justify-end">
-                    <DokanButton variant="secondary" onClick={ goBackToList }>
-                        <ArrowLeft className="text-dokan-link" size={ 16 } />
-                        { __( 'Back', 'dokan-lite' ) }
-                    </DokanButton>
-                    { canEditOrder && orderId > 0 && (
+                    { /* The React view carries the RFQ-style breadcrumb above
+                         the title instead of a Back button. */ }
+                    { ! isReactView && (
                         <DokanButton
                             variant="secondary"
+                            onClick={ goBackToList }
+                        >
+                            <ArrowLeft
+                                className="text-dokan-link"
+                                size={ 16 }
+                            />
+                            { __( 'Back', 'dokan-lite' ) }
+                        </DokanButton>
+                    ) }
+                    { /* No Print control: the legacy order details page never
+                         had one, and no printing evidence exists in its
+                         templates — browser print still works natively. */ }
+                    { canEditOrder && orderId > 0 && (
+                        <Button
+                            variant="outline"
+                            className="h-10 gap-2 rounded-lg! border! border-gray-200! bg-white! px-4! text-sm font-medium text-gray-800! shadow-none! hover:bg-gray-50!"
                             onClick={ () =>
                                 navigate( `/orders/edit/${ orderId }` )
                             }
                         >
-                            <Pencil className="text-dokan-link" size={ 16 } />
+                            { ! isReactView && (
+                                <Pencil
+                                    className="text-dokan-link"
+                                    size={ 16 }
+                                />
+                            ) }
                             { __( 'Edit Order', 'dokan-lite' ) }
-                        </DokanButton>
+                        </Button>
                     ) }
                     <Slot
                         name="dokan-header-actions"
                         fillProps={ { navigate, params, location } }
                     />
+                    { isReactView && <StatusDropdown orderId={ orderId } /> }
                 </div>
             </div>
             <div className="@container/after-header grid grid-cols-4 gap-4">

--- a/src/dashboard/orders/details/DownloadsCard.tsx
+++ b/src/dashboard/orders/details/DownloadsCard.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Ban, CalendarDays, Search } from 'lucide-react';
+import { useToast } from '@getdokan/dokan-ui';
+import { Input } from '@wedevs/plugin-ui';
+import {
+    DokanButton,
+    ProductAsyncSelect,
+    WpDatePicker,
+} from '@dokan/components';
+import { formatSiteDate } from './dateTime';
+import SectionCard from './SectionCard';
+import useOrderDownloads from './useOrderDownloads';
+import { useOrderDetailsContext } from './OrderDetailsContext';
+import type { OrderDownloadPermission } from './types';
+
+interface ProductOption {
+    value: number;
+    label: string;
+}
+
+interface RowEdit {
+    downloads_remaining: string;
+    access_expires: string;
+}
+
+const daysLeft = ( expires: string | null ): string => {
+    if ( ! expires ) {
+        return '';
+    }
+
+    const days = Math.ceil(
+        ( new Date( `${ expires }T00:00:00` ).getTime() - Date.now() ) /
+            ( 1000 * 60 * 60 * 24 )
+    );
+
+    if ( days < 0 ) {
+        return __( 'Expired', 'dokan-lite' );
+    }
+
+    /* translators: %d: number of days until download access expires */
+    return sprintf( __( '%d days left', 'dokan-lite' ), days );
+};
+
+/**
+ * Downloadable Product Permission card per the mockup: search + grant, and per
+ * permission an editable downloads limit and expiry with usage hints, saved by
+ * the card-level Update action.
+ */
+const DownloadsCard = () => {
+    const { orderId } = useOrderDetailsContext();
+    const toast = useToast();
+    const { permissions, isLoading, grantAccess, revokeAccess, refetch } =
+        useOrderDownloads( orderId );
+
+    const [ selected, setSelected ] = useState< ProductOption | null >( null );
+    const [ isGranting, setIsGranting ] = useState( false );
+    const [ isSavingRows, setIsSavingRows ] = useState( false );
+    const [ confirmingRevoke, setConfirmingRevoke ] = useState< number >( 0 );
+    const [ edits, setEdits ] = useState< Record< number, RowEdit > >( {} );
+
+    useEffect( () => {
+        const next: Record< number, RowEdit > = {};
+        permissions.forEach( ( permission ) => {
+            next[ permission.permission_id ] = {
+                downloads_remaining: permission.downloads_remaining ?? '',
+                access_expires: permission.access_expires ?? '',
+            };
+        } );
+        setEdits( next );
+    }, [ permissions ] );
+
+    const handleGrant = async () => {
+        if ( ! selected ) {
+            return;
+        }
+
+        setIsGranting( true );
+
+        try {
+            const created = await grantAccess( [ Number( selected.value ) ] );
+
+            toast( {
+                type: created.length ? 'success' : 'warning',
+                title: created.length
+                    ? __( 'Download access granted.', 'dokan-lite' )
+                    : __(
+                          'No downloadable files found on that product.',
+                          'dokan-lite'
+                      ),
+            } );
+            setSelected( null );
+        } catch ( grantError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( grantError as { message?: string } )?.message ||
+                    __( 'Could not grant download access.', 'dokan-lite' ),
+            } );
+        } finally {
+            setIsGranting( false );
+        }
+    };
+
+    const handleRevoke = async ( permissionId: number ) => {
+        try {
+            await revokeAccess( permissionId );
+            toast( {
+                type: 'success',
+                title: __( 'Download access revoked.', 'dokan-lite' ),
+            } );
+        } catch ( revokeError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( revokeError as { message?: string } )?.message ||
+                    __( 'Could not revoke download access.', 'dokan-lite' ),
+            } );
+        } finally {
+            setConfirmingRevoke( 0 );
+        }
+    };
+
+    const isRowDirty = ( permission: OrderDownloadPermission ): boolean => {
+        const edit = edits[ permission.permission_id ];
+
+        if ( ! edit ) {
+            return false;
+        }
+
+        return (
+            edit.downloads_remaining !==
+                ( permission.downloads_remaining ?? '' ) ||
+            edit.access_expires !== ( permission.access_expires ?? '' )
+        );
+    };
+
+    const handleUpdate = async () => {
+        const dirty = permissions.filter( isRowDirty );
+
+        if ( ! dirty.length ) {
+            return;
+        }
+
+        setIsSavingRows( true );
+
+        try {
+            await Promise.all(
+                dirty.map( ( permission ) =>
+                    apiFetch( {
+                        path: `/dokan/v1/orders/${ orderId }/downloads/${ permission.permission_id }`,
+                        method: 'PUT',
+                        data: edits[ permission.permission_id ],
+                    } )
+                )
+            );
+
+            toast( {
+                type: 'success',
+                title: __( 'Download permissions updated.', 'dokan-lite' ),
+            } );
+            refetch();
+        } catch ( updateError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( updateError as { message?: string } )?.message ||
+                    __(
+                        'Could not update download permissions.',
+                        'dokan-lite'
+                    ),
+            } );
+        } finally {
+            setIsSavingRows( false );
+        }
+    };
+
+    const hasDirtyRows = permissions.some( isRowDirty );
+
+    return (
+        <SectionCard
+            title={ __( 'Downloadable Product Permission', 'dokan-lite' ) }
+            contentClassName="px-0"
+        >
+            <div className="px-6 pb-4">
+                <p className="mb-2 text-sm font-semibold text-[#25252D]">
+                    { __( 'Add products', 'dokan-lite' ) }
+                </p>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                    <div className="min-w-0 flex-1">
+                        <ProductAsyncSelect
+                            value={ selected }
+                            onChange={ ( option ) =>
+                                setSelected( option as ProductOption | null )
+                            }
+                            extraQuery={ { downloadable: true } }
+                            icon={
+                                <Search size={ 16 } className="text-gray-400" />
+                            }
+                            placeholder={ __(
+                                'Search Downloadable Products',
+                                'dokan-lite'
+                            ) }
+                            isClearable
+                        />
+                    </div>
+                    { selected && (
+                        <DokanButton
+                            onClick={ handleGrant }
+                            disabled={ isGranting }
+                            loading={ isGranting }
+                        >
+                            { __( 'Grant Access', 'dokan-lite' ) }
+                        </DokanButton>
+                    ) }
+                </div>
+            </div>
+
+            { ! isLoading && permissions.length > 0 && (
+                <div className="flex flex-col divide-y divide-[#E9E9E9] border-t border-[#E9E9E9]">
+                    { permissions.map( ( permission ) => {
+                        const edit = edits[ permission.permission_id ] ?? {
+                            downloads_remaining: '',
+                            access_expires: '',
+                        };
+
+                        return (
+                            <div
+                                key={ permission.permission_id }
+                                className="flex flex-col gap-3.5 px-6 py-4"
+                            >
+                                <div className="flex items-start justify-between gap-3">
+                                    <div className="flex min-w-0 items-center gap-3">
+                                        <img
+                                            src={ permission.product_image }
+                                            alt=""
+                                            className="h-9 w-9 shrink-0 rounded border border-gray-200 object-cover"
+                                        />
+                                        <div className="min-w-0">
+                                            <p className="truncate text-sm font-medium text-gray-800">
+                                                { `#${ permission.product_id } — ${ permission.product_name }` }
+                                            </p>
+                                            { permission.file_name && (
+                                                <p className="truncate text-xs text-gray-400">
+                                                    { permission.file_name }
+                                                </p>
+                                            ) }
+                                        </div>
+                                    </div>
+                                    { confirmingRevoke ===
+                                    permission.permission_id ? (
+                                        <span className="flex shrink-0 items-center gap-2 text-xs">
+                                            <button
+                                                type="button"
+                                                className="border-0! bg-transparent! p-0! shadow-none! font-medium text-red-600!"
+                                                onClick={ () =>
+                                                    handleRevoke(
+                                                        permission.permission_id
+                                                    )
+                                                }
+                                            >
+                                                { __(
+                                                    'Confirm',
+                                                    'dokan-lite'
+                                                ) }
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className="border-0! bg-transparent! p-0! shadow-none! text-gray-500!"
+                                                onClick={ () =>
+                                                    setConfirmingRevoke( 0 )
+                                                }
+                                            >
+                                                { __( 'Cancel', 'dokan-lite' ) }
+                                            </button>
+                                        </span>
+                                    ) : (
+                                        <button
+                                            type="button"
+                                            className="inline-flex shrink-0 items-center gap-1.5 border-0! bg-transparent! p-0! shadow-none! text-sm font-medium text-red-500!"
+                                            onClick={ () =>
+                                                setConfirmingRevoke(
+                                                    permission.permission_id
+                                                )
+                                            }
+                                        >
+                                            <Ban size={ 14 } />
+                                            { __( 'Revoke', 'dokan-lite' ) }
+                                        </button>
+                                    ) }
+                                </div>
+
+                                <div>
+                                    <div className="mb-1.5 flex items-center justify-between">
+                                        <span className="text-xs font-medium text-[#25252D]">
+                                            { __(
+                                                'Downloads Limit',
+                                                'dokan-lite'
+                                            ) }
+                                        </span>
+                                        <span className="text-xs text-[#828282]">
+                                            { sprintf(
+                                                /* translators: 1: times downloaded 2: download limit */
+                                                __(
+                                                    'Downloaded %1$s/%2$s',
+                                                    'dokan-lite'
+                                                ),
+                                                permission.download_count ?? 0,
+                                                permission.downloads_remaining ||
+                                                    '∞'
+                                            ) }
+                                        </span>
+                                    </div>
+                                    <Input
+                                        type="number"
+                                        min={ 0 }
+                                        className="border-[#E9E9E9] shadow-none"
+                                        placeholder={ __(
+                                            'Put blank for unlimited downloads',
+                                            'dokan-lite'
+                                        ) }
+                                        value={ edit.downloads_remaining }
+                                        onChange={ ( event ) =>
+                                            setEdits( ( previous ) => ( {
+                                                ...previous,
+                                                [ permission.permission_id ]: {
+                                                    ...edit,
+                                                    downloads_remaining:
+                                                        event.target.value,
+                                                },
+                                            } ) )
+                                        }
+                                    />
+                                </div>
+
+                                <div>
+                                    <div className="mb-1.5 flex items-center justify-between">
+                                        <span className="text-xs font-medium text-[#25252D]">
+                                            { __( 'Expires', 'dokan-lite' ) }
+                                        </span>
+                                        <span className="text-xs text-[#828282]">
+                                            { daysLeft(
+                                                edit.access_expires || null
+                                            ) }
+                                        </span>
+                                    </div>
+                                    <WpDatePicker
+                                        currentDate={
+                                            edit.access_expires || undefined
+                                        }
+                                        onChange={ ( picked ) =>
+                                            setEdits( ( previous ) => ( {
+                                                ...previous,
+                                                [ permission.permission_id ]: {
+                                                    ...edit,
+                                                    access_expires: String(
+                                                        picked ?? ''
+                                                    ).slice( 0, 10 ),
+                                                },
+                                            } ) )
+                                        }
+                                    >
+                                        <div className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-md border border-[#E9E9E9] bg-white px-3 text-sm">
+                                            <CalendarDays
+                                                size={ 15 }
+                                                className="text-gray-400"
+                                            />
+                                            { edit.access_expires ? (
+                                                <span className="text-[#25252D]">
+                                                    { formatSiteDate(
+                                                        edit.access_expires
+                                                    ) }
+                                                </span>
+                                            ) : (
+                                                <span className="text-gray-400">
+                                                    { __(
+                                                        'Put blank for never expires',
+                                                        'dokan-lite'
+                                                    ) }
+                                                </span>
+                                            ) }
+                                        </div>
+                                    </WpDatePicker>
+                                </div>
+                            </div>
+                        );
+                    } ) }
+
+                    <div className="flex justify-end px-6 pt-4">
+                        <DokanButton
+                            onClick={ handleUpdate }
+                            disabled={ isSavingRows || ! hasDirtyRows }
+                            loading={ isSavingRows }
+                        >
+                            { __( 'Update', 'dokan-lite' ) }
+                        </DokanButton>
+                    </div>
+                </div>
+            ) }
+        </SectionCard>
+    );
+};
+
+export default DownloadsCard;

--- a/src/dashboard/orders/details/ItemRow.tsx
+++ b/src/dashboard/orders/details/ItemRow.tsx
@@ -1,0 +1,53 @@
+import { decodeEntities } from '@wordpress/html-entities';
+import { PriceHtml } from '@dokan/components';
+import type { DetailsLineItem } from './types';
+
+/**
+ * One order line: thumbnail, name, unit price, quantity, and line total with the
+ * pre-discount subtotal struck through when they differ.
+ * @param root0
+ * @param root0.item
+ */
+const ItemRow = ( { item }: { item: DetailsLineItem } ) => {
+    const subtotal = parseFloat( item.subtotal || '0' );
+    const total = parseFloat( item.total || '0' );
+    const discounted = Math.abs( subtotal - total ) > 0.005;
+
+    return (
+        <div className="grid grid-cols-[44fr_22fr_22fr_22fr] items-center gap-3 border-b border-[#E9E9E9] px-6 py-4">
+            <div className="flex min-w-0 items-center gap-3">
+                <img
+                    src={ item.image }
+                    alt={ decodeEntities( item.name ) }
+                    className="h-11 w-11 shrink-0 rounded border border-[#E9E9E9] object-cover"
+                />
+                <div className="min-w-0">
+                    <p className="truncate text-sm text-[#25252D]">
+                        { decodeEntities( item.name ) }
+                    </p>
+                    { item.sku && (
+                        <p className="truncate text-xs text-[#828282]">
+                            { item.sku }
+                        </p>
+                    ) }
+                </div>
+            </div>
+            <div className="text-sm text-[#575757]">
+                <PriceHtml price={ item.price } />
+            </div>
+            <div className="text-sm text-[#575757]">{ item.quantity }</div>
+            <div className="text-right text-sm text-[#25252D]">
+                <span className="font-medium">
+                    <PriceHtml price={ item.total } />
+                </span>
+                { discounted && (
+                    <span className="block text-xs text-gray-400 line-through">
+                        <PriceHtml price={ item.subtotal } />
+                    </span>
+                ) }
+            </div>
+        </div>
+    );
+};
+
+export default ItemRow;

--- a/src/dashboard/orders/details/ItemsCard.tsx
+++ b/src/dashboard/orders/details/ItemsCard.tsx
@@ -1,0 +1,46 @@
+import { __ } from '@wordpress/i18n';
+import { Slot } from '@wordpress/components';
+import SectionCard from './SectionCard';
+import ItemRow from './ItemRow';
+import TotalsRows from './TotalsRows';
+import { ORDER_DETAILS_ITEMS_ACTIONS_SLOT } from './slots';
+import { useOrderDetailsContext } from './OrderDetailsContext';
+
+/**
+ * The order items table with totals, per the mockup. The actions row under the
+ * items is a slot — Pro's "Refund Request" link renders there, so Lite ships no
+ * dead link.
+ */
+const ItemsCard = () => {
+    const context = useOrderDetailsContext();
+    const { order } = context;
+
+    if ( ! order ) {
+        return null;
+    }
+
+    return (
+        <SectionCard className="overflow-hidden py-0" contentClassName="px-0">
+            <div className="grid grid-cols-[44fr_22fr_22fr_22fr] items-center gap-3 bg-[#FDFDFD] px-6 py-5 border-b border-[#E9E9E9] text-[11px] font-medium uppercase tracking-wider text-[#828282]">
+                <span>{ __( 'Items', 'dokan-lite' ) }</span>
+                <span>{ __( 'Price', 'dokan-lite' ) }</span>
+                <span>{ __( 'Qty', 'dokan-lite' ) }</span>
+                <span className="text-right">
+                    { __( 'Total', 'dokan-lite' ) }
+                </span>
+            </div>
+            { order.line_items.map( ( item ) => (
+                <ItemRow key={ item.id } item={ item } />
+            ) ) }
+            <div className="empty:hidden px-6 py-3.5 border-b border-[#E9E9E9]">
+                <Slot
+                    name={ ORDER_DETAILS_ITEMS_ACTIONS_SLOT }
+                    fillProps={ context }
+                />
+            </div>
+            <TotalsRows />
+        </SectionCard>
+    );
+};
+
+export default ItemsCard;

--- a/src/dashboard/orders/details/OrderDetailsContext.tsx
+++ b/src/dashboard/orders/details/OrderDetailsContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from '@wordpress/element';
+import type { DetailsOrder } from './types';
+
+export interface OrderDetailsContextValue {
+    order: DetailsOrder | null;
+    orderId: number;
+    sections: Record< string, boolean >;
+    isLoading: boolean;
+    refetch: () => void;
+    navigate: ( path: string ) => void;
+}
+
+const OrderDetailsContext = createContext< OrderDetailsContextValue >( {
+    order: null,
+    orderId: 0,
+    sections: {},
+    isLoading: false,
+    refetch: () => {},
+    navigate: () => {},
+} );
+
+export const OrderDetailsProvider = OrderDetailsContext.Provider;
+
+export const useOrderDetailsContext = () => useContext( OrderDetailsContext );
+
+export default OrderDetailsContext;

--- a/src/dashboard/orders/details/OrderDetailsView.tsx
+++ b/src/dashboard/orders/details/OrderDetailsView.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Slot } from '@wordpress/components';
 import { useNavigate } from 'react-router-dom';
 import { DokanAlert } from '@dokan/components';
 import useOrderDetails from './useOrderDetails';
@@ -12,9 +11,8 @@ import DownloadsCard from './DownloadsCard';
 import CustomerCard from './sidebar/CustomerCard';
 import AddressCard from './sidebar/AddressCard';
 import NotesCard from './sidebar/NotesCard';
+import { SectionSlot, SectionWithSlots } from './SectionSlot';
 import {
-    ORDER_DETAILS_AFTER_ITEMS_SLOT,
-    ORDER_DETAILS_AFTER_SUMMARY_SLOT,
     ORDER_DETAILS_SIDEBAR_AFTER_SLOT,
     ORDER_DETAILS_SIDEBAR_BEFORE_SLOT,
     ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT,
@@ -100,48 +98,43 @@ const OrderDetailsView = ( { params }: { params?: { orderId?: string } } ) => {
         return <LoadingSkeleton />;
     }
 
-    const fillProps = context;
-
     return (
         <OrderDetailsProvider value={ context }>
             <style>{ PRINT_STYLES }</style>
             { /* mt-2 tops the layout's 16px up to the 24px header→card gap. */ }
             <div className="dokan-order-details-react-view mt-2 flex flex-col lg:flex-row gap-4">
                 <div className="flex-1 min-w-0 flex flex-col gap-4">
-                    <SummaryStrip />
-                    <Slot
-                        name={ ORDER_DETAILS_AFTER_SUMMARY_SLOT }
-                        fillProps={ fillProps }
-                    />
-                    <ItemsCard />
-                    <Slot
-                        name={ ORDER_DETAILS_AFTER_ITEMS_SLOT }
-                        fillProps={ fillProps }
-                    />
+                    <SectionWithSlots section="summary">
+                        <SummaryStrip />
+                    </SectionWithSlots>
+                    <SectionWithSlots section="items">
+                        <ItemsCard />
+                    </SectionWithSlots>
                     { isOrderDetailsSectionEnabled( 'downloads' ) && (
-                        <DownloadsCard />
+                        <SectionWithSlots section="downloads">
+                            <DownloadsCard />
+                        </SectionWithSlots>
                     ) }
                 </div>
                 { /* The sidebar prints too — legacy printing covers the whole
                      details page, customer info included. */ }
                 <aside className="w-full lg:w-80 shrink-0 flex flex-col gap-4">
-                    <Slot
-                        name={ ORDER_DETAILS_SIDEBAR_BEFORE_SLOT }
-                        fillProps={ fillProps }
-                    />
-                    <CustomerCard />
-                    <AddressCard />
+                    <SectionSlot name={ ORDER_DETAILS_SIDEBAR_BEFORE_SLOT } />
+                    <SectionWithSlots section="customer">
+                        <CustomerCard />
+                    </SectionWithSlots>
+                    <SectionWithSlots section="address">
+                        <AddressCard />
+                    </SectionWithSlots>
                     { /* Pro's Delivery Time card fills here, keeping the
                          sidebar order: Customer, Address, Delivery, Notes. */ }
-                    <Slot
-                        name={ ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT }
-                        fillProps={ fillProps }
-                    />
-                    { isOrderDetailsSectionEnabled( 'notes' ) && <NotesCard /> }
-                    <Slot
-                        name={ ORDER_DETAILS_SIDEBAR_AFTER_SLOT }
-                        fillProps={ fillProps }
-                    />
+                    <SectionSlot name={ ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT } />
+                    { isOrderDetailsSectionEnabled( 'notes' ) && (
+                        <SectionWithSlots section="notes">
+                            <NotesCard />
+                        </SectionWithSlots>
+                    ) }
+                    <SectionSlot name={ ORDER_DETAILS_SIDEBAR_AFTER_SLOT } />
                 </aside>
             </div>
         </OrderDetailsProvider>

--- a/src/dashboard/orders/details/OrderDetailsView.tsx
+++ b/src/dashboard/orders/details/OrderDetailsView.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Slot } from '@wordpress/components';
+import { useNavigate } from 'react-router-dom';
+import { DokanAlert } from '@dokan/components';
+import useOrderDetails from './useOrderDetails';
+import { OrderDetailsProvider } from './OrderDetailsContext';
+import { getOrderDetailsMarker, isOrderDetailsSectionEnabled } from './marker';
+import SummaryStrip from './SummaryStrip';
+import ItemsCard from './ItemsCard';
+import DownloadsCard from './DownloadsCard';
+import CustomerCard from './sidebar/CustomerCard';
+import AddressCard from './sidebar/AddressCard';
+import NotesCard from './sidebar/NotesCard';
+import {
+    ORDER_DETAILS_AFTER_ITEMS_SLOT,
+    ORDER_DETAILS_AFTER_SUMMARY_SLOT,
+    ORDER_DETAILS_SIDEBAR_AFTER_SLOT,
+    ORDER_DETAILS_SIDEBAR_BEFORE_SLOT,
+    ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT,
+} from './slots';
+
+/**
+ * Hide everything but the details view while printing, without touching the
+ * panel layout: the classic visibility flip needs no knowledge of the chrome
+ * around it.
+ */
+const PRINT_STYLES = `
+/* The product editor's canvas treatment: gray page, white cards. */
+.dokan-dashboard-content:has(.dokan-order-details-react-view) {
+    background-color: #f0f0f1;
+}
+@media print {
+    body * { visibility: hidden; }
+    .dokan-order-details-react-view,
+    .dokan-order-details-react-view * { visibility: visible; }
+    .dokan-order-details-react-view { position: absolute; left: 0; top: 0; width: 100%; }
+}
+`;
+
+const LoadingSkeleton = () => (
+    <div className="flex flex-col lg:flex-row gap-6">
+        <div className="flex-1 flex flex-col gap-6">
+            <div className="h-20 animate-pulse rounded-lg bg-gray-100" />
+            <div className="h-72 animate-pulse rounded-lg bg-gray-100" />
+            <div className="h-40 animate-pulse rounded-lg bg-gray-100" />
+        </div>
+        <div className="w-full lg:w-80 flex flex-col gap-6">
+            <div className="h-52 animate-pulse rounded-lg bg-gray-100" />
+            <div className="h-40 animate-pulse rounded-lg bg-gray-100" />
+        </div>
+    </div>
+);
+
+/**
+ * The first-party React order details view (mockup 1): summary strip, items and
+ * totals, downloads, and the customer/address/notes sidebar — with named slots
+ * where Pro's shipments, refund and delivery sections plug in.
+ * @param root0
+ * @param root0.params
+ * @param root0.params.orderId
+ */
+const OrderDetailsView = ( { params }: { params?: { orderId?: string } } ) => {
+    const orderId = Number( params?.orderId ?? 0 );
+    const navigate = useNavigate();
+    const { order, isLoading, error, refetch } = useOrderDetails( orderId );
+    const marker = getOrderDetailsMarker();
+
+    const context = useMemo(
+        () => ( {
+            order,
+            orderId,
+            sections: marker.sections ?? {},
+            isLoading,
+            refetch,
+            // In the context (not just slot fillProps) so every section —
+            // including fills that only receive the context object — can route.
+            navigate,
+        } ),
+        [ order, orderId, isLoading, refetch, navigate ] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    if ( error ) {
+        return (
+            <DokanAlert
+                variant="danger"
+                label={ __( 'Order details unavailable', 'dokan-lite' ) }
+            >
+                { error ||
+                    sprintf(
+                        /* translators: %d: order id */
+                        __( 'Order #%d could not be loaded.', 'dokan-lite' ),
+                        orderId
+                    ) }
+            </DokanAlert>
+        );
+    }
+
+    if ( isLoading || ! order ) {
+        return <LoadingSkeleton />;
+    }
+
+    const fillProps = context;
+
+    return (
+        <OrderDetailsProvider value={ context }>
+            <style>{ PRINT_STYLES }</style>
+            { /* mt-2 tops the layout's 16px up to the 24px header→card gap. */ }
+            <div className="dokan-order-details-react-view mt-2 flex flex-col lg:flex-row gap-4">
+                <div className="flex-1 min-w-0 flex flex-col gap-4">
+                    <SummaryStrip />
+                    <Slot
+                        name={ ORDER_DETAILS_AFTER_SUMMARY_SLOT }
+                        fillProps={ fillProps }
+                    />
+                    <ItemsCard />
+                    <Slot
+                        name={ ORDER_DETAILS_AFTER_ITEMS_SLOT }
+                        fillProps={ fillProps }
+                    />
+                    { isOrderDetailsSectionEnabled( 'downloads' ) && (
+                        <DownloadsCard />
+                    ) }
+                </div>
+                { /* The sidebar prints too — legacy printing covers the whole
+                     details page, customer info included. */ }
+                <aside className="w-full lg:w-80 shrink-0 flex flex-col gap-4">
+                    <Slot
+                        name={ ORDER_DETAILS_SIDEBAR_BEFORE_SLOT }
+                        fillProps={ fillProps }
+                    />
+                    <CustomerCard />
+                    <AddressCard />
+                    { /* Pro's Delivery Time card fills here, keeping the
+                         sidebar order: Customer, Address, Delivery, Notes. */ }
+                    <Slot
+                        name={ ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT }
+                        fillProps={ fillProps }
+                    />
+                    { isOrderDetailsSectionEnabled( 'notes' ) && <NotesCard /> }
+                    <Slot
+                        name={ ORDER_DETAILS_SIDEBAR_AFTER_SLOT }
+                        fillProps={ fillProps }
+                    />
+                </aside>
+            </div>
+        </OrderDetailsProvider>
+    );
+};
+
+export default OrderDetailsView;

--- a/src/dashboard/orders/details/SectionCard.tsx
+++ b/src/dashboard/orders/details/SectionCard.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { Card, CardContent, CardHeader, CardTitle } from '@wedevs/plugin-ui';
+
+interface SectionCardProps {
+    title?: ReactNode;
+    description?: ReactNode;
+    action?: ReactNode;
+    children: ReactNode;
+    className?: string;
+    contentClassName?: string;
+}
+
+/**
+ * The card shell every order-details section renders in — plugin-ui `Card`
+ * carrying the product editor's section-header spec (14/600 #25252d title,
+ * #828282 description, #ddd divider), so the page reads like the rest of the
+ * panel's Figma surfaces.
+ * @param root0
+ * @param root0.title
+ * @param root0.description
+ * @param root0.action
+ * @param root0.children
+ * @param root0.className
+ * @param root0.contentClassName
+ */
+const SectionCard = ( {
+    title,
+    description,
+    action,
+    children,
+    className = '',
+    contentClassName = '',
+}: SectionCardProps ) => (
+    // 6px radius, no ring border — a mild shadow carries the edge.
+    <Card
+        className={ twMerge(
+            'gap-4 rounded-md bg-white shadow-sm ring-0',
+            className
+        ) }
+    >
+        { ( title || action ) && (
+            <CardHeader className="grid-cols-[1fr_auto] items-center border-b border-[#E9E9E9] pb-4">
+                <div className="flex min-w-0 flex-col gap-0.5">
+                    <CardTitle className="text-sm font-semibold text-[#25252d]">
+                        { title }
+                    </CardTitle>
+                    { description && (
+                        <p className="text-sm font-normal text-[#828282]">
+                            { description }
+                        </p>
+                    ) }
+                </div>
+                { action && <div className="justify-self-end">{ action }</div> }
+            </CardHeader>
+        ) }
+        <CardContent className={ contentClassName }>{ children }</CardContent>
+    </Card>
+);
+
+export default SectionCard;

--- a/src/dashboard/orders/details/SectionCard.tsx
+++ b/src/dashboard/orders/details/SectionCard.tsx
@@ -5,10 +5,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@wedevs/plugin-ui';
 interface SectionCardProps {
     title?: ReactNode;
     description?: ReactNode;
+    subtitle?: ReactNode;
     action?: ReactNode;
     children: ReactNode;
     className?: string;
+    headerClassName?: string;
     contentClassName?: string;
+    headerDivider?: boolean;
 }
 
 /**
@@ -16,21 +19,31 @@ interface SectionCardProps {
  * carrying the product editor's section-header spec (14/600 #25252d title,
  * #828282 description, #ddd divider), so the page reads like the rest of the
  * panel's Figma surfaces.
+ *
+ * `subtitle` is the sidebar's variant: a value that belongs to the title itself
+ * (the customer's name under "Customer Details"), which is why it renders above
+ * the first divider rather than as the first row beneath it.
  * @param root0
  * @param root0.title
  * @param root0.description
+ * @param root0.subtitle
  * @param root0.action
  * @param root0.children
  * @param root0.className
+ * @param root0.headerClassName
  * @param root0.contentClassName
+ * @param root0.headerDivider
  */
 const SectionCard = ( {
     title,
     description,
+    subtitle,
     action,
     children,
     className = '',
+    headerClassName = '',
     contentClassName = '',
+    headerDivider = true,
 }: SectionCardProps ) => (
     // 6px radius, no ring border — a mild shadow carries the edge.
     <Card
@@ -40,7 +53,13 @@ const SectionCard = ( {
         ) }
     >
         { ( title || action ) && (
-            <CardHeader className="grid-cols-[1fr_auto] items-center border-b border-[#E9E9E9] pb-4">
+            <CardHeader
+                className={ twMerge(
+                    'grid-cols-[1fr_auto] items-center pb-4',
+                    headerDivider ? 'border-b border-[#E9E9E9]' : '',
+                    headerClassName
+                ) }
+            >
                 <div className="flex min-w-0 flex-col gap-0.5">
                     <CardTitle className="text-sm font-semibold text-[#25252d]">
                         { title }
@@ -48,6 +67,11 @@ const SectionCard = ( {
                     { description && (
                         <p className="text-sm font-normal text-[#828282]">
                             { description }
+                        </p>
+                    ) }
+                    { subtitle && (
+                        <p className="mt-1.5 text-sm font-normal leading-[1.4] text-[#575757]">
+                            { subtitle }
                         </p>
                     ) }
                 </div>

--- a/src/dashboard/orders/details/SectionSlot.tsx
+++ b/src/dashboard/orders/details/SectionSlot.tsx
@@ -1,0 +1,46 @@
+import { Slot } from '@wordpress/components';
+import { useOrderDetailsContext } from './OrderDetailsContext';
+import { ORDER_DETAILS_SECTION_SLOTS } from './slots';
+
+/**
+ * A slot that hands fills the whole view context — the order, its id, the
+ * section markers, the loading flag, `refetch` and `navigate` — so an
+ * extension never has to fetch the order again to render beside a section.
+ * @param root0
+ * @param root0.name
+ */
+export const SectionSlot = ( { name }: { name: string } ) => {
+    const context = useOrderDetailsContext();
+
+    return <Slot name={ name } fillProps={ context } />;
+};
+
+/**
+ * Brackets a first-party section with its `before-*` / `after-*` slots.
+ * @param root0
+ * @param root0.section
+ * @param root0.children
+ */
+export const SectionWithSlots = ( {
+    section,
+    children,
+}: {
+    section: keyof typeof ORDER_DETAILS_SECTION_SLOTS | string;
+    children: React.ReactNode;
+} ) => {
+    const slots = ORDER_DETAILS_SECTION_SLOTS[ section ];
+
+    if ( ! slots ) {
+        return <>{ children }</>;
+    }
+
+    return (
+        <>
+            <SectionSlot name={ slots.before } />
+            { children }
+            <SectionSlot name={ slots.after } />
+        </>
+    );
+};
+
+export default SectionSlot;

--- a/src/dashboard/orders/details/StatusDropdown.tsx
+++ b/src/dashboard/orders/details/StatusDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { applyFilters } from '@wordpress/hooks';
 import { ChevronDown } from 'lucide-react';
 import { useToast } from '@getdokan/dokan-ui';
 import {
@@ -18,6 +19,7 @@ import {
 } from '../events';
 import { getStatusLabel } from '../status';
 import { getOrderDetailsMarker } from './marker';
+import { ORDER_DETAILS_STATUSES_FILTER } from './slots';
 import type { OrderDetailsMeta } from '../types';
 
 const unprefix = ( status: string ) =>
@@ -79,9 +81,24 @@ const StatusDropdown = ( { orderId }: { orderId: number } ) => {
         return null;
     }
 
-    const statuses = ( marker.statuses ?? [] ).filter(
-        ( option ) => unprefix( option.value ) !== status
-    );
+    /**
+     * Filters the statuses a Vendor can switch this order to.
+     *
+     * The server publishes the list; this is where a store narrows it — a
+     * workflow that forbids jumping straight to Completed, say.
+     *
+     * @param {Array}  statuses Selectable statuses as `{ value, label }`.
+     * @param {string} status   The order's current (unprefixed) status.
+     * @param {number} orderId  The order being changed.
+     */
+    const statuses = applyFilters(
+        ORDER_DETAILS_STATUSES_FILTER,
+        ( marker.statuses ?? [] ).filter(
+            ( option ) => unprefix( option.value ) !== status
+        ),
+        status,
+        orderId
+    ) as Array< { value: string; label: string } >;
 
     const changeStatus = async ( wcStatus: string ) => {
         if ( unprefix( wcStatus ) === status || isSaving ) {

--- a/src/dashboard/orders/details/StatusDropdown.tsx
+++ b/src/dashboard/orders/details/StatusDropdown.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { ChevronDown } from 'lucide-react';
+import { useToast } from '@getdokan/dokan-ui';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@wedevs/plugin-ui';
+import { usePermission } from '@dokan/hooks';
+import {
+    ORDER_DETAILS_LOADED,
+    ORDER_DETAILS_STATUS_CHANGED,
+    emitOrderDetailsEvent,
+    onOrderDetailsEvent,
+} from '../events';
+import { getStatusLabel } from '../status';
+import { getOrderDetailsMarker } from './marker';
+import type { OrderDetailsMeta } from '../types';
+
+const unprefix = ( status: string ) =>
+    status.startsWith( 'wc-' ) ? status.slice( 3 ) : status;
+
+/**
+ * The header's status control — the RFQ-style split button: the current status
+ * as the primary segment, a chevron segment opening the list of other statuses.
+ * Self-sufficient: it lives in the panel header outside the view tree, reading
+ * and announcing status over the shared order-details events.
+ * @param root0
+ * @param root0.orderId
+ */
+const StatusDropdown = ( { orderId }: { orderId: number } ) => {
+    const toast = useToast();
+    const marker = getOrderDetailsMarker();
+    const canManageOrder = usePermission( 'dokan_manage_order' );
+
+    const [ status, setStatus ] = useState< string >( '' );
+    const [ isSaving, setIsSaving ] = useState( false );
+
+    useEffect( () => {
+        const unsubscribeLoaded = onOrderDetailsEvent(
+            ORDER_DETAILS_LOADED,
+            ( loaded ) => {
+                const meta = loaded as OrderDetailsMeta;
+
+                if ( Number( meta?.id ) === orderId ) {
+                    setStatus( unprefix( meta?.status ?? '' ) );
+                }
+            }
+        );
+
+        const unsubscribeChanged = onOrderDetailsEvent(
+            ORDER_DETAILS_STATUS_CHANGED,
+            ( changedOrderId, changedStatus ) => {
+                if ( Number( changedOrderId ) === orderId ) {
+                    setStatus( unprefix( String( changedStatus ) ) );
+                }
+            }
+        );
+
+        return () => {
+            unsubscribeLoaded();
+            unsubscribeChanged();
+        };
+    }, [ orderId ] );
+
+    // Legacy parity (templates/orders/details.php): the control only exists
+    // with the capability, the admin setting on, and never on orders already
+    // cancelled or refunded.
+    if (
+        ! canManageOrder ||
+        ! marker.status_change_allowed ||
+        ! orderId ||
+        ! status ||
+        [ 'cancelled', 'refunded' ].includes( status )
+    ) {
+        return null;
+    }
+
+    const statuses = ( marker.statuses ?? [] ).filter(
+        ( option ) => unprefix( option.value ) !== status
+    );
+
+    const changeStatus = async ( wcStatus: string ) => {
+        if ( unprefix( wcStatus ) === status || isSaving ) {
+            return;
+        }
+
+        setIsSaving( true );
+
+        try {
+            await apiFetch( {
+                path: `/dokan/v1/orders/${ orderId }`,
+                method: 'PUT',
+                data: { status: wcStatus },
+            } );
+
+            const plain = unprefix( wcStatus );
+
+            emitOrderDetailsEvent( ORDER_DETAILS_STATUS_CHANGED, [
+                orderId,
+                plain,
+                getStatusLabel( plain ),
+            ] );
+
+            toast( {
+                type: 'success',
+                title: __( 'Order status updated.', 'dokan-lite' ),
+            } );
+        } catch ( statusError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( statusError as { message?: string } )?.message ||
+                    __( 'Could not update the order status.', 'dokan-lite' ),
+            } );
+        } finally {
+            setIsSaving( false );
+        }
+    };
+
+    // The RFQ action button, measured: 42px tall, 12px label padding, a 42px
+    // chevron segment, 14/500 type, 6px radius, a hairline seam between the
+    // segments. One trigger — the whole control opens the menu.
+    return (
+        <span
+            className={ `relative inline-flex ${
+                isSaving ? 'opacity-70' : ''
+            }` }
+        >
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    disabled={ isSaving }
+                    aria-label={ __( 'Change order status', 'dokan-lite' ) }
+                    className="flex h-[42px]! cursor-pointer items-stretch overflow-hidden rounded-md! border-0! bg-dokan-btn! p-0! text-white! shadow-none! hover:bg-dokan-btn-hover!"
+                >
+                    <span className="flex items-center border-r border-white px-3 text-sm font-medium">
+                        { getStatusLabel( status ) }
+                    </span>
+                    <span className="flex w-[42px] items-center justify-center">
+                        <ChevronDown size={ 18 } />
+                    </span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                    align="end"
+                    className="z-50 min-w-[168px] rounded-lg border border-gray-100 bg-white p-1 shadow-lg"
+                >
+                    { statuses.map( ( option ) => (
+                        <DropdownMenuItem
+                            key={ option.value }
+                            className="px-3 py-2 text-sm text-[#25252D]"
+                            onClick={ () => changeStatus( option.value ) }
+                        >
+                            { option.label }
+                        </DropdownMenuItem>
+                    ) ) }
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </span>
+    );
+};
+
+export default StatusDropdown;

--- a/src/dashboard/orders/details/StatusPill.tsx
+++ b/src/dashboard/orders/details/StatusPill.tsx
@@ -1,0 +1,38 @@
+import { twMerge } from 'tailwind-merge';
+import { getStatusBadgeVariant, getStatusLabel } from '../status';
+
+/**
+ * The list badges' own theme classes carry the color combination
+ * (background + text) the order list uses; the pill just adds the
+ * RFQ-height shape and a 2px border in the text color.
+ */
+const VARIANT_TO_BADGE_CLASS: Record< string, string > = {
+    success: 'dokan-badge-success',
+    info: 'dokan-badge-info',
+    warning: 'dokan-badge-warning',
+    danger: 'dokan-badge-danger',
+    secondary: 'dokan-badge-secondary',
+};
+
+const StatusPill = ( {
+    status,
+    label,
+    className = '',
+}: {
+    status: string;
+    label?: string;
+    className?: string;
+} ) => (
+    <span
+        className={ twMerge(
+            'inline-flex items-center rounded-full border border-current px-3 py-1 text-xs font-medium leading-4',
+            VARIANT_TO_BADGE_CLASS[ getStatusBadgeVariant( status ) ] ??
+                VARIANT_TO_BADGE_CLASS.secondary,
+            className
+        ) }
+    >
+        { label ?? getStatusLabel( status ) }
+    </span>
+);
+
+export default StatusPill;

--- a/src/dashboard/orders/details/SummaryStrip.tsx
+++ b/src/dashboard/orders/details/SummaryStrip.tsx
@@ -1,8 +1,26 @@
+import type { ReactNode } from 'react';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { PriceHtml } from '@dokan/components';
 import SectionCard from './SectionCard';
 import { formatSiteDateTime } from './dateTime';
 import { useOrderDetailsContext } from './OrderDetailsContext';
+import { ORDER_DETAILS_SUMMARY_ITEMS_FILTER } from './slots';
+import type { DetailsOrder } from './types';
+
+interface SummaryItem {
+    id: string;
+    label: string;
+    value: ReactNode;
+}
+
+const COLUMN_CLASSES: Record< number, string > = {
+    1: 'sm:grid-cols-1',
+    2: 'sm:grid-cols-2',
+    3: 'sm:grid-cols-3',
+    4: 'sm:grid-cols-4',
+    5: 'sm:grid-cols-5',
+};
 
 const Cell = ( {
     label,
@@ -30,23 +48,56 @@ const SummaryStrip = () => {
         return null;
     }
 
-    return (
-        <SectionCard contentClassName="grid grid-cols-1 gap-4 sm:grid-cols-3 sm:gap-0 sm:divide-x sm:divide-[#E9E9E9]">
-            <Cell label={ __( 'Created', 'dokan-lite' ) }>
-                { order.date_created
+    /**
+     * Filters the summary cells.
+     *
+     * Extensions add, drop or reorder cells here; the strip lays out whatever
+     * it is handed.
+     *
+     * @param {Array}  items The summary cells.
+     * @param {Object} order The order being displayed.
+     */
+    const items = applyFilters(
+        ORDER_DETAILS_SUMMARY_ITEMS_FILTER,
+        [
+            {
+                id: 'created',
+                label: __( 'Created', 'dokan-lite' ),
+                value: order.date_created
                     ? formatSiteDateTime( order.date_created )
-                    : '—' }
-            </Cell>
-            <Cell label={ __( 'Earning', 'dokan-lite' ) }>
-                { null === order.earning ? (
-                    '—'
-                ) : (
-                    <PriceHtml price={ order.earning } />
-                ) }
-            </Cell>
-            <Cell label={ __( 'Payment method', 'dokan-lite' ) }>
-                { order.payment_method_title || __( 'None', 'dokan-lite' ) }
-            </Cell>
+                    : '—',
+            },
+            {
+                id: 'earning',
+                label: __( 'Earning', 'dokan-lite' ),
+                value:
+                    null === order.earning ? (
+                        '—'
+                    ) : (
+                        <PriceHtml price={ order.earning } />
+                    ),
+            },
+            {
+                id: 'payment_method',
+                label: __( 'Payment method', 'dokan-lite' ),
+                value: order.payment_method_title || __( 'None', 'dokan-lite' ),
+            },
+        ] as SummaryItem[],
+        order as DetailsOrder
+    ) as SummaryItem[];
+
+    // Literal class names: Tailwind only ships utilities it can see in source.
+    const columnClass = COLUMN_CLASSES[ items.length ] ?? 'sm:grid-cols-3';
+
+    return (
+        <SectionCard
+            contentClassName={ `grid grid-cols-1 gap-4 ${ columnClass } sm:gap-0 sm:divide-x sm:divide-[#E9E9E9]` }
+        >
+            { items.map( ( item ) => (
+                <Cell key={ item.id } label={ item.label }>
+                    { item.value }
+                </Cell>
+            ) ) }
         </SectionCard>
     );
 };

--- a/src/dashboard/orders/details/SummaryStrip.tsx
+++ b/src/dashboard/orders/details/SummaryStrip.tsx
@@ -1,0 +1,54 @@
+import { __ } from '@wordpress/i18n';
+import { PriceHtml } from '@dokan/components';
+import SectionCard from './SectionCard';
+import { formatSiteDateTime } from './dateTime';
+import { useOrderDetailsContext } from './OrderDetailsContext';
+
+const Cell = ( {
+    label,
+    children,
+}: {
+    label: string;
+    children: React.ReactNode;
+} ) => (
+    <div className="flex min-w-0 flex-col gap-1.5 sm:px-6 sm:first:pl-0 sm:last:pr-0">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-[#828282]">
+            { label }
+        </span>
+        <span className="text-sm text-[#25252D]">{ children }</span>
+    </div>
+);
+
+/**
+ * Created / Earning / Payment method strip under the header — three cells
+ * separated by hairline dividers, per the mockup.
+ */
+const SummaryStrip = () => {
+    const { order } = useOrderDetailsContext();
+
+    if ( ! order ) {
+        return null;
+    }
+
+    return (
+        <SectionCard contentClassName="grid grid-cols-1 gap-4 sm:grid-cols-3 sm:gap-0 sm:divide-x sm:divide-[#E9E9E9]">
+            <Cell label={ __( 'Created', 'dokan-lite' ) }>
+                { order.date_created
+                    ? formatSiteDateTime( order.date_created )
+                    : '—' }
+            </Cell>
+            <Cell label={ __( 'Earning', 'dokan-lite' ) }>
+                { null === order.earning ? (
+                    '—'
+                ) : (
+                    <PriceHtml price={ order.earning } />
+                ) }
+            </Cell>
+            <Cell label={ __( 'Payment method', 'dokan-lite' ) }>
+                { order.payment_method_title || __( 'None', 'dokan-lite' ) }
+            </Cell>
+        </SectionCard>
+    );
+};
+
+export default SummaryStrip;

--- a/src/dashboard/orders/details/TotalsRows.tsx
+++ b/src/dashboard/orders/details/TotalsRows.tsx
@@ -1,0 +1,153 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { PriceHtml } from '@dokan/components';
+import { useOrderDetailsContext } from './OrderDetailsContext';
+
+const Row = ( {
+    label,
+    children,
+    negative = false,
+    bold = false,
+}: {
+    label: React.ReactNode;
+    children: React.ReactNode;
+    negative?: boolean;
+    bold?: boolean;
+} ) => (
+    <div
+        className={ `flex items-center justify-between gap-3 px-6 ${
+            bold
+                ? 'border-t border-[#E9E9E9] py-4 font-semibold text-[#25252D]'
+                : 'py-2.5 text-[#575757]'
+        }` }
+    >
+        <span className="flex min-w-0 flex-wrap items-center gap-2 text-sm">
+            { label }
+        </span>
+        <span
+            className={ `shrink-0 whitespace-nowrap text-sm [&_div]:inline [&_span]:inline ${
+                negative ? 'text-red-500' : ''
+            } ${ bold ? 'font-semibold text-[#25252D]' : '' }` }
+        >
+            { children }
+        </span>
+    </div>
+);
+
+const sum = ( values: Array< string | number | undefined > ): number =>
+    values.reduce< number >(
+        ( carry, value ) => carry + ( parseFloat( String( value ?? 0 ) ) || 0 ),
+        0
+    );
+
+/**
+ * Order totals per the mockup: items subtotal, shipping, fees, taxes, refund
+ * rows in red, coupon chips, and the grand total row — taller, bold, with the
+ * original struck through once refunds exist.
+ */
+const TotalsRows = () => {
+    const { order } = useOrderDetailsContext();
+
+    if ( ! order ) {
+        return null;
+    }
+
+    const itemsSubtotal = sum(
+        order.line_items.map( ( item ) => item.subtotal )
+    );
+    const feesTotal = sum( order.fee_lines.map( ( fee ) => fee.total ) );
+    const refundedTotal = sum(
+        order.refunds.map( ( refund ) =>
+            Math.abs( parseFloat( refund.total ) )
+        )
+    );
+    const orderTotal = parseFloat( order.total || '0' );
+    const netTotal = orderTotal - refundedTotal;
+    const hasRefunds = order.refunds.length > 0;
+
+    // The plain rows get equal 12px padding above the first and below the
+    // last, so the gap before Items Subtotal matches the gap after the final
+    // row (e.g. Coupons) — and the Total row centers between its divider and
+    // the card edge.
+    return (
+        <div>
+            <div className="py-3">
+                <Row label={ __( 'Items Subtotal', 'dokan-lite' ) }>
+                    <PriceHtml price={ itemsSubtotal } />
+                </Row>
+                <Row label={ __( 'Shipping', 'dokan-lite' ) }>
+                    <PriceHtml price={ order.shipping_total } />
+                </Row>
+                { feesTotal > 0 && (
+                    <Row label={ __( 'Fees', 'dokan-lite' ) }>
+                        <PriceHtml price={ feesTotal } />
+                    </Row>
+                ) }
+                <Row label={ __( 'Taxes', 'dokan-lite' ) }>
+                    <PriceHtml price={ order.total_tax } />
+                </Row>
+                { order.refunds.map( ( refund ) => (
+                    <Row
+                        key={ refund.id }
+                        negative
+                        label={
+                            <>
+                                { sprintf(
+                                    /* translators: %d: refund id */
+                                    __( 'Refund #%d', 'dokan-lite' ),
+                                    refund.id
+                                ) }
+                                { refund.refund && (
+                                    <span className="text-xs text-[#828282]">
+                                        { ' – ' + refund.refund }
+                                    </span>
+                                ) }
+                            </>
+                        }
+                    >
+                        { '- ' }
+                        <PriceHtml
+                            price={ Math.abs( parseFloat( refund.total ) ) }
+                        />
+                    </Row>
+                ) ) }
+                { order.coupon_lines.length > 0 && (
+                    <Row
+                        negative
+                        label={
+                            <span className="inline-flex flex-wrap items-center gap-1.5">
+                                <span>{ __( 'Coupons', 'dokan-lite' ) }</span>
+                                { order.coupon_lines.map( ( coupon ) => (
+                                    <span
+                                        key={ coupon.id }
+                                        className="inline-flex items-center whitespace-nowrap rounded border border-[#E9E9E9] bg-[#F9FAFB] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#575757]"
+                                    >
+                                        { coupon.code }
+                                    </span>
+                                ) ) }
+                            </span>
+                        }
+                    >
+                        { '- ' }
+                        <PriceHtml
+                            price={ sum(
+                                order.coupon_lines.map(
+                                    ( coupon ) => coupon.discount
+                                )
+                            ) }
+                        />
+                    </Row>
+                ) }
+            </div>
+            <Row bold label={ __( 'Total', 'dokan-lite' ) }>
+                { hasRefunds && (
+                    <span className="mr-2 font-normal text-gray-400 line-through">
+                        <PriceHtml price={ orderTotal } />
+                    </span>
+                ) }
+                <PriceHtml price={ hasRefunds ? netTotal : orderTotal } />
+            </Row>
+        </div>
+    );
+};
+
+export default TotalsRows;

--- a/src/dashboard/orders/details/dateTime.ts
+++ b/src/dashboard/orders/details/dateTime.ts
@@ -1,0 +1,49 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n, getSettings, humanTimeDiff } from '@wordpress/date';
+
+declare const window: Window & {
+    dokan?: {
+        i18n_date_format?: string;
+        i18n_time_format?: string;
+    };
+};
+
+/**
+ * The panel's wp-date package ships WordPress defaults, not this site's
+ * settings — Dokan localizes the real admin formats on `window.dokan`.
+ */
+const siteFormats = () => ( {
+    date: window?.dokan?.i18n_date_format || getSettings().formats.date,
+    time: window?.dokan?.i18n_time_format || getSettings().formats.time,
+} );
+
+/**
+ * Format a date-time exactly as the site's WordPress general settings ask,
+ * joined the way WordPress itself presents the pair: "date at time".
+ * @param value
+ */
+export const formatSiteDateTime = ( value: string ): string => {
+    const { date, time } = siteFormats();
+
+    return sprintf(
+        /* translators: 1: formatted date 2: formatted time */
+        __( '%1$s at %2$s', 'dokan-lite' ),
+        dateI18n( date, value, undefined ),
+        dateI18n( time, value, undefined )
+    );
+};
+
+/**
+ * Format a date exactly as the site's WordPress general settings ask.
+ * @param value
+ */
+export const formatSiteDate = ( value: string ): string =>
+    dateI18n( siteFormats().date, value, undefined );
+
+/**
+ * "added 20 hours ago" style relative time for note timestamps.
+ * `humanTimeDiff` already includes the "ago" suffix.
+ * @param value
+ */
+export const timeAgo = ( value: string ): string =>
+    humanTimeDiff( value, undefined );

--- a/src/dashboard/orders/details/index.tsx
+++ b/src/dashboard/orders/details/index.tsx
@@ -1,0 +1,22 @@
+import OrderDetailsFragment from '../OrderDetails';
+import OrderDetailsView from './OrderDetailsView';
+import { isReactOrderDetailsView } from './marker';
+
+/**
+ * The order-details route element: the server-side marker picks the renderer.
+ *
+ * `react` renders the first-party view; anything else falls back to the
+ * server-rendered fragment (ADR-0005) — the permanent compatibility path for
+ * stores with third-party template hooks and for Vendor staff sessions.
+ * @param props
+ * @param props.params
+ * @param props.params.orderId
+ */
+const OrderDetailsRoute = ( props: { params?: { orderId?: string } } ) =>
+    isReactOrderDetailsView() ? (
+        <OrderDetailsView { ...props } />
+    ) : (
+        <OrderDetailsFragment { ...props } />
+    );
+
+export default OrderDetailsRoute;

--- a/src/dashboard/orders/details/marker.ts
+++ b/src/dashboard/orders/details/marker.ts
@@ -1,0 +1,20 @@
+import type { OrderDetailsMarker } from './types';
+
+declare const window: Window & {
+    dokanFrontend?: {
+        order_details?: OrderDetailsMarker;
+    };
+};
+
+/**
+ * The server-computed marker deciding how the order-details route renders and
+ * which sections exist on this store.
+ */
+export const getOrderDetailsMarker = (): OrderDetailsMarker =>
+    window?.dokanFrontend?.order_details ?? {};
+
+export const isReactOrderDetailsView = (): boolean =>
+    getOrderDetailsMarker().view === 'react';
+
+export const isOrderDetailsSectionEnabled = ( section: string ): boolean =>
+    Boolean( getOrderDetailsMarker().sections?.[ section ] );

--- a/src/dashboard/orders/details/sidebar/AddressCard.tsx
+++ b/src/dashboard/orders/details/sidebar/AddressCard.tsx
@@ -1,47 +1,124 @@
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import SectionCard from '../SectionCard';
+import { applyFilters } from '@wordpress/hooks';
+import { DokanTooltip } from '@dokan/components';
+import { SidebarBlock, SidebarCard } from './SidebarCard';
 import { useOrderDetailsContext } from '../OrderDetailsContext';
+import { ORDER_DETAILS_ADDRESS_PARTS_FILTER } from '../slots';
 import type { DetailsAddress } from '../types';
 
-const formatAddress = ( address: DetailsAddress ): string[] => {
-    const name = [ address.first_name, address.last_name ]
-        .filter( Boolean )
-        .join( ' ' );
-    const cityLine = [ address.city, address.state, address.postcode ]
+/**
+ * The mockup prints the address as one flowing sentence rather than a stack of
+ * one-field lines, so it fills the sidebar's width before it wraps.
+ * @param address
+ * @param type
+ */
+const formatAddress = ( address: DetailsAddress, type: string ): string => {
+    /**
+     * Filters the parts an address is composed of, in order.
+     *
+     * Locales that order an address differently — or stores that want the
+     * company left out — change the list here.
+     *
+     * @param {Array}  parts   Address parts, joined with ", ".
+     * @param {Object} address The raw address object.
+     * @param {string} type    "shipping" or "billing".
+     */
+    const parts = applyFilters(
+        ORDER_DETAILS_ADDRESS_PARTS_FILTER,
+        [
+            [ address.first_name, address.last_name ]
+                .filter( Boolean )
+                .join( ' ' ),
+            address.company,
+            address.address_1,
+            address.address_2,
+            address.city,
+            address.state,
+            address.postcode,
+            address.country,
+        ],
+        address,
+        type
+    ) as Array< string | undefined >;
+
+    return parts
+        .map( ( part ) => decodeEntities( String( part ?? '' ) ).trim() )
         .filter( Boolean )
         .join( ', ' );
-
-    return [
-        name,
-        address.company,
-        address.address_1,
-        address.address_2,
-        cityLine,
-        address.country,
-    ].filter( Boolean ) as string[];
 };
 
 const AddressBlock = ( {
     label,
     address,
+    type,
 }: {
     label: string;
     address: DetailsAddress;
+    type: string;
 } ) => {
-    const lines = formatAddress( address );
+    const text = formatAddress( address, type );
+    const containerRef = useRef< HTMLDivElement >( null );
+    const textRef = useRef< HTMLParagraphElement >( null );
+    const [ isTruncated, setIsTruncated ] = useState( false );
+
+    // Long addresses clamp at three lines; the full text stays reachable on
+    // hover, so nothing is lost to the ellipsis. Measured through a
+    // ResizeObserver because the first paint lies: web fonts swap in after it,
+    // and a wider glyph set is exactly what pushes an address past three lines.
+    useEffect( () => {
+        // Read the paragraph through the ref, and watch the block around it:
+        // adding the tooltip re-creates the paragraph, and a stale node
+        // measures zero — which would unwrap it again, forever.
+        const measure = () => {
+            const element = textRef.current;
+
+            if ( ! element?.isConnected ) {
+                return;
+            }
+
+            setIsTruncated( element.scrollHeight > element.clientHeight + 1 );
+        };
+
+        measure();
+
+        const observer =
+            'undefined' !== typeof ResizeObserver
+                ? new ResizeObserver( measure )
+                : null;
+
+        if ( containerRef.current ) {
+            observer?.observe( containerRef.current );
+        }
+
+        document.fonts?.ready?.then( measure ).catch( () => {} );
+        window.addEventListener( 'resize', measure );
+
+        return () => {
+            observer?.disconnect();
+            window.removeEventListener( 'resize', measure );
+        };
+    }, [ text ] );
+
+    const body = (
+        <p ref={ textRef } className="line-clamp-3 w-full break-words">
+            { text || __( 'None', 'dokan-lite' ) }
+        </p>
+    );
 
     return (
-        <div className="px-6 py-3 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0">
-            <p className="mb-1 text-xs font-medium text-gray-500">{ label }</p>
-            <div className="text-sm text-gray-800">
-                { lines.length
-                    ? lines.map( ( line ) => (
-                          <p key={ line }>{ decodeEntities( line ) }</p>
-                      ) )
-                    : __( 'None', 'dokan-lite' ) }
+        <SidebarBlock label={ label }>
+            <div ref={ containerRef }>
+                { isTruncated ? (
+                    <DokanTooltip content={ text }>
+                        <span className="block w-full">{ body }</span>
+                    </DokanTooltip>
+                ) : (
+                    body
+                ) }
             </div>
-        </div>
+        </SidebarBlock>
     );
 };
 
@@ -56,19 +133,18 @@ const AddressCard = () => {
     }
 
     return (
-        <SectionCard
-            title={ __( 'Address', 'dokan-lite' ) }
-            contentClassName="px-0"
-        >
+        <SidebarCard title={ __( 'Address', 'dokan-lite' ) }>
             <AddressBlock
                 label={ __( 'Shipping Address', 'dokan-lite' ) }
                 address={ order.shipping }
+                type="shipping"
             />
             <AddressBlock
                 label={ __( 'Billing Address', 'dokan-lite' ) }
                 address={ order.billing }
+                type="billing"
             />
-        </SectionCard>
+        </SidebarCard>
     );
 };
 

--- a/src/dashboard/orders/details/sidebar/AddressCard.tsx
+++ b/src/dashboard/orders/details/sidebar/AddressCard.tsx
@@ -1,0 +1,75 @@
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import SectionCard from '../SectionCard';
+import { useOrderDetailsContext } from '../OrderDetailsContext';
+import type { DetailsAddress } from '../types';
+
+const formatAddress = ( address: DetailsAddress ): string[] => {
+    const name = [ address.first_name, address.last_name ]
+        .filter( Boolean )
+        .join( ' ' );
+    const cityLine = [ address.city, address.state, address.postcode ]
+        .filter( Boolean )
+        .join( ', ' );
+
+    return [
+        name,
+        address.company,
+        address.address_1,
+        address.address_2,
+        cityLine,
+        address.country,
+    ].filter( Boolean ) as string[];
+};
+
+const AddressBlock = ( {
+    label,
+    address,
+}: {
+    label: string;
+    address: DetailsAddress;
+} ) => {
+    const lines = formatAddress( address );
+
+    return (
+        <div className="px-6 py-3 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0">
+            <p className="mb-1 text-xs font-medium text-gray-500">{ label }</p>
+            <div className="text-sm text-gray-800">
+                { lines.length
+                    ? lines.map( ( line ) => (
+                          <p key={ line }>{ decodeEntities( line ) }</p>
+                      ) )
+                    : __( 'None', 'dokan-lite' ) }
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Shipping + billing address sidebar card with "None" empty states per the mockup.
+ */
+const AddressCard = () => {
+    const { order } = useOrderDetailsContext();
+
+    if ( ! order ) {
+        return null;
+    }
+
+    return (
+        <SectionCard
+            title={ __( 'Address', 'dokan-lite' ) }
+            contentClassName="px-0"
+        >
+            <AddressBlock
+                label={ __( 'Shipping Address', 'dokan-lite' ) }
+                address={ order.shipping }
+            />
+            <AddressBlock
+                label={ __( 'Billing Address', 'dokan-lite' ) }
+                address={ order.billing }
+            />
+        </SectionCard>
+    );
+};
+
+export default AddressCard;

--- a/src/dashboard/orders/details/sidebar/CustomerCard.tsx
+++ b/src/dashboard/orders/details/sidebar/CustomerCard.tsx
@@ -1,33 +1,32 @@
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { ExternalLink } from 'lucide-react';
-import SectionCard from '../SectionCard';
+import { ExternalLink, Mail, Phone } from 'lucide-react';
+import { SidebarBlock, SidebarCard } from './SidebarCard';
 import { useOrderDetailsContext } from '../OrderDetailsContext';
 
-const Block = ( {
-    label,
-    upper = false,
+/**
+ * Contact line: a 16px glyph and the value, on the mockup's 9px gap.
+ * @param root0
+ * @param root0.icon
+ * @param root0.children
+ */
+const ContactLine = ( {
+    icon: Icon,
     children,
 }: {
-    label: string;
-    upper?: boolean;
+    icon: typeof Mail;
     children: React.ReactNode;
 } ) => (
-    <div className="border-t border-[#E9E9E9] px-6 py-3 last:pb-0">
-        <p
-            className={ `mb-1 font-medium text-[#828282] ${
-                upper ? 'text-[11px] uppercase tracking-wider' : 'text-xs'
-            }` }
-        >
-            { label }
-        </p>
-        <div className="break-words text-sm text-[#575757]">{ children }</div>
-    </div>
+    <p className="flex items-center gap-[9px]">
+        <Icon className="shrink-0 text-[#575757]" size={ 16 } />
+        <span className="min-w-0 break-words">{ children }</span>
+    </p>
 );
 
 /**
- * Customer Details sidebar card, per the mockup: the customer name sits right
- * under the card title, and the section dividers run edge to edge.
+ * Customer Details sidebar card, per the mockup: the customer name belongs to
+ * the title block (no rule between the two), then contact, IP and note blocks
+ * separated by edge-to-edge dividers.
  */
 const CustomerCard = () => {
     const { order } = useOrderDetailsContext();
@@ -40,51 +39,67 @@ const CustomerCard = () => {
     const fullName = [ order.billing.first_name, order.billing.last_name ]
         .filter( Boolean )
         .join( ' ' );
+    const displayName =
+        isGuest && ! fullName
+            ? __( 'Guest Customer', 'dokan-lite' )
+            : decodeEntities( fullName ) ||
+              __( 'Guest Customer', 'dokan-lite' );
 
-    const contactLines = [ order.billing.email, order.billing.phone ].filter(
-        Boolean
-    );
+    const hasContact = Boolean( order.billing.email || order.billing.phone );
 
     return (
-        <SectionCard
+        <SidebarCard
             title={ __( 'Customer Details', 'dokan-lite' ) }
-            contentClassName="px-0"
+            subtitle={ displayName }
         >
-            <p className="px-6 pb-3 text-sm text-gray-600">
-                { isGuest && ! fullName
-                    ? __( 'Guest Customer', 'dokan-lite' )
-                    : decodeEntities( fullName ) ||
-                      __( 'Guest Customer', 'dokan-lite' ) }
-            </p>
-            <Block label={ __( 'Contact', 'dokan-lite' ) }>
-                { contactLines.length
-                    ? contactLines.map( ( line ) => (
-                          <p key={ line }>{ line }</p>
-                      ) )
-                    : __( 'None', 'dokan-lite' ) }
-            </Block>
-            <Block label={ __( 'Customer IP', 'dokan-lite' ) } upper>
+            <SidebarBlock label={ __( 'Contact', 'dokan-lite' ) }>
+                { hasContact ? (
+                    // Tight enough that the email and phone read as one
+                    // contact block rather than two separate facts.
+                    <div className="flex flex-col gap-2">
+                        { order.billing.email && (
+                            <ContactLine icon={ Mail }>
+                                { order.billing.email }
+                            </ContactLine>
+                        ) }
+                        { order.billing.phone && (
+                            <ContactLine icon={ Phone }>
+                                { order.billing.phone }
+                            </ContactLine>
+                        ) }
+                    </div>
+                ) : (
+                    __( 'None', 'dokan-lite' )
+                ) }
+            </SidebarBlock>
+
+            <SidebarBlock label={ __( 'Customer IP', 'dokan-lite' ) }>
                 { order.customer_ip_address ? (
                     // Same geo-lookup link the legacy details page uses.
                     <a
                         href={ `https://tools.keycdn.com/geo?host=${ order.customer_ip_address }` }
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex items-center gap-1 text-dokan-link"
+                        className="flex items-center gap-[9px] text-dokan-link"
                     >
-                        <ExternalLink size={ 12 } />
-                        { order.customer_ip_address }
+                        <ExternalLink className="shrink-0" size={ 16 } />
+                        <span className="min-w-0 break-words">
+                            { order.customer_ip_address }
+                        </span>
                     </a>
                 ) : (
                     __( 'None', 'dokan-lite' )
                 ) }
-            </Block>
-            <Block label={ __( 'Customer Note', 'dokan-lite' ) }>
-                { order.customer_note
-                    ? decodeEntities( order.customer_note )
-                    : __( 'None', 'dokan-lite' ) }
-            </Block>
-        </SectionCard>
+            </SidebarBlock>
+
+            <SidebarBlock label={ __( 'Customer Note', 'dokan-lite' ) }>
+                <p className="whitespace-pre-wrap break-words">
+                    { order.customer_note
+                        ? decodeEntities( order.customer_note )
+                        : __( 'None', 'dokan-lite' ) }
+                </p>
+            </SidebarBlock>
+        </SidebarCard>
     );
 };
 

--- a/src/dashboard/orders/details/sidebar/CustomerCard.tsx
+++ b/src/dashboard/orders/details/sidebar/CustomerCard.tsx
@@ -1,0 +1,91 @@
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { ExternalLink } from 'lucide-react';
+import SectionCard from '../SectionCard';
+import { useOrderDetailsContext } from '../OrderDetailsContext';
+
+const Block = ( {
+    label,
+    upper = false,
+    children,
+}: {
+    label: string;
+    upper?: boolean;
+    children: React.ReactNode;
+} ) => (
+    <div className="border-t border-[#E9E9E9] px-6 py-3 last:pb-0">
+        <p
+            className={ `mb-1 font-medium text-[#828282] ${
+                upper ? 'text-[11px] uppercase tracking-wider' : 'text-xs'
+            }` }
+        >
+            { label }
+        </p>
+        <div className="break-words text-sm text-[#575757]">{ children }</div>
+    </div>
+);
+
+/**
+ * Customer Details sidebar card, per the mockup: the customer name sits right
+ * under the card title, and the section dividers run edge to edge.
+ */
+const CustomerCard = () => {
+    const { order } = useOrderDetailsContext();
+
+    if ( ! order ) {
+        return null;
+    }
+
+    const isGuest = ! order.customer_id;
+    const fullName = [ order.billing.first_name, order.billing.last_name ]
+        .filter( Boolean )
+        .join( ' ' );
+
+    const contactLines = [ order.billing.email, order.billing.phone ].filter(
+        Boolean
+    );
+
+    return (
+        <SectionCard
+            title={ __( 'Customer Details', 'dokan-lite' ) }
+            contentClassName="px-0"
+        >
+            <p className="px-6 pb-3 text-sm text-gray-600">
+                { isGuest && ! fullName
+                    ? __( 'Guest Customer', 'dokan-lite' )
+                    : decodeEntities( fullName ) ||
+                      __( 'Guest Customer', 'dokan-lite' ) }
+            </p>
+            <Block label={ __( 'Contact', 'dokan-lite' ) }>
+                { contactLines.length
+                    ? contactLines.map( ( line ) => (
+                          <p key={ line }>{ line }</p>
+                      ) )
+                    : __( 'None', 'dokan-lite' ) }
+            </Block>
+            <Block label={ __( 'Customer IP', 'dokan-lite' ) } upper>
+                { order.customer_ip_address ? (
+                    // Same geo-lookup link the legacy details page uses.
+                    <a
+                        href={ `https://tools.keycdn.com/geo?host=${ order.customer_ip_address }` }
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-dokan-link"
+                    >
+                        <ExternalLink size={ 12 } />
+                        { order.customer_ip_address }
+                    </a>
+                ) : (
+                    __( 'None', 'dokan-lite' )
+                ) }
+            </Block>
+            <Block label={ __( 'Customer Note', 'dokan-lite' ) }>
+                { order.customer_note
+                    ? decodeEntities( order.customer_note )
+                    : __( 'None', 'dokan-lite' ) }
+            </Block>
+        </SectionCard>
+    );
+};
+
+export default CustomerCard;

--- a/src/dashboard/orders/details/sidebar/NotesCard.tsx
+++ b/src/dashboard/orders/details/sidebar/NotesCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Trash2 } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import { useToast } from '@getdokan/dokan-ui';
 import {
     Select,
@@ -12,10 +12,17 @@ import {
     Textarea,
 } from '@wedevs/plugin-ui';
 import { DokanButton } from '@dokan/components';
-import SectionCard from '../SectionCard';
+import { SidebarCard } from './SidebarCard';
 import useOrderNotes from '../useOrderNotes';
 import { timeAgo } from '../dateTime';
 import { useOrderDetailsContext } from '../OrderDetailsContext';
+
+type NoteType = 'private' | 'customer';
+
+const noteTypeLabel = ( type: NoteType ): string =>
+    'customer' === type
+        ? __( 'Customer Note', 'dokan-lite' )
+        : __( 'Private Note', 'dokan-lite' );
 
 /**
  * Order Note sidebar card per the mockup: plain note entries with the type
@@ -28,9 +35,7 @@ const NotesCard = () => {
         useOrderNotes( orderId );
 
     const [ noteText, setNoteText ] = useState( '' );
-    const [ noteType, setNoteType ] = useState< 'private' | 'customer' >(
-        'customer'
-    );
+    const [ noteType, setNoteType ] = useState< NoteType >( 'customer' );
     const [ isSaving, setIsSaving ] = useState( false );
     const [ confirmingDelete, setConfirmingDelete ] = useState< number >( 0 );
 
@@ -84,39 +89,43 @@ const NotesCard = () => {
     };
 
     return (
-        <SectionCard
-            title={ __( 'Order Note', 'dokan-lite' ) }
-            contentClassName="px-0"
-        >
+        <SidebarCard title={ __( 'Order Note', 'dokan-lite' ) }>
             { isLoading && (
-                <div className="mx-6 h-16 animate-pulse rounded bg-gray-100" />
+                <div className="mx-5 mt-5 h-16 animate-pulse rounded bg-gray-100" />
             ) }
 
             { ! isLoading && ! error && ! notes.length && (
-                <p className="px-6 text-sm text-[#828282]">
+                <p className="mt-5 border-t border-[#E9E9E9] px-5 pt-5 text-sm leading-[1.4] text-[#828282]">
                     { __( 'No notes for this order yet.', 'dokan-lite' ) }
                 </p>
             ) }
 
             { ! isLoading && error && (
-                <p className="px-6 text-sm text-[#828282]">{ error }</p>
+                <p className="mt-5 border-t border-[#E9E9E9] px-5 pt-5 text-sm leading-[1.4] text-[#828282]">
+                    { error }
+                </p>
             ) }
 
             { ! isLoading && notes.length > 0 && (
-                <ul className="flex flex-col divide-y divide-[#E9E9E9]">
+                <ul className="flex flex-col">
                     { notes.map( ( note ) => (
-                        <li key={ note.id } className="px-6 py-3 first:pt-0">
-                            <div className="mb-1 flex items-center justify-between gap-2">
-                                <span className="text-xs font-medium text-[#828282]">
-                                    { note.customer_note
-                                        ? __( 'Customer Note', 'dokan-lite' )
-                                        : __( 'Private Note', 'dokan-lite' ) }
+                        <li
+                            key={ note.id }
+                            className="mt-5 border-t border-[#E9E9E9] px-5 pt-5"
+                        >
+                            <div className="flex items-start justify-between gap-2">
+                                <span className="text-xs font-semibold leading-[1.3] text-[#393939]">
+                                    { noteTypeLabel(
+                                        note.customer_note
+                                            ? 'customer'
+                                            : 'private'
+                                    ) }
                                 </span>
                                 { confirmingDelete === note.id ? (
                                     <span className="flex items-center gap-2 text-xs">
                                         <button
                                             type="button"
-                                            className="border-0! bg-transparent! p-0! shadow-none! font-medium text-red-600!"
+                                            className="border-0! bg-transparent! p-0! font-medium shadow-none! text-red-600!"
                                             onClick={ () =>
                                                 handleDelete( note.id )
                                             }
@@ -125,7 +134,7 @@ const NotesCard = () => {
                                         </button>
                                         <button
                                             type="button"
-                                            className="border-0! bg-transparent! p-0! shadow-none! text-gray-500!"
+                                            className="border-0! bg-transparent! p-0! text-gray-500! shadow-none!"
                                             onClick={ () =>
                                                 setConfirmingDelete( 0 )
                                             }
@@ -140,19 +149,19 @@ const NotesCard = () => {
                                             'Delete note',
                                             'dokan-lite'
                                         ) }
-                                        className="border-0! bg-transparent! p-0.5! shadow-none! text-gray-400! hover:text-red-500!"
+                                        className="border-0! bg-transparent! p-0! text-[#A5A5AA]! shadow-none! hover:text-red-500!"
                                         onClick={ () =>
                                             setConfirmingDelete( note.id )
                                         }
                                     >
-                                        <Trash2 size={ 14 } />
+                                        <Trash2 size={ 16 } />
                                     </button>
                                 ) }
                             </div>
-                            <p className="whitespace-pre-wrap break-words text-sm text-[#575757]">
+                            <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-[1.4] text-[#575757]">
                                 { decodeEntities( note.note ) }
                             </p>
-                            <p className="mt-1 text-[11px] text-gray-400">
+                            <p className="mt-2 text-xs leading-[1.4] text-[#A5A5AA]">
                                 { sprintf(
                                     /* translators: %s: human readable time difference, e.g. "3 hours ago" */
                                     __( 'added %s', 'dokan-lite' ),
@@ -165,47 +174,52 @@ const NotesCard = () => {
             ) }
 
             { ! error && (
-                <div className="mt-3 border-t border-[#E9E9E9] px-6 pt-4">
+                <div className="mt-5 border-t border-[#E9E9E9] px-5 pt-5">
                     <Select
                         value={ noteType }
                         onValueChange={ ( value ) =>
-                            setNoteType( value as 'private' | 'customer' )
+                            setNoteType( value as NoteType )
                         }
                     >
-                        <SelectTrigger className="mb-2 w-auto gap-2 border-[#E9E9E9] text-sm shadow-none">
-                            <SelectValue />
+                        { /* Without explicit children the trigger prints the
+                             raw value ("customer") instead of its label. */ }
+                        <SelectTrigger className="h-8! w-auto gap-2 rounded-[5px]! border-[#E9E9E9]! px-3! text-xs font-medium text-[#25252d]! shadow-none!">
+                            <SelectValue>
+                                { noteTypeLabel( noteType ) }
+                            </SelectValue>
                         </SelectTrigger>
                         <SelectContent className="z-50">
                             <SelectItem value="customer">
-                                { __( 'Customer Note', 'dokan-lite' ) }
+                                { noteTypeLabel( 'customer' ) }
                             </SelectItem>
                             <SelectItem value="private">
-                                { __( 'Private Note', 'dokan-lite' ) }
+                                { noteTypeLabel( 'private' ) }
                             </SelectItem>
                         </SelectContent>
                     </Select>
                     <Textarea
                         rows={ 3 }
-                        className="border-[#E9E9E9] shadow-none"
+                        className="mt-2.5 rounded-[5px] border-[#E9E9E9] text-sm shadow-none"
                         placeholder={ __( 'Write here', 'dokan-lite' ) }
                         value={ noteText }
                         onChange={ ( event ) =>
                             setNoteText( event.target.value )
                         }
                     />
-                    <div className="mt-2.5 flex justify-end">
+                    <div className="mt-3 flex justify-end">
                         <DokanButton
                             variant="secondary"
                             onClick={ handleAdd }
                             disabled={ isSaving || ! noteText.trim() }
                             loading={ isSaving }
                         >
-                            { __( 'Add Note +', 'dokan-lite' ) }
+                            { __( 'Add Note', 'dokan-lite' ) }
+                            <Plus size={ 16 } />
                         </DokanButton>
                     </div>
                 </div>
             ) }
-        </SectionCard>
+        </SidebarCard>
     );
 };
 

--- a/src/dashboard/orders/details/sidebar/NotesCard.tsx
+++ b/src/dashboard/orders/details/sidebar/NotesCard.tsx
@@ -1,0 +1,212 @@
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Trash2 } from 'lucide-react';
+import { useToast } from '@getdokan/dokan-ui';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Textarea,
+} from '@wedevs/plugin-ui';
+import { DokanButton } from '@dokan/components';
+import SectionCard from '../SectionCard';
+import useOrderNotes from '../useOrderNotes';
+import { timeAgo } from '../dateTime';
+import { useOrderDetailsContext } from '../OrderDetailsContext';
+
+/**
+ * Order Note sidebar card per the mockup: plain note entries with the type
+ * label, a trash action, and an "added … ago" stamp — plus the add-note form.
+ */
+const NotesCard = () => {
+    const { orderId, order } = useOrderDetailsContext();
+    const toast = useToast();
+    const { notes, isLoading, error, addNote, deleteNote } =
+        useOrderNotes( orderId );
+
+    const [ noteText, setNoteText ] = useState( '' );
+    const [ noteType, setNoteType ] = useState< 'private' | 'customer' >(
+        'customer'
+    );
+    const [ isSaving, setIsSaving ] = useState( false );
+    const [ confirmingDelete, setConfirmingDelete ] = useState< number >( 0 );
+
+    const handleAdd = async () => {
+        if ( ! noteText.trim() ) {
+            return;
+        }
+
+        setIsSaving( true );
+
+        try {
+            await addNote(
+                noteText.trim(),
+                'customer' === noteType,
+                order?.status ?? 'processing'
+            );
+            setNoteText( '' );
+            toast( {
+                type: 'success',
+                title: __( 'Note added.', 'dokan-lite' ),
+            } );
+        } catch ( addError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( addError as { message?: string } )?.message ||
+                    __( 'Could not add the note.', 'dokan-lite' ),
+            } );
+        } finally {
+            setIsSaving( false );
+        }
+    };
+
+    const handleDelete = async ( noteId: number ) => {
+        try {
+            await deleteNote( noteId );
+            toast( {
+                type: 'success',
+                title: __( 'Note deleted.', 'dokan-lite' ),
+            } );
+        } catch ( deleteError ) {
+            toast( {
+                type: 'error',
+                title:
+                    ( deleteError as { message?: string } )?.message ||
+                    __( 'Could not delete the note.', 'dokan-lite' ),
+            } );
+        } finally {
+            setConfirmingDelete( 0 );
+        }
+    };
+
+    return (
+        <SectionCard
+            title={ __( 'Order Note', 'dokan-lite' ) }
+            contentClassName="px-0"
+        >
+            { isLoading && (
+                <div className="mx-6 h-16 animate-pulse rounded bg-gray-100" />
+            ) }
+
+            { ! isLoading && ! error && ! notes.length && (
+                <p className="px-6 text-sm text-[#828282]">
+                    { __( 'No notes for this order yet.', 'dokan-lite' ) }
+                </p>
+            ) }
+
+            { ! isLoading && error && (
+                <p className="px-6 text-sm text-[#828282]">{ error }</p>
+            ) }
+
+            { ! isLoading && notes.length > 0 && (
+                <ul className="flex flex-col divide-y divide-[#E9E9E9]">
+                    { notes.map( ( note ) => (
+                        <li key={ note.id } className="px-6 py-3 first:pt-0">
+                            <div className="mb-1 flex items-center justify-between gap-2">
+                                <span className="text-xs font-medium text-[#828282]">
+                                    { note.customer_note
+                                        ? __( 'Customer Note', 'dokan-lite' )
+                                        : __( 'Private Note', 'dokan-lite' ) }
+                                </span>
+                                { confirmingDelete === note.id ? (
+                                    <span className="flex items-center gap-2 text-xs">
+                                        <button
+                                            type="button"
+                                            className="border-0! bg-transparent! p-0! shadow-none! font-medium text-red-600!"
+                                            onClick={ () =>
+                                                handleDelete( note.id )
+                                            }
+                                        >
+                                            { __( 'Confirm', 'dokan-lite' ) }
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="border-0! bg-transparent! p-0! shadow-none! text-gray-500!"
+                                            onClick={ () =>
+                                                setConfirmingDelete( 0 )
+                                            }
+                                        >
+                                            { __( 'Cancel', 'dokan-lite' ) }
+                                        </button>
+                                    </span>
+                                ) : (
+                                    <button
+                                        type="button"
+                                        aria-label={ __(
+                                            'Delete note',
+                                            'dokan-lite'
+                                        ) }
+                                        className="border-0! bg-transparent! p-0.5! shadow-none! text-gray-400! hover:text-red-500!"
+                                        onClick={ () =>
+                                            setConfirmingDelete( note.id )
+                                        }
+                                    >
+                                        <Trash2 size={ 14 } />
+                                    </button>
+                                ) }
+                            </div>
+                            <p className="whitespace-pre-wrap break-words text-sm text-[#575757]">
+                                { decodeEntities( note.note ) }
+                            </p>
+                            <p className="mt-1 text-[11px] text-gray-400">
+                                { sprintf(
+                                    /* translators: %s: human readable time difference, e.g. "3 hours ago" */
+                                    __( 'added %s', 'dokan-lite' ),
+                                    timeAgo( note.date_created )
+                                ) }
+                            </p>
+                        </li>
+                    ) ) }
+                </ul>
+            ) }
+
+            { ! error && (
+                <div className="mt-3 border-t border-[#E9E9E9] px-6 pt-4">
+                    <Select
+                        value={ noteType }
+                        onValueChange={ ( value ) =>
+                            setNoteType( value as 'private' | 'customer' )
+                        }
+                    >
+                        <SelectTrigger className="mb-2 w-auto gap-2 border-[#E9E9E9] text-sm shadow-none">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent className="z-50">
+                            <SelectItem value="customer">
+                                { __( 'Customer Note', 'dokan-lite' ) }
+                            </SelectItem>
+                            <SelectItem value="private">
+                                { __( 'Private Note', 'dokan-lite' ) }
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <Textarea
+                        rows={ 3 }
+                        className="border-[#E9E9E9] shadow-none"
+                        placeholder={ __( 'Write here', 'dokan-lite' ) }
+                        value={ noteText }
+                        onChange={ ( event ) =>
+                            setNoteText( event.target.value )
+                        }
+                    />
+                    <div className="mt-2.5 flex justify-end">
+                        <DokanButton
+                            variant="secondary"
+                            onClick={ handleAdd }
+                            disabled={ isSaving || ! noteText.trim() }
+                            loading={ isSaving }
+                        >
+                            { __( 'Add Note +', 'dokan-lite' ) }
+                        </DokanButton>
+                    </div>
+                </div>
+            ) }
+        </SectionCard>
+    );
+};
+
+export default NotesCard;

--- a/src/dashboard/orders/details/sidebar/SidebarCard.tsx
+++ b/src/dashboard/orders/details/sidebar/SidebarCard.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+import SectionCard from '../SectionCard';
+
+interface SidebarCardProps {
+    title: ReactNode;
+    subtitle?: ReactNode;
+    children: ReactNode;
+    contentClassName?: string;
+}
+
+/**
+ * The sidebar's card preset: the shared section shell on the mockup's 20px
+ * grid, with dividers that run edge to edge instead of insetting with the text.
+ *
+ * The header never draws the rule itself — the card header's own
+ * `[.border-b]:pb-6` variant would then win the padding on specificity and put
+ * that one card off the grid. Each block draws the rule above itself instead,
+ * so every card breathes identically.
+ * @param root0
+ * @param root0.title
+ * @param root0.subtitle
+ * @param root0.children
+ * @param root0.contentClassName
+ */
+export const SidebarCard = ( {
+    title,
+    subtitle,
+    children,
+    contentClassName = '',
+}: SidebarCardProps ) => (
+    <SectionCard
+        title={ title }
+        subtitle={ subtitle }
+        headerDivider={ false }
+        className="gap-0 py-5"
+        headerClassName="px-5 pb-0"
+        contentClassName={ twMerge( 'px-0 pt-0', contentClassName ) }
+    >
+        { children }
+    </SectionCard>
+);
+
+/**
+ * One labelled block inside a sidebar card, opening with the 20px rule that
+ * separates it from whatever came before.
+ * @param root0
+ * @param root0.label
+ * @param root0.children
+ */
+export const SidebarBlock = ( {
+    label,
+    children,
+}: {
+    label: ReactNode;
+    children: ReactNode;
+} ) => (
+    <div className="mt-5 border-t border-[#E9E9E9] px-5 pt-5">
+        { /* Every block label reads at one size and weight — the sidebar has
+             no hierarchy between Contact, Customer IP and Customer Note. */ }
+        <p className="text-xs font-semibold leading-[1.3] text-[#25252d]">
+            { label }
+        </p>
+        <div className="mt-2.5 text-sm leading-[1.4] text-[#575757]">
+            { children }
+        </div>
+    </div>
+);

--- a/src/dashboard/orders/details/slots.ts
+++ b/src/dashboard/orders/details/slots.ts
@@ -3,22 +3,82 @@
  *
  * These names are public API: Pro and third-party panel bundles register fills
  * against them via `registerPlugin( name, { render, scope: 'dokan-order-details' } )`.
- * Every slot receives `{ order, orderId, sections, refetch, navigate }` as fillProps.
+ * Every slot receives the view's context as fillProps:
+ * `{ order, orderId, sections, isLoading, refetch, navigate }`.
+ *
+ * Every section — main column and sidebar alike — is bracketed by a
+ * `before-*` and an `after-*` slot, so an extension can add a card anywhere
+ * without replacing a first-party one.
  */
 
-export const ORDER_DETAILS_AFTER_SUMMARY_SLOT =
-    'dokan-order-details-after-summary';
+const PREFIX = 'dokan-order-details-';
 
-export const ORDER_DETAILS_ITEMS_ACTIONS_SLOT =
-    'dokan-order-details-items-actions';
+export const ORDER_DETAILS_BEFORE_SUMMARY_SLOT = `${ PREFIX }before-summary`;
+export const ORDER_DETAILS_AFTER_SUMMARY_SLOT = `${ PREFIX }after-summary`;
 
-export const ORDER_DETAILS_AFTER_ITEMS_SLOT = 'dokan-order-details-after-items';
+export const ORDER_DETAILS_BEFORE_ITEMS_SLOT = `${ PREFIX }before-items`;
+export const ORDER_DETAILS_ITEMS_ACTIONS_SLOT = `${ PREFIX }items-actions`;
+export const ORDER_DETAILS_AFTER_ITEMS_SLOT = `${ PREFIX }after-items`;
 
-export const ORDER_DETAILS_SIDEBAR_BEFORE_SLOT =
-    'dokan-order-details-sidebar-before';
+export const ORDER_DETAILS_BEFORE_DOWNLOADS_SLOT = `${ PREFIX }before-downloads`;
+export const ORDER_DETAILS_AFTER_DOWNLOADS_SLOT = `${ PREFIX }after-downloads`;
 
-export const ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT =
-    'dokan-order-details-sidebar-middle';
+export const ORDER_DETAILS_SIDEBAR_BEFORE_SLOT = `${ PREFIX }sidebar-before`;
+export const ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT = `${ PREFIX }sidebar-middle`;
+export const ORDER_DETAILS_SIDEBAR_AFTER_SLOT = `${ PREFIX }sidebar-after`;
 
-export const ORDER_DETAILS_SIDEBAR_AFTER_SLOT =
-    'dokan-order-details-sidebar-after';
+export const ORDER_DETAILS_BEFORE_CUSTOMER_SLOT = `${ PREFIX }before-customer`;
+export const ORDER_DETAILS_AFTER_CUSTOMER_SLOT = `${ PREFIX }after-customer`;
+
+export const ORDER_DETAILS_BEFORE_ADDRESS_SLOT = `${ PREFIX }before-address`;
+export const ORDER_DETAILS_AFTER_ADDRESS_SLOT = `${ PREFIX }after-address`;
+
+export const ORDER_DETAILS_BEFORE_NOTES_SLOT = `${ PREFIX }before-notes`;
+export const ORDER_DETAILS_AFTER_NOTES_SLOT = `${ PREFIX }after-notes`;
+
+/**
+ * Slot names a section renders around itself, by section id.
+ *
+ * Cards use this so a new section only has to name itself once.
+ */
+export const ORDER_DETAILS_SECTION_SLOTS: Record<
+    string,
+    { before: string; after: string }
+> = {
+    summary: {
+        before: ORDER_DETAILS_BEFORE_SUMMARY_SLOT,
+        after: ORDER_DETAILS_AFTER_SUMMARY_SLOT,
+    },
+    items: {
+        before: ORDER_DETAILS_BEFORE_ITEMS_SLOT,
+        after: ORDER_DETAILS_AFTER_ITEMS_SLOT,
+    },
+    downloads: {
+        before: ORDER_DETAILS_BEFORE_DOWNLOADS_SLOT,
+        after: ORDER_DETAILS_AFTER_DOWNLOADS_SLOT,
+    },
+    customer: {
+        before: ORDER_DETAILS_BEFORE_CUSTOMER_SLOT,
+        after: ORDER_DETAILS_AFTER_CUSTOMER_SLOT,
+    },
+    address: {
+        before: ORDER_DETAILS_BEFORE_ADDRESS_SLOT,
+        after: ORDER_DETAILS_AFTER_ADDRESS_SLOT,
+    },
+    notes: {
+        before: ORDER_DETAILS_BEFORE_NOTES_SLOT,
+        after: ORDER_DETAILS_AFTER_NOTES_SLOT,
+    },
+};
+
+/**
+ * JavaScript filter hooks the view runs its own data through, for extensions
+ * that need to change what a first-party section shows rather than add to it.
+ */
+export const ORDER_DETAILS_SUMMARY_ITEMS_FILTER =
+    'dokan_order_details_summary_items';
+
+export const ORDER_DETAILS_STATUSES_FILTER = 'dokan_order_details_statuses';
+
+export const ORDER_DETAILS_ADDRESS_PARTS_FILTER =
+    'dokan_order_details_address_parts';

--- a/src/dashboard/orders/details/slots.ts
+++ b/src/dashboard/orders/details/slots.ts
@@ -1,0 +1,24 @@
+/**
+ * Named slots of the React order details view — the section contract.
+ *
+ * These names are public API: Pro and third-party panel bundles register fills
+ * against them via `registerPlugin( name, { render, scope: 'dokan-order-details' } )`.
+ * Every slot receives `{ order, orderId, sections, refetch, navigate }` as fillProps.
+ */
+
+export const ORDER_DETAILS_AFTER_SUMMARY_SLOT =
+    'dokan-order-details-after-summary';
+
+export const ORDER_DETAILS_ITEMS_ACTIONS_SLOT =
+    'dokan-order-details-items-actions';
+
+export const ORDER_DETAILS_AFTER_ITEMS_SLOT = 'dokan-order-details-after-items';
+
+export const ORDER_DETAILS_SIDEBAR_BEFORE_SLOT =
+    'dokan-order-details-sidebar-before';
+
+export const ORDER_DETAILS_SIDEBAR_MIDDLE_SLOT =
+    'dokan-order-details-sidebar-middle';
+
+export const ORDER_DETAILS_SIDEBAR_AFTER_SLOT =
+    'dokan-order-details-sidebar-after';

--- a/src/dashboard/orders/details/types.ts
+++ b/src/dashboard/orders/details/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Types for the first-party React order details view.
+ *
+ * Shapes mirror `GET /dokan/v1/orders/<id>` (OrderController::get_formatted_item_data)
+ * and the server-side marker payload published by
+ * `WeDevs\Dokan\Order\VendorPanelOrderDetails`.
+ */
+
+export interface DetailsAddress {
+    first_name: string;
+    last_name: string;
+    company: string;
+    address_1: string;
+    address_2: string;
+    city: string;
+    state: string;
+    postcode: string;
+    country: string;
+    email?: string;
+    phone?: string;
+}
+
+export interface DetailsLineItemMeta {
+    id: number;
+    key: string;
+    value: unknown;
+    display_key?: string;
+    display_value?: string;
+}
+
+export interface DetailsLineItem {
+    id: number;
+    name: string;
+    product_id: number;
+    variation_id: number;
+    quantity: number;
+    sku: string | null;
+    price: number;
+    subtotal: string;
+    subtotal_tax?: string;
+    total: string;
+    total_tax?: string;
+    image?: string;
+    meta_data?: DetailsLineItemMeta[];
+}
+
+export interface DetailsShippingLine {
+    id: number;
+    method_title: string;
+    method_id?: string;
+    total: string;
+    [ key: string ]: unknown;
+}
+
+export interface DetailsFeeLine {
+    id: number;
+    name?: string;
+    total: string;
+    [ key: string ]: unknown;
+}
+
+export interface DetailsCouponLine {
+    id: number;
+    code: string;
+    discount: string;
+    discount_tax?: string;
+    [ key: string ]: unknown;
+}
+
+export interface DetailsTaxLine {
+    id: number;
+    rate_code?: string;
+    label?: string;
+    tax_total?: string;
+    shipping_tax_total?: string;
+    [ key: string ]: unknown;
+}
+
+export interface DetailsRefund {
+    id: number;
+    refund: string;
+    total: string;
+}
+
+/**
+ * Pro appends this through the `dokan_rest_prepare_shop_order_object` filter.
+ */
+export interface RefundSummaryItem {
+    qty_refunded: number;
+    total_refunded: string;
+}
+
+export interface RefundSummary {
+    total_refunded: string;
+    remaining: string;
+    items: Record< string, RefundSummaryItem >;
+    has_pending_request: boolean;
+}
+
+export interface OrderMetaData {
+    id: number;
+    key: string;
+    value: unknown;
+}
+
+export interface DetailsOrder {
+    id: number;
+    number: string;
+    status: string;
+    currency: string;
+    date_created: string | null;
+    customer_id: number;
+    customer_ip_address: string;
+    customer_note: string;
+    billing: DetailsAddress;
+    shipping: DetailsAddress;
+    payment_method: string;
+    payment_method_title: string;
+    line_items: DetailsLineItem[];
+    shipping_lines: DetailsShippingLine[];
+    fee_lines: DetailsFeeLine[];
+    coupon_lines: DetailsCouponLine[];
+    tax_lines: DetailsTaxLine[];
+    refunds: DetailsRefund[];
+    meta_data?: OrderMetaData[];
+    discount_total: string;
+    shipping_total: string;
+    cart_tax: string;
+    total: string;
+    total_tax: string;
+    earning: string | null;
+    order_shipment: string;
+    refund_summary?: RefundSummary;
+    [ key: string ]: unknown;
+}
+
+export interface OrderNote {
+    id: number;
+    date_created: string;
+    date_created_gmt: string;
+    note: string;
+    customer_note: boolean;
+}
+
+export interface OrderDownloadPermission {
+    permission_id: number;
+    product_id: number;
+    product_name: string;
+    product_image: string;
+    download_id: string;
+    file_name: string;
+    download_count: number;
+    downloads_remaining: string;
+    access_expires: string | null;
+}
+
+export interface OrderStatusOption {
+    value: string;
+    label: string;
+}
+
+/**
+ * The server-side marker payload for the order-details route.
+ */
+export interface OrderDetailsMarker {
+    panel_route_enabled?: boolean;
+    view?: 'react' | 'fragment';
+    statuses?: OrderStatusOption[];
+    status_change_allowed?: boolean;
+    sections?: Record< string, boolean >;
+}

--- a/src/dashboard/orders/details/useOrderDetails.ts
+++ b/src/dashboard/orders/details/useOrderDetails.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+    ORDER_DETAILS_LOADED,
+    ORDER_DETAILS_STATUS_CHANGED,
+    emitOrderDetailsEvent,
+    onOrderDetailsEvent,
+} from '../events';
+import { getStatusLabel } from '../status';
+import type { DetailsOrder } from './types';
+
+/**
+ * The one order fetch feeding the whole React details view.
+ *
+ * Emits `ORDER_DETAILS_LOADED` with the same meta shape the fragment endpoint
+ * announces, so the shared panel header works identically under either renderer,
+ * and patches its cache on `ORDER_DETAILS_STATUS_CHANGED` so no card can disagree
+ * with the header badge.
+ * @param orderId
+ */
+const useOrderDetails = ( orderId: number ) => {
+    const [ order, setOrder ] = useState< DetailsOrder | null >( null );
+    const [ isLoading, setIsLoading ] = useState( true );
+    const [ error, setError ] = useState< string >( '' );
+    const [ fetchIndex, setFetchIndex ] = useState( 0 );
+
+    const refetch = useCallback( () => {
+        setFetchIndex( ( previous ) => previous + 1 );
+    }, [] );
+
+    useEffect( () => {
+        if ( ! orderId ) {
+            setIsLoading( false );
+            setOrder( null );
+            return;
+        }
+
+        let cancelled = false;
+
+        setIsLoading( true );
+        setError( '' );
+
+        apiFetch< DetailsOrder >( {
+            path: `/dokan/v1/orders/${ orderId }`,
+        } )
+            .then( ( loadedOrder ) => {
+                if ( cancelled ) {
+                    return;
+                }
+
+                setOrder( loadedOrder );
+
+                emitOrderDetailsEvent( ORDER_DETAILS_LOADED, [
+                    {
+                        id: loadedOrder.id,
+                        number: loadedOrder.number,
+                        status: loadedOrder.status,
+                        status_label: getStatusLabel( loadedOrder.status ),
+                        date_created: loadedOrder.date_created,
+                        // Pro's manual-order screen only edits vendor-created
+                        // orders; the header hides Edit Order for the rest.
+                        manual_order_editable: Boolean(
+                            loadedOrder.meta_data?.some(
+                                ( meta ) =>
+                                    '_wc_order_attribution_source_type' ===
+                                        meta.key && 'vendor' === meta.value
+                            )
+                        ),
+                    },
+                ] );
+            } )
+            .catch( ( fetchError: { message?: string } ) => {
+                if ( ! cancelled ) {
+                    setError( fetchError?.message || '' );
+                }
+            } )
+            .finally( () => {
+                if ( ! cancelled ) {
+                    setIsLoading( false );
+                }
+            } );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [ orderId, fetchIndex ] );
+
+    useEffect( () => {
+        return onOrderDetailsEvent(
+            ORDER_DETAILS_STATUS_CHANGED,
+            ( changedOrderId, changedStatus ) => {
+                if ( Number( changedOrderId ) !== orderId ) {
+                    return;
+                }
+
+                setOrder( ( previous ) =>
+                    previous
+                        ? { ...previous, status: String( changedStatus ) }
+                        : previous
+                );
+            }
+        );
+    }, [ orderId ] );
+
+    return { order, isLoading, error, refetch };
+};
+
+export default useOrderDetails;

--- a/src/dashboard/orders/details/useOrderDownloads.ts
+++ b/src/dashboard/orders/details/useOrderDownloads.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import type { OrderDownloadPermission } from './types';
+
+/**
+ * Downloadable-product permissions over `dokan/v1/orders/<id>/downloads`.
+ * @param orderId
+ */
+const useOrderDownloads = ( orderId: number ) => {
+    const [ permissions, setPermissions ] = useState<
+        OrderDownloadPermission[]
+    >( [] );
+    const [ isLoading, setIsLoading ] = useState( true );
+    const [ error, setError ] = useState< string >( '' );
+
+    const fetchPermissions = useCallback( () => {
+        if ( ! orderId ) {
+            return;
+        }
+
+        setIsLoading( true );
+        setError( '' );
+
+        apiFetch< OrderDownloadPermission[] >( {
+            path: `/dokan/v1/orders/${ orderId }/downloads`,
+        } )
+            .then( ( loaded ) => {
+                setPermissions( Array.isArray( loaded ) ? loaded : [] );
+            } )
+            .catch( ( fetchError: { message?: string } ) => {
+                setError( fetchError?.message || '' );
+            } )
+            .finally( () => setIsLoading( false ) );
+    }, [ orderId ] );
+
+    useEffect( () => {
+        fetchPermissions();
+    }, [ fetchPermissions ] );
+
+    const grantAccess = useCallback(
+        ( productIds: number[] ) =>
+            apiFetch< OrderDownloadPermission[] >( {
+                path: `/dokan/v1/orders/${ orderId }/downloads`,
+                method: 'POST',
+                data: { product_ids: productIds },
+            } ).then( ( created ) => {
+                fetchPermissions();
+                return created;
+            } ),
+        [ orderId, fetchPermissions ]
+    );
+
+    const revokeAccess = useCallback(
+        ( permissionId: number ) =>
+            apiFetch( {
+                path: `/dokan/v1/orders/${ orderId }/downloads/${ permissionId }`,
+                method: 'DELETE',
+            } ).then( ( result ) => {
+                setPermissions( ( previous ) =>
+                    previous.filter(
+                        ( permission ) =>
+                            permission.permission_id !== permissionId
+                    )
+                );
+                return result;
+            } ),
+        [ orderId ]
+    );
+
+    return {
+        permissions,
+        isLoading,
+        error,
+        grantAccess,
+        revokeAccess,
+        refetch: fetchPermissions,
+    };
+};
+
+export default useOrderDownloads;

--- a/src/dashboard/orders/details/useOrderNotes.ts
+++ b/src/dashboard/orders/details/useOrderNotes.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import type { OrderNote } from './types';
+
+/**
+ * Order notes over the existing `dokan/v1/orders/<id>/notes` routes.
+ * @param orderId
+ */
+const useOrderNotes = ( orderId: number ) => {
+    const [ notes, setNotes ] = useState< OrderNote[] >( [] );
+    const [ isLoading, setIsLoading ] = useState( true );
+    const [ error, setError ] = useState< string >( '' );
+
+    const fetchNotes = useCallback( () => {
+        if ( ! orderId ) {
+            return;
+        }
+
+        setIsLoading( true );
+        setError( '' );
+
+        apiFetch< OrderNote[] >( {
+            path: `/dokan/v1/orders/${ orderId }/notes`,
+        } )
+            .then( ( loadedNotes ) => {
+                setNotes( Array.isArray( loadedNotes ) ? loadedNotes : [] );
+            } )
+            .catch( ( fetchError: { message?: string } ) => {
+                setError( fetchError?.message || '' );
+            } )
+            .finally( () => setIsLoading( false ) );
+    }, [ orderId ] );
+
+    useEffect( () => {
+        fetchNotes();
+    }, [ fetchNotes ] );
+
+    const addNote = useCallback(
+        ( note: string, customerNote: boolean, orderStatus: string ) =>
+            apiFetch< OrderNote >( {
+                path: `/dokan/v1/orders/${ orderId }/notes`,
+                method: 'POST',
+                // The route validates against the order item schema:
+                // `customer_note` is a string there, and `status` must be a
+                // valid unprefixed status because the schema's own default
+                // ("all") is not in its enum.
+                data: {
+                    note,
+                    customer_note: customerNote ? '1' : '',
+                    status: orderStatus,
+                },
+            } ).then( ( created ) => {
+                fetchNotes();
+                return created;
+            } ),
+        [ orderId, fetchNotes ]
+    );
+
+    const deleteNote = useCallback(
+        ( noteId: number ) =>
+            apiFetch( {
+                path: `/dokan/v1/orders/${ orderId }/notes/${ noteId }`,
+                method: 'DELETE',
+            } ).then( ( result ) => {
+                setNotes( ( previous ) =>
+                    previous.filter( ( note ) => note.id !== noteId )
+                );
+                return result;
+            } ),
+        [ orderId ]
+    );
+
+    return {
+        notes,
+        isLoading,
+        error,
+        addNote,
+        deleteNote,
+        refetch: fetchNotes,
+    };
+};
+
+export default useOrderNotes;

--- a/src/dashboard/orders/types.ts
+++ b/src/dashboard/orders/types.ts
@@ -63,6 +63,12 @@ export interface OrderDetailsMeta {
     status: string;
     status_label: string;
     date_created: string | null;
+    /**
+     * Whether Pro's manual-order screen can edit this order (vendor-created
+     * orders only). Absent when the fragment endpoint announces the meta —
+     * consumers fall back to the legacy always-offer behaviour then.
+     */
+    manual_order_editable?: boolean;
 }
 
 /**

--- a/src/routing/routes.tsx
+++ b/src/routing/routes.tsx
@@ -5,7 +5,7 @@ import WithdrawRequests from '@src/dashboard/withdraw/WithdrawRequests';
 import App from '@src/dashboard/product-editor/App';
 import Products from '@src/dashboard/products';
 import Orders from '@src/dashboard/orders';
-import OrderDetails from '@src/dashboard/orders/OrderDetails';
+import OrderDetailsRoute from '@src/dashboard/orders/details';
 import OrderDetailsHeader from '@src/dashboard/orders/OrderDetailsHeader';
 import ReverseWithdrawal from '@src/dashboard/reverse-withdraw';
 
@@ -36,7 +36,7 @@ export default [
         // static segments above dynamic ones regardless of registration order.
         id: 'dokan-order-details',
         title: __( 'Order Details', 'dokan-lite' ),
-        element: OrderDetails,
+        element: OrderDetailsRoute,
         // The panel owns the chrome here: the order number as the title, a live status
         // badge, Back, and the Edit Order action Pro would otherwise lose with the
         // status-filter bar the fragment does not render.


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)
* [ ] I've included developer documentation

### Changes proposed in this Pull Request:

Gives the Vendor panel's `/orders/:orderId` route a **first-party React UI** matching the design mockups, while the #3333 server-rendered fragment stays as the **permanent compatibility fallback** (ADR-0005 intact). Stacked on `feat/vendor-panel-order-details-fragment`.

**Everything is additive** — the only shipped files touched are one-line registrations plus this feature's own files from the base branch. `OrderController`, `Assets.php`, `Order/functions.php`, `DetailsFragment` and the fragment component are byte-identical.

* **Server-side view marker** — new `WeDevs\Dokan\Order\VendorPanelOrderDetails` (Hookable) publishes `dokanFrontend.order_details.view` (`react` | `fragment`) through the existing `dokan_react_frontend_localized_args` seam, plus `sections`, the status list and the `order_status_change` admin setting. Defaults to `react`, with automatic fallback to the fragment when third-party callbacks are detected on the details-template hooks (reflection, best-effort — the `dokan_vendor_panel_order_details_view` filter is the guaranteed override) or when the session is Vendor staff (whose access only the fragment endpoint currently grants — the shipped staff-refusing permission rule is deliberately untouched, per the #2133 split).
* **React view** (`src/dashboard/orders/details/`) — summary strip (site-format "date at time", Dokan-formatted earning), items card (Figma column spec `44fr/22fr/22fr/22fr`, `#FDFDFD` header strip, coupon chips, refund rows, strikethrough totals), downloadable-permissions card (search + grant, per-file editable limit/expiry with usage hints, revoke), sidebar Customer/Address/Notes cards built to the Figma spec (20px card grid with block-owned dividers, one label size throughout, lucide mail/phone/IP glyphs, addresses as a single line clamped to three with the full text on hover, legacy keycdn geo IP link, `humanTimeDiff` note stamps, trash-icon delete). One order fetch feeds the page; `ORDER_DETAILS_LOADED`/`ORDER_DETAILS_STATUS_CHANGED` keep the shared header in sync under either renderer.
* **Extension contract** — every section is bracketed by `before-*` / `after-*` slots (`summary`, `items`, `downloads`, `customer`, `address`, `notes`) alongside `items-actions` and `sidebar-before/middle/after`, each receiving `{ order, orderId, sections, isLoading, refetch, navigate }` as fillProps; Pro's sections plug in via `registerPlugin` scoped to the route id (companion PR). First-party data runs through JS filters too — `dokan_order_details_summary_items`, `dokan_order_details_statuses`, `dokan_order_details_address_parts` — and on the server, `dokan_vendor_panel_order_details_sections` and `…_statuses` join the existing `…_args` / `…_view`.
* **Header** — RFQ-style breadcrumb ("< All Orders"), outlined status pill reusing the order-list badge theme classes at the RFQ pill's measured size, and the RFQ-measured split status button (42px segments, sharp white seam) offering the legacy status list — hidden on cancelled/refunded orders and honoring `dokan_manage_order` + the `order_status_change` admin setting. No Print control: the legacy page has none.
* **Downloads REST** — new `OrderDownloadController`: `GET/POST dokan/v1/orders/<id>/downloads`, `PUT/DELETE …/downloads/<permission_id>`, registered via the `dokan_rest_api_class_map` filter; staff-aware permission callbacks modeled on the fragment endpoint; grant wraps `wc_downloadable_file_permission()` with the vendor-ownership guard from the AJAX handler; expiry stored as UTC midnight so the picked day round-trips timezone-stable.

### Related Pull Request(s)

* Base (stacked on): #3333
* dokan-pro companion: getdokan/dokan-pro#5985

### Closes

* Part of getdokan/plugin-internal-tasks#2159 (implementation slices S1–S8 + parts of S10; automated tests and the extension-guide doc slice remain)

### How to test the changes in this Pull Request:

1. Build (`npm run build`) and open `/dashboard/new/#/orders`, then any order — the details render as first-party React (no fragment markup), on the product editor's gray canvas.
2. Change the status from the split button — the header pill, button label and page data update together; the control is absent on cancelled/refunded orders and when the admin's "Order Status Change" setting is off.
3. Add/delete an order note; grant a downloadable product, edit its limit/expiry, Update, Revoke.
4. `add_filter( 'dokan_vendor_panel_order_details_view', fn() => 'fragment' );` — the same route renders the #3333 fragment again (ADR-0005 gate). Legacy URL unchanged.
5. Register any callback on `dokan_order_detail_after_order_items` from a theme — the view auto-falls back to the fragment.

### Changelog entry

**Vendor order details render as first-party React in the Vendor panel**

**Previous behaviour:** the panel's order-details route displayed the legacy server-rendered template bridged in as an HTML fragment.

**New behaviour:** stores without third-party template hooks get a first-party React details view matching the new design (summary, items and totals, downloadable permissions, customer/address/notes sidebar), with named section slots for extensions. The fragment remains the automatic fallback for stores with third-party hooked output, for Vendor staff sessions, and via the `dokan_vendor_panel_order_details_view` filter; the legacy URL keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

