### PR TITLE
fix(security): gate commission settings on the public store-categories REST endpoint (L10)

### DIFF
--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -779,10 +779,8 @@ class StoreController extends WP_REST_Controller {
 
         $is_authorized = $this->can_access_vendor_store( $store->get_id() );
 
-        $is_admin = current_user_can( 'manage_options' );
-
         // Restrict admin commission fields for all except admins and vendor only
-        if ( ! $is_admin && ! dokan_is_user_seller( get_current_user_id(), true ) ) {
+        if ( ! $this->can_view_commission_settings() ) {
             $restricted_fields[] = 'admin_category_commission';
             $restricted_fields[] = 'admin_commission';
             $restricted_fields[] = 'admin_additional_fee';
@@ -811,6 +809,20 @@ class StoreController extends WP_REST_Controller {
         }
 
         return apply_filters( 'dokan_rest_store_restricted_fields_for_view', $restricted_fields, $store, $request );
+    }
+
+    /**
+     * Whether the current user's role may see admin-configured commission settings at all.
+     *
+     * Callers must additionally confirm the user is authorized for the store in question,
+     * since this only answers the role question — vendor staff are excluded deliberately.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return bool
+     */
+    protected function can_view_commission_settings(): bool {
+        return current_user_can( 'manage_options' ) || dokan_is_user_seller( get_current_user_id(), true );
     }
 
     /**
@@ -1108,11 +1120,18 @@ class StoreController extends WP_REST_Controller {
         }
 
         $category_data = $store->get_store_categories( $best_selling );
-        $commission_settings = $store->get_commission_settings();
+
+        // Terms stay public, but commission is admin-configured data, so it is limited to the callers the single-store endpoint shows it to.
+        if ( ! $this->can_access_vendor_store( $store_id ) || ! $this->can_view_commission_settings() ) {
+            return rest_ensure_response( $category_data );
+        }
+
+        $commission_settings  = $store->get_commission_settings();
         $category_commissions = $commission_settings->get_category_commissions();
+        $commission_type      = $commission_settings->get_type();
 
         foreach ( $category_data as $term ) {
-            $term->admin_commission_type = $commission_settings->get_type();
+            $term->admin_commission_type = $commission_type;
 
             if ( isset( $category_commissions['items'][ $term->term_id ] ) ) {
                 $term->commission = $category_commissions['items'][ $term->term_id ];
@@ -1123,9 +1142,7 @@ class StoreController extends WP_REST_Controller {
             }
         }
 
-        $response = rest_ensure_response( $category_data );
-
-        return $response;
+        return rest_ensure_response( $category_data );
     }
 
     /**

--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -1135,7 +1135,7 @@ class StoreController extends WP_REST_Controller {
 
             if ( isset( $category_commissions['items'][ $term->term_id ] ) ) {
                 $term->commission = $category_commissions['items'][ $term->term_id ];
-            } elseif ( $category_commissions['all'] ) {
+            } elseif ( ! empty( $category_commissions['all'] ) ) {
                 $term->commission = $category_commissions['all'];
             } else {
                 $term->commission = [];

--- a/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
+++ b/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\REST\StoreController;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Authorization test for the store-categories REST endpoint.
+ *
+ * Covers the unauthenticated commission disclosure (audit L10 /
+ * plugin-internal-tasks#2172): `GET dokan/v1/stores/<id>/categories` is a public
+ * route, so the vendor's admin-configured commission must not ride along in the
+ * response for callers the single-store endpoint would not show it to.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @group dokan-store-controller
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\REST\StoreController::get_store_category
+ */
+class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
+
+    /**
+     * Commission fields that must reach only authorized callers.
+     *
+     * @var array
+     */
+    protected const COMMISSION_FIELDS = [ 'admin_commission_type', 'commission' ];
+
+    public function set_up() {
+        parent::set_up();
+
+        ( new StoreController() )->register_routes();
+
+        $category_id = $this->factory()->term->create( [ 'taxonomy' => 'product_cat' ] );
+        $product     = $this->factory()->product->create_simple_product();
+
+        wp_update_post(
+            [
+                'ID'          => $product->get_id(),
+                'post_author' => $this->seller_id1,
+                'post_status' => 'publish',
+            ]
+        );
+        wp_set_object_terms( $product->get_id(), [ $category_id ], 'product_cat' );
+    }
+
+    /**
+     * An anonymous caller gets the category terms but no commission data.
+     */
+    public function test_anonymous_caller_does_not_receive_commission_fields() {
+        wp_set_current_user( 0 );
+
+        $this->assertCommissionFieldsVisible( false, 'Anonymous callers' );
+    }
+
+    /**
+     * Another vendor is no more privileged than the public for this store's commission.
+     */
+    public function test_other_vendor_does_not_receive_commission_fields() {
+        wp_set_current_user( $this->seller_id2 );
+
+        $this->assertCommissionFieldsVisible( false, 'A different vendor' );
+    }
+
+    /**
+     * Vendor staff are excluded too, matching what the single-store endpoint strips from them.
+     */
+    public function test_vendor_staff_does_not_receive_commission_fields() {
+        wp_set_current_user( $this->create_vendor_staff( $this->seller_id1 ) );
+
+        $this->assertCommissionFieldsVisible( false, 'Vendor staff' );
+    }
+
+    /**
+     * The store's own vendor still sees their commission settings.
+     */
+    public function test_store_owner_receives_commission_fields() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $this->assertCommissionFieldsVisible( true, 'The store owner' );
+    }
+
+    /**
+     * An admin / shop manager still sees commission settings for any store.
+     */
+    public function test_admin_receives_commission_fields() {
+        wp_set_current_user( $this->admin_id );
+
+        $this->assertCommissionFieldsVisible( true, 'An admin' );
+    }
+
+    /**
+     * Assert whether the commission fields are attached to every returned term.
+     */
+    protected function assertCommissionFieldsVisible( bool $expected, string $who ) {
+        foreach ( $this->request_store_categories() as $term ) {
+            $data = get_object_vars( $term );
+
+            foreach ( self::COMMISSION_FIELDS as $field ) {
+                if ( $expected ) {
+                    $this->assertArrayHasKey( $field, $data, sprintf( '%s should still receive "%s".', $who, $field ) );
+                } else {
+                    $this->assertArrayNotHasKey( $field, $data, sprintf( '%s must not receive "%s".', $who, $field ) );
+                }
+            }
+        }
+    }
+
+    /**
+     * Dispatch the public store-categories route for seller_id1.
+     */
+    protected function request_store_categories(): array {
+        $response = $this->get_request( "stores/{$this->seller_id1}/categories" );
+
+        $this->assertSame( 200, $response->get_status() );
+
+        $terms = (array) $response->get_data();
+
+        // Guard the assertions below against passing vacuously — the terms themselves stay public for everyone.
+        $this->assertNotEmpty( $terms, 'The category terms themselves stay public.' );
+
+        return $terms;
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
+++ b/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
@@ -30,13 +30,49 @@ class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
      */
     protected const COMMISSION_FIELDS = [ 'admin_commission_type', 'commission' ];
 
+    /**
+     * Rate the vendor falls back to for categories without their own override.
+     *
+     * @var array
+     */
+    protected const DEFAULT_COMMISSION = [
+        'percentage' => '42',
+        'flat'       => '3',
+    ];
+
+    /**
+     * Rate configured against one specific category.
+     *
+     * @var array
+     */
+    protected const OVERRIDE_COMMISSION = [
+        'percentage' => '17',
+        'flat'       => '1',
+    ];
+
+    /**
+     * Category carrying its own rate.
+     *
+     * @var int
+     */
+    protected $override_category_id;
+
+    /**
+     * Category with no rate of its own.
+     *
+     * @var int
+     */
+    protected $default_category_id;
+
     public function set_up() {
         parent::set_up();
 
         ( new StoreController() )->register_routes();
 
-        $category_id = $this->factory()->term->create( [ 'taxonomy' => 'product_cat' ] );
-        $product     = $this->factory()->product->create_simple_product();
+        $this->override_category_id = $this->factory()->term->create( [ 'taxonomy' => 'product_cat' ] );
+        $this->default_category_id  = $this->factory()->term->create( [ 'taxonomy' => 'product_cat' ] );
+
+        $product = $this->factory()->product->create_simple_product();
 
         wp_update_post(
             [
@@ -45,7 +81,18 @@ class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
                 'post_status' => 'publish',
             ]
         );
-        wp_set_object_terms( $product->get_id(), [ $category_id ], 'product_cat' );
+        wp_set_object_terms( $product->get_id(), [ $this->override_category_id, $this->default_category_id ], 'product_cat' );
+
+        // Give the vendor real rates, so the authorized cases assert the payload the leak exposed rather than bare key presence.
+        update_user_meta( $this->seller_id1, 'dokan_admin_percentage_type', 'category_based' );
+        update_user_meta(
+            $this->seller_id1,
+            'admin_category_commission',
+            [
+                'all'   => self::DEFAULT_COMMISSION,
+                'items' => [ $this->override_category_id => self::OVERRIDE_COMMISSION ],
+            ]
+        );
     }
 
     /**
@@ -114,12 +161,23 @@ class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
             $data = get_object_vars( $term );
 
             foreach ( self::COMMISSION_FIELDS as $field ) {
-                if ( $expected ) {
-                    $this->assertArrayHasKey( $field, $data, sprintf( '%s should still receive "%s".', $who, $field ) );
-                } else {
+                if ( ! $expected ) {
                     $this->assertArrayNotHasKey( $field, $data, sprintf( '%s must not receive "%s".', $who, $field ) );
+                    continue;
                 }
+
+                $this->assertArrayHasKey( $field, $data, sprintf( '%s should still receive "%s".', $who, $field ) );
             }
+
+            if ( ! $expected ) {
+                continue;
+            }
+
+            $this->assertSame( 'category_based', $data['admin_commission_type'], sprintf( '%s should see the configured commission type.', $who ) );
+
+            $rate = (int) $term->term_id === (int) $this->override_category_id ? self::OVERRIDE_COMMISSION : self::DEFAULT_COMMISSION;
+
+            $this->assertSame( $rate, $data['commission'], sprintf( '%s should see the rate configured for term %d.', $who, $term->term_id ) );
         }
     }
 
@@ -134,7 +192,7 @@ class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
         $terms = (array) $response->get_data();
 
         // Guard the assertions below against passing vacuously — the terms themselves stay public for everyone.
-        $this->assertNotEmpty( $terms, 'The category terms themselves stay public.' );
+        $this->assertCount( 2, $terms, 'Both the overridden and the fallback category stay public.' );
 
         return $terms;
     }

--- a/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
+++ b/tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php
@@ -85,12 +85,25 @@ class StoreCategoriesCommissionDisclosureTest extends DokanTestCase {
     }
 
     /**
-     * An admin / shop manager still sees commission settings for any store.
+     * An admin still sees commission settings for any store.
      */
     public function test_admin_receives_commission_fields() {
         wp_set_current_user( $this->admin_id );
 
         $this->assertCommissionFieldsVisible( true, 'An admin' );
+    }
+
+    /**
+     * A shop manager keeps access too — Installer grants them 'dokandar', which is what the gate accepts.
+     */
+    public function test_shop_manager_receives_commission_fields() {
+        $shop_manager_id = $this->factory()->user->create( [ 'role' => 'shop_manager' ] );
+        wp_set_current_user( $shop_manager_id );
+
+        $this->assertTrue( current_user_can( 'manage_woocommerce' ), 'Precondition: the fixture really is a shop manager.' );
+        $this->assertFalse( current_user_can( 'manage_options' ), 'Precondition: shop managers are not administrators.' );
+
+        $this->assertCommissionFieldsVisible( true, 'A shop manager' );
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

`GET /wp-json/dokan/v1/stores/<id>/categories` is registered with `'permission_callback' => '__return_true'`, and `get_store_category()` attached the vendor's admin-configured commission to **every** returned term — `admin_commission_type`, plus the per-category and default `percentage`/`flat` rates when category-based commission is configured. Anyone could read a marketplace's commission configuration with a single unauthenticated request, no cookie and no nonce.

The sibling store endpoints are not affected, and they show the intended policy: `get_store()` / `get_stores()` build their payload through `prepare_item_for_response()`, which adds the commission fields only when `can_access_vendor_store()` is true and then strips them again in `get_restricted_fields_for_view()` unless the caller is an admin or a vendor owner. `get_store_category()` bypasses `prepare_item_for_response()` entirely, so it inherited neither guard.

**The fix.** The category terms stay public — the storefront needs them — but the commission fields are now attached only to callers that satisfy the same two conditions the single-store endpoint applies: authorized for that store, **and** holding a role that may see commission at all.

While writing this I found the two conditions were easy to get subtly wrong: `can_access_vendor_store()` alone returns `true` for **vendor staff**, whom the single-store endpoint deliberately strips commission from. So the role half is extracted into `can_view_commission_settings()` and used by both `get_store_category()` and `get_restricted_fields_for_view()`, giving one definition instead of two that can drift. That refactor is behaviour-neutral for the single-store path (those fields are only ever added when the caller is already authorized, so the extra `unset()` was a no-op) and it keeps the per-store call count unchanged on the list endpoint.

**Sweep.** Every other `permission_callback => '__return_true'` route in Lite **and** Pro was checked for the same class of leak — `/stores`, `/stores/<id>`, `/stores/<id>/products`, `/stores/<id>/reviews`, `/stores/check`, the seller-contact route, `ProductController`'s `related`/`top_rated`/`best_selling`/`featured`/`latest`, `VendorDashboardController::/preferences`, and Pro's `delivery-time/time-slot`, `delivery-time/location-slot`, `store-reviews`. All either expose storefront-only data or route through the gated `prepare_item_for_response()`. **This was the only instance.**

### Related Pull Request(s)

* Part of the getdokan/dokan-pro#5982 batch, alongside the L11 and L12 fixes

### Closes

* Closes getdokan/plugin-internal-tasks#2172
* Closes https://github.com/getdokan/plugin-internal-tasks/issues/2236

### How to test the changes in this Pull Request:

1. Give a vendor a category-based commission (Admin → Vendors → edit → Commission: type `category_based`, e.g. 42% + 3 flat).
2. Anonymous request — `curl 'http://<site>/?rest_route=/dokan/v1/stores/<vendor_id>/categories'`. **Before:** each term carries `admin_commission_type` and `commission{percentage,flat}`. **After:** the terms are returned unchanged but carry no commission keys.
3. As the store's own vendor, and as an admin / shop manager: commission fields are still present (the vendor dashboard and admin vendor screens are unaffected).
4. As a **different** vendor, and as **vendor staff** of that store: no commission fields — matching what `GET /dokan/v1/stores/<id>` already gives those callers.
5. Confirm the storefront store page still renders its category list.
6. Automated: `tests/php/src/REST/StoreCategoriesCommissionDisclosureTest.php` covers all five caller types.

> Note: PHPUnit could not be executed locally for this branch (Docker unavailable on this machine), so CI is the first run of the new test. Behaviour was instead verified end-to-end against a live install for all five caller types (anonymous / other vendor / vendor staff / store owner / admin) plus shop manager, comparing the categories route against the single-store route in each case, and confirmed the pre-fix leak reproduces on `develop`.

### Changelog entry

**Fix — Unauthenticated disclosure of commission settings via the store-categories REST endpoint**

Previously, `GET dokan/v1/stores/<id>/categories` returned each category term with the vendor's admin-configured commission type and rates attached, and the route is public — so the marketplace's commission configuration was readable by anyone without logging in. The commission fields are now limited to the same callers the single-store endpoint shows them to (admins and the store's own vendor); the category terms themselves remain public.

### Before Changes

```
curl 'https://example.com/?rest_route=/dokan/v1/stores/7/categories'
-> [{"term_id":57,"name":"T-Shirt","admin_commission_type":"category_based",
     "commission":{"flat":"3","percentage":"42"}}, ...]
```

### After Changes

```
curl 'https://example.com/?rest_route=/dokan/v1/stores/7/categories'
-> [{"term_id":57,"name":"T-Shirt", ...}]   # no admin_commission_type / commission
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted commission-related category details to store owners and authorized administrators.
  - Prevented anonymous visitors, other vendors, and vendor staff from viewing commission settings in store category responses.
- **Tests**
  - Added coverage verifying commission-field visibility across relevant user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->