### PR TITLE
fix(security): require plugin capabilities, not manage_woocommerce, to install plugins (L11)

### DIFF
--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -937,9 +937,14 @@ class SetupWizard {
     }
 
     /**
-     * Should we show the WooCommerce Conversion Tracking install option?
+     * Whether the current user may install plugins through Dokan.
      *
-     * True only if the user can install plugins.
+     * Authorizes the wizard and onboarding install sinks, and gates the visibility of
+     * the 'Recommended' step. Both capabilities are required because the queued
+     * installer activates whatever it downloads.
+     *
+     * @since DOKAN_SINCE Made public for the onboarding controller, and added the
+     *                    `activate_plugins` requirement.
      *
      * @return boolean
      */

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -943,8 +943,9 @@ class SetupWizard {
      *
      * @return boolean
      */
-    protected function user_can_install_plugin() {
-        return current_user_can( 'install_plugins' );
+    public function user_can_install_plugin() {
+        // The background installer activates what it installs, so both caps are required.
+        return current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' );
     }
 
     protected function display_recommended_item( $item_info ) {
@@ -1009,7 +1010,8 @@ class SetupWizard {
      * @param array  $plugin_info Plugin info array containing name and repo-slug, and optionally file if different from [repo-slug].php.
      */
     public function install_plugin( $plugin_id, $plugin_info ) {
-        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        // Installing and activating arbitrary code is a full-trust action, so require the caps WordPress requires for it — not `manage_woocommerce`, which Shop Managers hold.
+        if ( ! $this->user_can_install_plugin() ) {
             return;
         }
 

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -652,7 +652,7 @@ class SetupWizard {
         $options['admin_percentage']                          = $dokan_commission_percentage;
         $options['additional_fee']                            = isset( $_POST['dokan_commission_flat'] ) ? sanitize_text_field( wp_unslash( $_POST['dokan_commission_flat'] ) ) : 0;
         $options['commission_category_based_values']          = isset( $_POST['dokan_commission_category_based'] ) ? wc_clean( json_decode( sanitize_text_field( wp_unslash( $_POST['dokan_commission_category_based'] ) ), true ) ) : [];
-        $options['reset_sub_category_when_edit_all_category'] = isset( $_POST['reset_sub_category'] ) && false === dokan_string_to_bool( $_POST['reset_sub_category'] ) ? 'off' : 'on';
+        $options['reset_sub_category_when_edit_all_category'] = isset( $_POST['reset_sub_category'] ) && false === dokan_string_to_bool( sanitize_text_field( wp_unslash( $_POST['reset_sub_category'] ) ) ) ? 'off' : 'on';
 
         update_option( 'dokan_selling', $options );
 

--- a/includes/Admin/SetupWizardNoWC.php
+++ b/includes/Admin/SetupWizardNoWC.php
@@ -121,6 +121,15 @@ class SetupWizardNoWC extends DokanSetupWizard {
     public function install_woocommerce() {
         check_admin_referer( 'dokan-setup' );
 
+        // The wizard itself only requires `manage_woocommerce`, but installing and activating WooCommerce needs the plugin caps.
+        if ( ! $this->user_can_install_plugin() ) {
+            wp_die(
+                esc_html__( 'You do not have permission to install plugins.', 'dokan-lite' ),
+                esc_html__( 'Error installing WooCommerce plugin', 'dokan-lite' ),
+                [ 'response' => 403 ]
+            );
+        }
+
         require_once DOKAN_INC_DIR . '/functions.php';
 
         // Using output buffer to prevent outputting `trigger_error` in `plugins_api` function

--- a/includes/REST/AdminExtensionsController.php
+++ b/includes/REST/AdminExtensionsController.php
@@ -51,6 +51,20 @@ class AdminExtensionsController extends DokanBaseAdminController {
     }
 
     /**
+     * Check whether the current user may install plugins.
+     *
+     * Overrides the admin base check: this route installs code from wordpress.org, so
+     * `manage_woocommerce` is not enough — a Shop Manager holds it without `install_plugins`.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return bool
+     */
+    public function check_permission() {
+        return current_user_can( 'install_plugins' );
+    }
+
+    /**
      * Install a plugin from WordPress.org.
      *
      * @since SUSPENDED

--- a/includes/REST/AdminExtensionsController.php
+++ b/includes/REST/AdminExtensionsController.php
@@ -44,23 +44,28 @@ class AdminExtensionsController extends DokanBaseAdminController {
                             'sanitize_callback' => 'sanitize_text_field',
                         ],
                     ],
-                    'permission_callback' => [ $this, 'check_permission' ],
+                    'permission_callback' => [ $this, 'check_install_permission' ],
                 ],
             ]
         );
     }
 
     /**
-     * Check whether the current user may install plugins.
+     * Check whether the current user may install plugins through this controller.
      *
-     * Overrides the admin base check: this route installs code from wordpress.org, so
-     * `manage_woocommerce` is not enough — a Shop Manager holds it without `install_plugins`.
+     * Deliberately stricter than the admin base check: this route downloads code from
+     * wordpress.org, and `manage_woocommerce` is a capability a Shop Manager holds
+     * without holding `install_plugins`. Scoped to the install route rather than
+     * overriding `check_permission()`, so any read route added here later keeps the
+     * ordinary admin capability.
+     *
+     * `activate_plugins` is not required: this route only writes the plugin to disk.
      *
      * @since DOKAN_SINCE
      *
      * @return bool
      */
-    public function check_permission() {
+    public function check_install_permission() {
         return current_user_can( 'install_plugins' );
     }
 

--- a/includes/REST/AdminOnboardingController.php
+++ b/includes/REST/AdminOnboardingController.php
@@ -351,6 +351,11 @@ class AdminOnboardingController extends DokanBaseAdminController {
     protected function install_required_plugins( array $plugins ): void {
         $setup_wizard = new \WeDevs\Dokan\Admin\SetupWizard();
 
+        // install_plugin() enforces this too; bailing here also keeps the install hooks below from firing for a user who may not install.
+        if ( ! $setup_wizard->user_can_install_plugin() ) {
+            return;
+        }
+
         /**
          * Filter the plugins to install during onboarding.
          *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3483,6 +3483,14 @@ if ( ! function_exists( 'dokan_get_seller_status_count' ) ) {
 /**
  * Install a plugin from wp.org
  *
+ * Installs *and activates* the plugin, despite the name.
+ *
+ * Performs no capability check by design, so that non-request callers such as WP-CLI and
+ * cron keep working. Installing and activating arbitrary code is a full-trust action, so
+ * any caller reachable from a request MUST gate itself on `install_plugins` and
+ * `activate_plugins` first — `manage_woocommerce` is not sufficient, since a Shop Manager
+ * holds it without holding either plugin capability.
+ *
  * Example:
  * To download WooCommerce `dokan_install_wp_org_plugin( 'woocommerce' )`
  * To download plugin like dokan-lite that has different slug and main plugin file,

--- a/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
+++ b/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\REST\AdminExtensionsController;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Capability tests for the admin routes that install plugins.
+ *
+ * Covers the privilege escalation in audit L11 / plugin-internal-tasks#2173: these
+ * paths gated on `manage_woocommerce`, which a Shop Manager holds without holding
+ * `install_plugins`/`activate_plugins`, so that role could install (and via
+ * onboarding install *and activate*) arbitrary wordpress.org plugins.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @group dokan-admin-rest
+ * @group dokan-authorization
+ * @group security
+ *
+ * @covers \WeDevs\Dokan\REST\AdminExtensionsController::check_permission
+ * @covers \WeDevs\Dokan\REST\AdminOnboardingController::install_required_plugins
+ */
+class AdminPluginInstallCapabilityTest extends DokanTestCase {
+
+    /**
+     * Plugin id used for the onboarding install attempts.
+     *
+     * @var string
+     */
+    protected const PLUGIN_ID = 'classic-editor';
+
+    /**
+     * Shop manager user id — holds manage_woocommerce, not install_plugins.
+     *
+     * @var int
+     */
+    protected int $shop_manager_id;
+
+    /**
+     * Extensions controller under test.
+     *
+     * @var AdminExtensionsController
+     */
+    protected AdminExtensionsController $controller;
+
+    public function set_up() {
+        parent::set_up();
+
+        // Both controllers are in the REST class map, so DokanTestCase's rest_api_init already registered their routes.
+        $this->controller      = new AdminExtensionsController();
+        $this->shop_manager_id = $this->factory()->user->create( [ 'role' => 'shop_manager' ] );
+    }
+
+    /**
+     * A shop manager holds manage_woocommerce but must not reach the install route.
+     */
+    public function test_shop_manager_cannot_install_extensions() {
+        wp_set_current_user( $this->shop_manager_id );
+
+        $this->assertTrue( current_user_can( 'manage_woocommerce' ), 'Precondition: shop managers hold manage_woocommerce.' );
+        $this->assertFalse( current_user_can( 'install_plugins' ), 'Precondition: shop managers do not hold install_plugins.' );
+
+        $response = $this->post_request( 'admin/extensions/install', [ 'slug' => 'classic-widgets' ] );
+        $this->assertSame( 403, $response->get_status(), 'The install route must reject a shop manager.' );
+    }
+
+    /**
+     * An administrator may still install extensions.
+     *
+     * Asserted at the permission callback rather than by dispatching, because the route
+     * would perform a real wordpress.org download.
+     */
+    public function test_admin_can_install_extensions() {
+        wp_set_current_user( $this->admin_id );
+
+        $this->assertTrue(
+            $this->controller->check_permission(),
+            'Administrators hold install_plugins and must keep access.'
+        );
+    }
+
+    /**
+     * Onboarding must not install plugins for a shop manager, but must still save.
+     */
+    public function test_onboarding_does_not_install_plugins_for_shop_manager() {
+        wp_set_current_user( $this->shop_manager_id );
+
+        $response = $this->post_request( 'admin/onboarding', $this->onboarding_payload() );
+
+        $this->assertSame( 200, $response->get_status(), 'Onboarding itself stays available to shop managers.' );
+        $this->assertFalse(
+            get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
+            'No install may be queued for a user without install_plugins.'
+        );
+    }
+
+    /**
+     * Onboarding still queues the install for an administrator.
+     */
+    public function test_onboarding_installs_plugins_for_admin() {
+        wp_set_current_user( $this->admin_id );
+
+        $response = $this->post_request( 'admin/onboarding', $this->onboarding_payload() );
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertNotFalse(
+            get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
+            'An administrator must still be able to install the onboarding plugins.'
+        );
+    }
+
+    /**
+     * Onboarding request body carrying one plugin to install.
+     */
+    protected function onboarding_payload(): array {
+        return [
+            'onboarding'       => true,
+            // Required by the endpoint schema, so the request would 400 without it.
+            'marketplace_goal' => [
+                'marketplace_focus' => 'physical',
+                'handle_delivery'   => 'vendor',
+                'top_priority'      => 'growth',
+            ],
+            'plugins'          => [
+                [
+                    'id'   => self::PLUGIN_ID,
+                    'info' => [ 'repo-slug' => self::PLUGIN_ID ],
+                ],
+            ],
+        ];
+    }
+
+    public function tear_down() {
+        // install_plugin() defers the real download to shutdown; drop it so no test ever hits wordpress.org.
+        remove_all_actions( 'shutdown' );
+
+        wp_set_current_user( 0 );
+
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
+++ b/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
@@ -112,6 +112,37 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
     }
 
     /**
+     * install_plugins alone is not enough: the queued installer also activates.
+     */
+    public function test_onboarding_does_not_install_for_user_who_cannot_activate() {
+        $role_name = 'dokan_test_installer_only';
+        add_role(
+            $role_name,
+            'Installer Only',
+            [
+                'read'               => true,
+                'manage_woocommerce' => true,
+                'install_plugins'    => true,
+            ]
+        );
+
+        wp_set_current_user( $this->factory()->user->create( [ 'role' => $role_name ] ) );
+
+        $this->assertTrue( current_user_can( 'install_plugins' ), 'Precondition: this user may install.' );
+        $this->assertFalse( current_user_can( 'activate_plugins' ), 'Precondition: this user may not activate.' );
+
+        $response = $this->post_request( 'admin/onboarding', $this->onboarding_payload() );
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertFalse(
+            get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
+            'The install queues an activation, so install_plugins without activate_plugins must not be enough.'
+        );
+
+        remove_role( $role_name );
+    }
+
+    /**
      * Onboarding request body carrying one plugin to install.
      */
     protected function onboarding_payload(): array {
@@ -135,6 +166,9 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
     public function tear_down() {
         // install_plugin() defers the real download to shutdown; drop it so no test ever hits wordpress.org.
         remove_all_actions( 'shutdown' );
+
+        // Clear the queue flag too, or a later test would hit install_plugin()'s "already queued" early return.
+        delete_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID );
 
         wp_set_current_user( 0 );
 

--- a/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
+++ b/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
@@ -2,11 +2,13 @@
 
 namespace WeDevs\Dokan\Test\REST;
 
-use WeDevs\Dokan\REST\AdminExtensionsController;
+use ReflectionMethod;
+use WeDevs\Dokan\Admin\SetupWizard;
 use WeDevs\Dokan\Test\DokanTestCase;
+use WP_Error;
 
 /**
- * Capability tests for the admin routes that install plugins.
+ * Capability tests for the admin paths that install plugins.
  *
  * Covers the privilege escalation in audit L11 / plugin-internal-tasks#2173: these
  * paths gated on `manage_woocommerce`, which a Shop Manager holds without holding
@@ -19,17 +21,33 @@ use WeDevs\Dokan\Test\DokanTestCase;
  * @group dokan-authorization
  * @group security
  *
- * @covers \WeDevs\Dokan\REST\AdminExtensionsController::check_permission
+ * @covers \WeDevs\Dokan\REST\AdminExtensionsController::check_install_permission
  * @covers \WeDevs\Dokan\REST\AdminOnboardingController::install_required_plugins
+ * @covers \WeDevs\Dokan\Admin\SetupWizard::user_can_install_plugin
+ * @covers \WeDevs\Dokan\Admin\SetupWizard::install_plugin
  */
 class AdminPluginInstallCapabilityTest extends DokanTestCase {
 
     /**
-     * Plugin id used for the onboarding install attempts.
+     * Plugin id used for the install attempts.
      *
      * @var string
      */
     protected const PLUGIN_ID = 'classic-editor';
+
+    /**
+     * Slug the extensions route is asked for; deliberately not a real plugin.
+     *
+     * @var string
+     */
+    protected const UNINSTALLED_SLUG = 'dokan-l11-not-a-real-plugin';
+
+    /**
+     * Role granted install_plugins but not activate_plugins.
+     *
+     * @var string
+     */
+    protected const INSTALLER_ONLY_ROLE = 'dokan_test_installer_only';
 
     /**
      * Shop manager user id — holds manage_woocommerce, not install_plugins.
@@ -39,17 +57,20 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
     protected int $shop_manager_id;
 
     /**
-     * Extensions controller under test.
-     *
-     * @var AdminExtensionsController
+     * Set up the fixtures and seal off every route to the network.
      */
-    protected AdminExtensionsController $controller;
-
     public function set_up() {
         parent::set_up();
 
+        // is_plugin_active()/get_plugins() are admin-only includes, and the sinks below call them directly.
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+        // Belt and braces: tear_down() unhooks the deferred installer, but a fatal or an exit
+        // inside a test would fire `shutdown` first. Blocking HTTP makes "no test ever reaches
+        // wordpress.org" hold regardless of hook ordering.
+        add_filter( 'pre_http_request', [ $this, 'block_http_requests' ] );
+
         // Both controllers are in the REST class map, so DokanTestCase's rest_api_init already registered their routes.
-        $this->controller      = new AdminExtensionsController();
         $this->shop_manager_id = $this->factory()->user->create( [ 'role' => 'shop_manager' ] );
     }
 
@@ -62,22 +83,31 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
         $this->assertTrue( current_user_can( 'manage_woocommerce' ), 'Precondition: shop managers hold manage_woocommerce.' );
         $this->assertFalse( current_user_can( 'install_plugins' ), 'Precondition: shop managers do not hold install_plugins.' );
 
-        $response = $this->post_request( 'admin/extensions/install', [ 'slug' => 'classic-widgets' ] );
+        $response = $this->post_request( 'admin/extensions/install', [ 'slug' => self::UNINSTALLED_SLUG ] );
+
         $this->assertSame( 403, $response->get_status(), 'The install route must reject a shop manager.' );
     }
 
     /**
-     * An administrator may still install extensions.
+     * An administrator still passes the install route's permission gate.
      *
-     * Asserted at the permission callback rather than by dispatching, because the route
-     * would perform a real wordpress.org download.
+     * Dispatches the real route so the assertion also proves the permission callback is
+     * still wired in register_routes(). plugins_api() is short-circuited to an error, so
+     * the request stops at the first thing past the gate instead of downloading anything:
+     * reaching that 400 is only possible once the 403 gate has been cleared.
      */
     public function test_admin_can_install_extensions() {
         wp_set_current_user( $this->admin_id );
 
-        $this->assertTrue(
-            $this->controller->check_permission(),
-            'Administrators hold install_plugins and must keep access.'
+        add_filter( 'plugins_api', [ $this, 'block_plugins_api' ] );
+
+        $response = $this->post_request( 'admin/extensions/install', [ 'slug' => self::UNINSTALLED_SLUG ] );
+
+        $this->assertSame( 400, $response->get_status(), 'Administrators must clear the permission gate and reach the handler.' );
+        $this->assertSame(
+            'dokan_rest_plugin_info_failed',
+            $response->get_data()['code'] ?? '',
+            'The 400 must come from the stubbed plugins_api lookup, not from the permission layer.'
         );
     }
 
@@ -115,18 +145,7 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
      * The install_plugins cap alone is not enough: the queued installer also activates.
      */
     public function test_onboarding_does_not_install_for_user_who_cannot_activate() {
-        $role_name = 'dokan_test_installer_only';
-        add_role(
-            $role_name,
-            'Installer Only',
-            [
-                'read'               => true,
-                'manage_woocommerce' => true,
-                'install_plugins'    => true,
-            ]
-        );
-
-        wp_set_current_user( $this->factory()->user->create( [ 'role' => $role_name ] ) );
+        wp_set_current_user( $this->create_installer_only_user() );
 
         $this->assertTrue( current_user_can( 'install_plugins' ), 'Precondition: this user may install.' );
         $this->assertFalse( current_user_can( 'activate_plugins' ), 'Precondition: this user may not activate.' );
@@ -138,8 +157,91 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
             get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
             'The install queues an activation, so install_plugins without activate_plugins must not be enough.'
         );
+    }
 
-        remove_role( $role_name );
+    /**
+     * The wizard's own sink is guarded, not just the onboarding route that shares it.
+     *
+     * The Recommended step calls install_plugin() directly through
+     * dokan_setup_recommended_save(), so the guard has to hold when the method is reached
+     * outside the REST layer.
+     */
+    public function test_setup_wizard_does_not_queue_install_for_shop_manager() {
+        wp_set_current_user( $this->shop_manager_id );
+
+        $wizard = new SetupWizard();
+        $wizard->install_plugin( self::PLUGIN_ID, [ 'repo-slug' => self::PLUGIN_ID ] );
+
+        $this->assertFalse(
+            get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
+            'The wizard sink must not queue an install for a user without the plugin capabilities.'
+        );
+    }
+
+    /**
+     * The same wizard sink still works for an administrator.
+     */
+    public function test_setup_wizard_queues_install_for_admin() {
+        wp_set_current_user( $this->admin_id );
+
+        $wizard = new SetupWizard();
+        $wizard->install_plugin( self::PLUGIN_ID, [ 'repo-slug' => self::PLUGIN_ID ] );
+
+        $this->assertNotFalse(
+            get_option( 'woocommerce_setup_background_installing_' . self::PLUGIN_ID ),
+            'An administrator must still be able to queue the wizard install.'
+        );
+    }
+
+    /**
+     * The Recommended step is hidden from anyone who cannot complete an install.
+     *
+     * Adding activate_plugins to the predicate changes this display path as well as the
+     * authorization ones, so pin the visibility down in all three directions.
+     */
+    public function test_recommended_step_visibility_follows_the_plugin_capabilities() {
+        wp_set_current_user( $this->admin_id );
+        $this->assertTrue( $this->should_show_recommended_step(), 'Administrators keep the Recommended step.' );
+
+        wp_set_current_user( $this->shop_manager_id );
+        $this->assertFalse( $this->should_show_recommended_step(), 'Shop managers must not be offered plugin installs.' );
+
+        wp_set_current_user( $this->create_installer_only_user() );
+        $this->assertFalse(
+            $this->should_show_recommended_step(),
+            'The step installs and activates, so install_plugins alone must not reveal it.'
+        );
+    }
+
+    /**
+     * Invoke the wizard's protected visibility predicate for the current user.
+     */
+    protected function should_show_recommended_step(): bool {
+        // Constructed per call: the wizard reads capabilities in its constructor.
+        $method = new ReflectionMethod( SetupWizard::class, 'should_show_recommended_step' );
+        $method->setAccessible( true );
+
+        return (bool) $method->invoke( new SetupWizard() );
+    }
+
+    /**
+     * Create a user granted install_plugins but denied activate_plugins.
+     *
+     * DokanTestCase::tear_down() rebuilds the WP_Roles singleton from the rolled-back
+     * option, so the role does not need removing here and cannot leak between tests.
+     */
+    protected function create_installer_only_user(): int {
+        add_role(
+            self::INSTALLER_ONLY_ROLE,
+            'Installer Only',
+            [
+                'read'               => true,
+                'manage_woocommerce' => true,
+                'install_plugins'    => true,
+            ]
+        );
+
+        return $this->factory()->user->create( [ 'role' => self::INSTALLER_ONLY_ROLE ] );
     }
 
     /**
@@ -163,6 +265,27 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
         ];
     }
 
+    /**
+     * Fail any outbound HTTP request made during a test.
+     *
+     * @return WP_Error
+     */
+    public function block_http_requests() {
+        return new WP_Error( 'dokan_test_http_blocked', 'Outbound HTTP is blocked in this test case.' );
+    }
+
+    /**
+     * Short-circuit plugins_api() so the install route never queries wordpress.org.
+     *
+     * @return WP_Error
+     */
+    public function block_plugins_api() {
+        return new WP_Error( 'dokan_test_plugins_api_blocked', 'plugins_api is stubbed in this test case.' );
+    }
+
+    /**
+     * Tear down the test case.
+     */
     public function tear_down() {
         // install_plugin() defers the real download to shutdown; drop it so no test ever hits wordpress.org.
         remove_all_actions( 'shutdown' );

--- a/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
+++ b/tests/php/src/REST/AdminPluginInstallCapabilityTest.php
@@ -112,7 +112,7 @@ class AdminPluginInstallCapabilityTest extends DokanTestCase {
     }
 
     /**
-     * install_plugins alone is not enough: the queued installer also activates.
+     * The install_plugins cap alone is not enough: the queued installer also activates.
      */
     public function test_onboarding_does_not_install_for_user_who_cannot_activate() {
         $role_name = 'dokan_test_installer_only';


### PR DESCRIPTION
### All Submissions:

* [x] My code follows the WordPress coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Four code paths that install wordpress.org plugins — and in three cases **activate** them too — were gated on `manage_woocommerce`. A **Shop Manager** natively holds `manage_woocommerce` but *not* `install_plugins`/`activate_plugins`, so that role could install plugins it cannot install through wp-admin, and install **and activate** them via the onboarding route. Installing and activating arbitrary code is a full-trust capability, so this is a privilege escalation to code execution.

The reporter named the two REST routes. A sweep of every plugin-install/activate primitive in the repo found **two more reachable instances of the same substitution**, so all four are fixed here:

| # | Location | Change | Note |
|---|---|---|---|
| 1 | `AdminExtensionsController` (`POST /dokan/v1/admin/extensions/install`) | `check_permission()` override requiring `install_plugins` | reported. This route only installs, never activates, so `activate_plugins` is deliberately **not** required |
| 2 | `AdminOnboardingController::install_required_plugins()` (`POST /dokan/v1/admin/onboarding`) | bails without `install_plugins` + `activate_plugins` | reported |
| 3 | `SetupWizard::install_plugin()` | guard changed from `manage_woocommerce` to `user_can_install_plugin()` | **new** — the shared sink behind #2 *and* the wizard's "Recommended" step |
| 4 | `SetupWizardNoWC::install_woocommerce()` | guarded via the inherited predicate | **new** — fixed slug (WooCommerce), so lower impact than #1–#3 |

`SetupWizard::user_can_install_plugin()` already returned `install_plugins`, but was only used to decide whether to *display* the Recommended step — never to authorize an install. It now also requires `activate_plugins` (the queued `WC_Install::background_installer` activates what it installs) and became `public` so the onboarding controller can reuse it rather than spelling the capability pair out a third time.

Two deliberate calls worth flagging for review:

* **The onboarding route itself stays on `manage_woocommerce`.** A Shop Manager legitimately completes onboarding, so only the install step is skipped — settings still save and the request still succeeds. The guard sits at the step rather than the route for that reason, and also stops `dokan_before_install_plugin` / `dokan_after_install_plugin` / `dokan_admin_onboarding_plugins_installed` from firing for a user who may not install.
* **`dokan_install_wp_org_plugin()` (`includes/functions.php`) is left without a capability check.** It is a documented general utility, and WP core's own `Plugin_Upgrader` likewise leaves authorization to the request layer; adding `current_user_can()` there would break any non-request caller (WP-CLI, cron). Its only production caller is #4, which this PR guards.

### Related Pull Request(s)

* Part of the getdokan/dokan-pro#5982 batch, alongside #3351 (L10) and the L12 fix
* Pro sibling finding filed as getdokan/plugin-internal-tasks#2175

### Closes

* Closes getdokan/plugin-internal-tasks#2173

### How to test the changes in this Pull Request:

As a **Shop Manager** (holds `manage_woocommerce`, lacks `install_plugins`), with a `wp_rest` nonce from any Dokan admin screen:

1. `POST /wp-json/dokan/v1/admin/extensions/install` with `{"slug":"classic-widgets"}`. **Before:** `200 {"success":true}` and the plugin is really on disk. **After:** `403 rest_forbidden`, nothing installed.
2. `POST /wp-json/dokan/v1/admin/onboarding` with `{"onboarding":true,"marketplace_goal":{…},"plugins":[{"id":"classic-editor","info":{"repo-slug":"classic-editor"}}]}`. **Before:** install queued (`woocommerce_setup_background_installing_classic-editor` set) and activated on shutdown. **After:** no install queued — but the response is still `200` and the onboarding settings are still saved.
3. As an **administrator**, confirm both still work: the extensions install succeeds and onboarding still queues its plugins.
4. Confirm the setup wizard's "Recommended" step still appears for an administrator.
5. Automated: `tests/php/src/REST/AdminPluginInstallCapabilityTest.php`.

> Note: PHPUnit could not be executed locally (Docker unavailable on this machine), so CI is the first run of the new test. Behaviour was verified end-to-end against a live install instead: pre-fix, a Shop Manager really did download `classic-widgets` to `wp-content/plugins/` through step 1 and queue the `classic-editor` install through step 2; post-fix both are blocked while the administrator paths and the onboarding save are unchanged. The test suppresses `shutdown` in `tear_down()` so the deferred installer can never reach wordpress.org during a test run.

### Changelog entry

**Fix — Shop Managers could install and activate arbitrary plugins through Dokan admin routes**

Previously, the Dokan extensions-install and onboarding REST routes, the setup wizard's plugin installer, and the no-WooCommerce wizard step all authorized plugin installation with the `manage_woocommerce` capability. A Shop Manager holds that capability without holding `install_plugins`/`activate_plugins`, so the role could install — and via onboarding install and activate — arbitrary WordPress.org plugins. These paths now require the WordPress plugin capabilities; onboarding itself remains available to Shop Managers, minus the plugin-install step.

### Before Changes

Shop Manager → `POST dokan/v1/admin/extensions/install {"slug":"classic-widgets"}` → `200`, plugin installed. Onboarding with a `plugins` array → installed **and activated**.

### After Changes

Shop Manager → `403 rest_forbidden`, nothing installed. Onboarding → `200`, settings saved, no plugin install queued. Administrators unaffected.

### Note for the reviewer

The second commit (`fix(cs)`) is unrelated to the vulnerability: `SetupWizard.php` had a pre-existing unsanitized `$_POST['reset_sub_category']` read, and Lite's PHPCS job scans whole changed files, so the branch could not go green without it. It is split into its own commit for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved commission settings so category reset preferences are saved consistently.
  - Prevented unauthorized users from installing plugins or extensions through setup, onboarding, and administration tools.
  - Added safeguards to stop installation actions when the required permissions are missing.

- **Security**
  - Plugin installation now requires both installation and activation permissions.
  - Unauthorized installation attempts are rejected with an appropriate permission error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->