### PR TITLE
ci: refresh the e2e shard-duration baseline

### DIFF
--- a/tests/pw/utils/shard-durations.json
+++ b/tests/pw/utils/shard-durations.json
@@ -794,7 +794,7 @@
     },
     {
       "file": "spmv/spmv.spec.ts",
-      "ms": 15212,
+      "ms": 15832,
       "tests": 18
     },
     {
@@ -829,7 +829,7 @@
     },
     {
       "file": "store-reviews/storeReviews.spec.ts",
-      "ms": 8485,
+      "ms": 8525,
       "tests": 17
     },
     {
@@ -874,7 +874,7 @@
     },
     {
       "file": "live-search/liveSearch.spec.ts",
-      "ms": 3766,
+      "ms": 3809,
       "tests": 7
     },
     {
@@ -884,22 +884,22 @@
     },
     {
       "file": "live-chat/liveChat.spec.ts",
-      "ms": 3123,
+      "ms": 3184,
       "tests": 12
     },
     {
       "file": "single-product/singleProduct.spec.ts",
-      "ms": 3045,
+      "ms": 3900,
       "tests": 8
     },
     {
       "file": "privacy-policy/privacyPolicy.spec.ts",
-      "ms": 1494,
+      "ms": 1725,
       "tests": 4
     },
     {
       "file": "products-details-bookings/productsDetailsBookings.spec.ts",
-      "ms": 274,
+      "ms": 276,
       "tests": 2
     },
     {
@@ -909,32 +909,32 @@
     },
     {
       "file": "shipping/shipping.spec.ts",
-      "ms": 88,
+      "ms": 114,
       "tests": 10
     },
     {
       "file": "shop/shop.spec.ts",
-      "ms": 54,
+      "ms": 89,
       "tests": 7
     },
     {
       "file": "menu-manager/menuManager.spec.ts",
-      "ms": 53,
+      "ms": 67,
       "tests": 8
     },
     {
       "file": "request-for-quote-rules/requestForQuoteRules.spec.ts",
-      "ms": 50,
+      "ms": 58,
       "tests": 6
     },
     {
       "file": "my-orders/myOrders.spec.ts",
-      "ms": 42,
+      "ms": 52,
       "tests": 6
     },
     {
       "file": "stripe-express/stripeExpress3ds.spec.ts",
-      "ms": 42,
+      "ms": 400000,
       "tests": 5
     },
     {
@@ -944,33 +944,34 @@
     },
     {
       "file": "tax/tax.spec.ts",
-      "ms": 23,
+      "ms": 45,
       "tests": 2
     },
     {
       "file": "stripe-express/stripeExpressPreflight.spec.ts",
-      "ms": 9,
+      "ms": 120000,
       "tests": 1
     },
     {
       "file": "stripe-express/stripeExpressSubscriptions.spec.ts",
-      "ms": 6,
+      "ms": 1040000,
       "tests": 11
     },
     {
       "file": "admin/adminTools.spec.ts",
-      "ms": 0,
+      "ms": 500,
       "tests": 16
     },
     {
       "file": "tools/tools.spec.ts",
-      "ms": 0,
+      "ms": 500,
       "tests": 9
     },
     {
       "file": "visual/visual.spec.ts",
-      "ms": 0,
+      "ms": 287147,
       "tests": 57
     }
-  ]
+  ],
+  "note": "merged from run 30346616808 with a skip-guard: specs measured at <1s/test in that run (i.e. skipped, not fast) keep their prior baseline weight \u2014 as of 2026-07-29 that is visual, stripeExpress3ds/Preflight/Subscriptions, and the tools/adminTools floors. Refresh only from non-PR (nightly/dispatch) runs; PR smoke runs measure a subset only."
 }

--- a/tests/pw/utils/shard-durations.json
+++ b/tests/pw/utils/shard-durations.json
@@ -1,957 +1,976 @@
 {
-  "generatedAt": "2026-07-15T00:00:00Z",
+  "generatedAt": "2026-07-28T10:56:25.651Z",
   "shards": 12,
   "specs": [
     {
-      "file": "adminDataViewsMigration.spec.ts",
-      "ms": 9366,
-      "tests": 19
+      "file": "stripe-express/stripeExpressPayouts.spec.ts",
+      "ms": 637730,
+      "tests": 11
     },
     {
-      "file": "vendor-auction/vendorAuction.spec.ts",
-      "ms": 102401,
-      "tests": 19
-    },
-    {
-      "file": "vendor-auction/newAuction.spec.ts",
-      "ms": 140330,
-      "tests": 12
-    },
-    {
-      "file": "vendor-return-request/newReturnRequest.spec.ts",
-      "ms": 148230,
-      "tests": 10
-    },
-    {
-      "file": "vendor-return-request/vendorReturnRequest.spec.ts",
-      "ms": 34640,
-      "tests": 12
-    },
-    {
-      "file": "settings/settings.spec.ts",
-      "ms": 252882,
-      "tests": 34
-    },
-    {
-      "file": "products-details-bookings/productsDetailsBookings.spec.ts",
-      "ms": 276,
-      "tests": 2
-    },
-    {
-      "file": "product-enquiry/productEnquiry.spec.ts",
-      "ms": 123,
-      "tests": 4
-    },
-    {
-      "file": "request-for-quotes/newRequestedQuotes.spec.ts",
-      "ms": 76472,
-      "tests": 9
-    },
-    {
-      "file": "request-for-quotes/requestForQuotes.spec.ts",
-      "ms": 66130,
-      "tests": 24
-    },
-    {
-      "file": "menu-manager/menuManager.spec.ts",
-      "ms": 67,
-      "tests": 9
-    },
-    {
-      "file": "menu-manager/newMenuManager.spec.ts",
-      "ms": 29374,
-      "tests": 4
-    },
-    {
-      "file": "email-verification/emailVerification.spec.ts",
-      "ms": 5123,
-      "tests": 4
-    },
-    {
-      "file": "payments/payments.spec.ts",
-      "ms": 113277,
-      "tests": 33
-    },
-    {
-      "file": "vendor-product-subscription/vendorProductSubscription.spec.ts",
-      "ms": 30561,
-      "tests": 16
-    },
-    {
-      "file": "vendor-product-subscription/newUserSubscription.spec.ts",
-      "ms": 55283,
-      "tests": 9
-    },
-    {
-      "file": "brand-filter/brandFilter.spec.ts",
-      "ms": 6435,
-      "tests": 2
-    },
-    {
-      "file": "live-search/liveSearch.spec.ts",
-      "ms": 3809,
-      "tests": 7
-    },
-    {
-      "file": "tools/tools.spec.ts",
-      "ms": 500,
-      "tests": 10
-    },
-    {
-      "file": "commission/commission.spec.ts",
-      "ms": 19279,
-      "tests": 3
-    },
-    {
-      "file": "withdraws/newWithdraw.spec.ts",
-      "ms": 147681,
-      "tests": 12
-    },
-    {
-      "file": "withdraws/newWithdrawB15.spec.ts",
-      "ms": 22032,
-      "tests": 3
-    },
-    {
-      "file": "withdraws/withdraws.spec.ts",
-      "ms": 49849,
-      "tests": 24
-    },
-    {
-      "file": "seller-vacation/sellerVacation.spec.ts",
-      "ms": 21,
-      "tests": 2
-    },
-    {
-      "file": "product-reviews/productReviews.spec.ts",
-      "ms": 61852,
-      "tests": 13
-    },
-    {
-      "file": "products/newProductsProActions.spec.ts",
-      "ms": 50727,
-      "tests": 3
-    },
-    {
-      "file": "products/newProducts.spec.ts",
-      "ms": 275595,
-      "tests": 28
-    },
-    {
-      "file": "products/products.spec.ts",
-      "ms": 343008,
-      "tests": 33
+      "file": "_auth.setup.ts",
+      "ms": 578501,
+      "tests": 132
     },
     {
       "file": "products-details/productsDetails.spec.ts",
-      "ms": 516063,
+      "ms": 515673,
       "tests": 95
     },
     {
-      "file": "stripe-express/stripeExpressSubscriptions.spec.ts",
-      "ms": 1040000,
-      "tests": 26
+      "file": "_site.setup.ts",
+      "ms": 470986,
+      "tests": 276
+    },
+    {
+      "file": "product-form-manager/newProductFormEdit.spec.ts",
+      "ms": 411036,
+      "tests": 10
     },
     {
       "file": "stripe-express/stripeExpressRefunds.spec.ts",
-      "ms": 840000,
-      "tests": 21
-    },
-    {
-      "file": "stripe-express/stripeExpressEdge.spec.ts",
-      "ms": 600000,
-      "tests": 15
-    },
-    {
-      "file": "stripe-express/stripeExpressSavedCards.spec.ts",
-      "ms": 800000,
-      "tests": 20
-    },
-    {
-      "file": "stripe-express/stripeExpressSettings.spec.ts",
-      "ms": 920000,
-      "tests": 23
-    },
-    {
-      "file": "stripe-express/stripeExpressCurrency.spec.ts",
-      "ms": 440000,
-      "tests": 11
-    },
-    {
-      "file": "stripe-express/stripeExpressPreflight.spec.ts",
-      "ms": 120000,
-      "tests": 3
-    },
-    {
-      "file": "stripe-express/stripeExpressSecurity.spec.ts",
-      "ms": 920000,
-      "tests": 23
+      "ms": 398957,
+      "tests": 7
     },
     {
       "file": "stripe-express/stripeExpressWebhooks.spec.ts",
-      "ms": 1320000,
-      "tests": 33
-    },
-    {
-      "file": "stripe-express/stripeExpressAdvertisement.spec.ts",
-      "ms": 160000,
-      "tests": 4
-    },
-    {
-      "file": "stripe-express/stripeExpress3ds.spec.ts",
-      "ms": 400000,
-      "tests": 10
-    },
-    {
-      "file": "stripe-express/stripeExpress.spec.ts",
-      "ms": 520000,
-      "tests": 13
-    },
-    {
-      "file": "stripe-express/stripeExpressVendorOnboarding.spec.ts",
-      "ms": 360000,
-      "tests": 9
-    },
-    {
-      "file": "stripe-express/stripeExpressXss.spec.ts",
-      "ms": 280000,
-      "tests": 7
-    },
-    {
-      "file": "stripe-express/stripeExpressPayouts.spec.ts",
-      "ms": 960000,
-      "tests": 24
-    },
-    {
-      "file": "stripe-express/stripeExpressGuest.spec.ts",
-      "ms": 240000,
-      "tests": 6
-    },
-    {
-      "file": "stripe-express/stripeExpressWallet.spec.ts",
-      "ms": 400000,
-      "tests": 10
-    },
-    {
-      "file": "frontend-badges/frontendBadges.spec.ts",
-      "ms": 4746,
-      "tests": 2
-    },
-    {
-      "file": "vendor-verifications/vendorVerifications.spec.ts",
-      "ms": 163901,
-      "tests": 39
-    },
-    {
-      "file": "vendor-verifications/newVendorVerifications.spec.ts",
-      "ms": 143327,
-      "tests": 10
-    },
-    {
-      "file": "license/license.spec.ts",
-      "ms": 21736,
-      "tests": 7
-    },
-    {
-      "file": "printful/printful.spec.ts",
-      "ms": 38089,
-      "tests": 10
-    },
-    {
-      "file": "intelligence/intelligence.spec.ts",
-      "ms": 21887,
-      "tests": 2
-    },
-    {
-      "file": "rank-math/rankMath.spec.ts",
-      "ms": 30881,
+      "ms": 391466,
       "tests": 16
-    },
-    {
-      "file": "store-supports/storeSupports.spec.ts",
-      "ms": 60995,
-      "tests": 42
-    },
-    {
-      "file": "store-supports/newStoreSupport.spec.ts",
-      "ms": 159690,
-      "tests": 15
-    },
-    {
-      "file": "vendor-delivery-time/newDeliveryTime.spec.ts",
-      "ms": 22472,
-      "tests": 3
-    },
-    {
-      "file": "vendor-delivery-time/vendorDeliveryTime.spec.ts",
-      "ms": 65165,
-      "tests": 13
-    },
-    {
-      "file": "privacy-policy/privacyPolicy.spec.ts",
-      "ms": 1725,
-      "tests": 4
-    },
-    {
-      "file": "table-rate-shipping/tableRateShipping.spec.ts",
-      "ms": 17230,
-      "tests": 2
-    },
-    {
-      "file": "table-rate-shipping/newShippingRate.spec.ts",
-      "ms": 38124,
-      "tests": 6
-    },
-    {
-      "file": "vendor-tools/vendorTools.spec.ts",
-      "ms": 17725,
-      "tests": 9
-    },
-    {
-      "file": "store-appearance/storeAppearance.spec.ts",
-      "ms": 21128,
-      "tests": 2
-    },
-    {
-      "file": "product-tabs/productTabs.spec.ts",
-      "ms": 8382,
-      "tests": 2
-    },
-    {
-      "file": "vendor-booking/vendorBooking.spec.ts",
-      "ms": 130909,
-      "tests": 25
-    },
-    {
-      "file": "vendor-booking/newBooking.spec.ts",
-      "ms": 135947,
-      "tests": 11
-    },
-    {
-      "file": "manual-order/manualOrder.spec.ts",
-      "ms": 8581,
-      "tests": 3
-    },
-    {
-      "file": "manual-order/newManualOrder.spec.ts",
-      "ms": 162715,
-      "tests": 11
-    },
-    {
-      "file": "shop/shop.spec.ts",
-      "ms": 89,
-      "tests": 7
-    },
-    {
-      "file": "diagnostic-notice/diagnosticNotice.spec.ts",
-      "ms": 8229,
-      "tests": 2
-    },
-    {
-      "file": "min-max-quantities/minMaxQuantities.spec.ts",
-      "ms": 9430,
-      "tests": 3
-    },
-    {
-      "file": "plugin/plugin.spec.ts",
-      "ms": 9857,
-      "tests": 8
-    },
-    {
-      "file": "admin/adminSetupGuide.spec.ts",
-      "ms": 148852,
-      "tests": 17
-    },
-    {
-      "file": "admin/adminAbuseReports.spec.ts",
-      "ms": 83144,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminModules.spec.ts",
-      "ms": 108250,
-      "tests": 18
-    },
-    {
-      "file": "admin/adminVendorCreate.spec.ts",
-      "ms": 104722,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminStoreReviews.spec.ts",
-      "ms": 92567,
-      "tests": 12
-    },
-    {
-      "file": "admin/adminDummyData.spec.ts",
-      "ms": 81944,
-      "tests": 17
-    },
-    {
-      "file": "admin/adminSubscriptions.spec.ts",
-      "ms": 76051,
-      "tests": 16
-    },
-    {
-      "file": "admin/adminStoreSupport.spec.ts",
-      "ms": 123448,
-      "tests": 16
-    },
-    {
-      "file": "admin/adminWithdraw.spec.ts",
-      "ms": 101406,
-      "tests": 16
-    },
-    {
-      "file": "admin/adminStatus.spec.ts",
-      "ms": 41563,
-      "tests": 11
-    },
-    {
-      "file": "admin/adminReverseWithdrawal.spec.ts",
-      "ms": 103951,
-      "tests": 15
-    },
-    {
-      "file": "admin/adminDashboardHome.spec.ts",
-      "ms": 95246,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminVendors.spec.ts",
-      "ms": 101881,
-      "tests": 15
-    },
-    {
-      "file": "admin/adminTools.spec.ts",
-      "ms": 500,
-      "tests": 17
-    },
-    {
-      "file": "admin/admin.spec.ts",
-      "ms": 108780,
-      "tests": 17
-    },
-    {
-      "file": "admin/adminSellerBadges.spec.ts",
-      "ms": 114235,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminReports.spec.ts",
-      "ms": 150079,
-      "tests": 26
-    },
-    {
-      "file": "admin/adminVendorSupport.spec.ts",
-      "ms": 84277,
-      "tests": 19
-    },
-    {
-      "file": "admin/adminVerifications.spec.ts",
-      "ms": 35865,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminExtensions.spec.ts",
-      "ms": 107083,
-      "tests": 18
-    },
-    {
-      "file": "admin/adminVendorEdit.spec.ts",
-      "ms": 99936,
-      "tests": 13
-    },
-    {
-      "file": "admin/adminVendorSingle.spec.ts",
-      "ms": 95113,
-      "tests": 15
-    },
-    {
-      "file": "admin/adminLicense.spec.ts",
-      "ms": 57584,
-      "tests": 12
-    },
-    {
-      "file": "admin/adminProductQa.spec.ts",
-      "ms": 111051,
-      "tests": 16
-    },
-    {
-      "file": "admin/adminWholesaleCustomer.spec.ts",
-      "ms": 100918,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminRefundRequests.spec.ts",
-      "ms": 123585,
-      "tests": 14
-    },
-    {
-      "file": "admin/adminProductAdvertising.spec.ts",
-      "ms": 94810,
-      "tests": 15
-    },
-    {
-      "file": "admin/adminChangelog.spec.ts",
-      "ms": 122842,
-      "tests": 21
-    },
-    {
-      "file": "admin/adminRequestForQuote.spec.ts",
-      "ms": 84915,
-      "tests": 12
-    },
-    {
-      "file": "admin/adminAnnouncements.spec.ts",
-      "ms": 88919,
-      "tests": 13
-    },
-    {
-      "file": "stores/stores.spec.ts",
-      "ms": 62811,
-      "tests": 18
-    },
-    {
-      "file": "tax/tax.spec.ts",
-      "ms": 45,
-      "tests": 2
-    },
-    {
-      "file": "announcements/announcementsNewUI.spec.ts",
-      "ms": 135056,
-      "tests": 13
-    },
-    {
-      "file": "announcements/newAnnouncements.spec.ts",
-      "ms": 60217,
-      "tests": 3
-    },
-    {
-      "file": "announcements/announcements.spec.ts",
-      "ms": 191762,
-      "tests": 20
-    },
-    {
-      "file": "manual-order-pro/manualOrderPro.spec.ts",
-      "ms": 21106,
-      "tests": 2
-    },
-    {
-      "file": "store-seo/storeSeo.spec.ts",
-      "ms": 19905,
-      "tests": 2
-    },
-    {
-      "file": "store-seo/newStoreSeo.spec.ts",
-      "ms": 63924,
-      "tests": 6
-    },
-    {
-      "file": "shipping/shipping.spec.ts",
-      "ms": 114,
-      "tests": 10
-    },
-    {
-      "file": "catalog-mode/catalogMode.spec.ts",
-      "ms": 17845,
-      "tests": 6
-    },
-    {
-      "file": "my-orders/myOrders.spec.ts",
-      "ms": 52,
-      "tests": 6
-    },
-    {
-      "file": "export-import/exportImport.spec.ts",
-      "ms": 19671,
-      "tests": 2
-    },
-    {
-      "file": "shortcodes/shortcodes.spec.ts",
-      "ms": 12791,
-      "tests": 13
-    },
-    {
-      "file": "spmv/spmv.spec.ts",
-      "ms": 15832,
-      "tests": 18
-    },
-    {
-      "file": "product-variations/productVariations.spec.ts",
-      "ms": 19693,
-      "tests": 2
-    },
-    {
-      "file": "product-qa/newProductQa.spec.ts",
-      "ms": 156342,
-      "tests": 10
-    },
-    {
-      "file": "product-qa/productQA.spec.ts",
-      "ms": 55081,
-      "tests": 19
-    },
-    {
-      "file": "seller-badges/sellerBadges.spec.ts",
-      "ms": 90787,
-      "tests": 21
-    },
-    {
-      "file": "seller-badges/newSellerBadge.spec.ts",
-      "ms": 134296,
-      "tests": 13
-    },
-    {
-      "file": "dashboard/dashboard.spec.ts",
-      "ms": 218021,
-      "tests": 24
-    },
-    {
-      "file": "vendor-support/newVendorSupport.spec.ts",
-      "ms": 182872,
-      "tests": 16
-    },
-    {
-      "file": "coupons/newCoupons.spec.ts",
-      "ms": 173422,
-      "tests": 14
-    },
-    {
-      "file": "vendor-reports-admin/vendorReportsAdmin.spec.ts",
-      "ms": 14795,
-      "tests": 10
-    },
-    {
-      "file": "vendor-staff/vendorStaff.spec.ts",
-      "ms": 20434,
-      "tests": 13
-    },
-    {
-      "file": "vendor-staff/newVendorStaff.spec.ts",
-      "ms": 200917,
-      "tests": 13
-    },
-    {
-      "file": "colors/colors.spec.ts",
-      "ms": 25784,
-      "tests": 6
-    },
-    {
-      "file": "product-advertising/newProductAdvertising.spec.ts",
-      "ms": 63840,
-      "tests": 6
-    },
-    {
-      "file": "product-advertising/productAdvertising.spec.ts",
-      "ms": 51191,
-      "tests": 17
-    },
-    {
-      "file": "product-bulk-edit/productBulkEdit.spec.ts",
-      "ms": 19331,
-      "tests": 2
-    },
-    {
-      "file": "visual/visual.spec.ts",
-      "ms": 287147,
-      "tests": 58
-    },
-    {
-      "file": "eu-compliance/euCompliance.spec.ts",
-      "ms": 44501,
-      "tests": 21
-    },
-    {
-      "file": "notice-and-promotion/noticeAndPromotion.spec.ts",
-      "ms": 11318,
-      "tests": 3
-    },
-    {
-      "file": "geolocation/geolocation.spec.ts",
-      "ms": 127783,
-      "tests": 8
-    },
-    {
-      "file": "products-details-auction/productsDetailsAuction.spec.ts",
-      "ms": 203338,
-      "tests": 56
-    },
-    {
-      "file": "wholesale/wholesale.spec.ts",
-      "ms": 34700,
-      "tests": 26
-    },
-    {
-      "file": "single-product/singleProduct.spec.ts",
-      "ms": 3900,
-      "tests": 8
-    },
-    {
-      "file": "vendor-shipping/vendorShipping.spec.ts",
-      "ms": 35984,
-      "tests": 4
     },
     {
       "file": "vendor-shipping/newShipping.spec.ts",
-      "ms": 371223,
-      "tests": 17
+      "ms": 371065,
+      "tests": 16
     },
     {
-      "file": "setup-guide/setupGuide.spec.ts",
-      "ms": 45748,
+      "file": "stripe-express/stripeExpressCurrency.spec.ts",
+      "ms": 316561,
       "tests": 5
     },
     {
-      "file": "refunds/refunds.spec.ts",
-      "ms": 13502,
-      "tests": 10
+      "file": "products/newProducts.spec.ts",
+      "ms": 316494,
+      "tests": 29
     },
     {
-      "file": "vendor-settings/vendorSettings.spec.ts",
-      "ms": 47730,
-      "tests": 30
+      "file": "abuse-reports/abuseReports.spec.ts",
+      "ms": 299309,
+      "tests": 43
     },
     {
-      "file": "dokan-invoice/dokanInvoice.spec.ts",
-      "ms": 176746,
-      "tests": 27
-    },
-    {
-      "file": "vendor-analytics/vendorAnalytics.spec.ts",
-      "ms": 33521,
-      "tests": 5
-    },
-    {
-      "file": "single-store/singleStore.spec.ts",
-      "ms": 14392,
-      "tests": 9
-    },
-    {
-      "file": "orders/newOrdersGaps.spec.ts",
-      "ms": 39482,
+      "file": "stripe-express/stripeExpressGuest.spec.ts",
+      "ms": 295224,
       "tests": 3
     },
     {
       "file": "orders/orders.spec.ts",
-      "ms": 289670,
-      "tests": 26
-    },
-    {
-      "file": "orders/newOrders.spec.ts",
-      "ms": 253271,
+      "ms": 291152,
       "tests": 23
     },
     {
-      "file": "store-reviews/storeReviews.spec.ts",
-      "ms": 8525,
+      "file": "stripe-express/stripeExpressSavedCards.spec.ts",
+      "ms": 270739,
+      "tests": 8
+    },
+    {
+      "file": "stripe-express/stripeExpressEdge.spec.ts",
+      "ms": 269810,
+      "tests": 7
+    },
+    {
+      "file": "orders/newOrders.spec.ts",
+      "ms": 249125,
+      "tests": 21
+    },
+    {
+      "file": "product-form-manager/newProductForm.spec.ts",
+      "ms": 246295,
+      "tests": 13
+    },
+    {
+      "file": "products/products.spec.ts",
+      "ms": 240183,
+      "tests": 33
+    },
+    {
+      "file": "product-form-manager/newProductFormAuction.spec.ts",
+      "ms": 239357,
+      "tests": 13
+    },
+    {
+      "file": "products-details-auction/productsDetailsAuction.spec.ts",
+      "ms": 222754,
+      "tests": 50
+    },
+    {
+      "file": "dashboard/dashboard.spec.ts",
+      "ms": 218997,
+      "tests": 24
+    },
+    {
+      "file": "_env.setup.ts",
+      "ms": 207766,
+      "tests": 516
+    },
+    {
+      "file": "vendor-staff/newVendorStaff.spec.ts",
+      "ms": 201934,
+      "tests": 13
+    },
+    {
+      "file": "product-form-manager/productFormManagerAdmin.spec.ts",
+      "ms": 198801,
+      "tests": 46
+    },
+    {
+      "file": "vendor-products/addProduct.spec.ts",
+      "ms": 196343,
+      "tests": 18
+    },
+    {
+      "file": "vendor-booking-fast/vendorBookingFast.spec.ts",
+      "ms": 190402,
       "tests": 17
     },
     {
-      "file": "store-reviews/newStoreReviews.spec.ts",
-      "ms": 68484,
-      "tests": 9
+      "file": "vendor-verifications/vendorVerifications.spec.ts",
+      "ms": 189368,
+      "tests": 39
+    },
+    {
+      "file": "announcements/announcements.spec.ts",
+      "ms": 187310,
+      "tests": 20
+    },
+    {
+      "file": "vendor-support/newVendorSupport.spec.ts",
+      "ms": 180069,
+      "tests": 16
     },
     {
       "file": "product-form-manager/newProductFormValidation.spec.ts",
-      "ms": 178867,
+      "ms": 175837,
       "tests": 9
     },
     {
+      "file": "coupons/newCoupons.spec.ts",
+      "ms": 173219,
+      "tests": 14
+    },
+    {
+      "file": "dokan-invoice/dokanInvoice.spec.ts",
+      "ms": 164116,
+      "tests": 26
+    },
+    {
+      "file": "store-supports/newStoreSupport.spec.ts",
+      "ms": 162277,
+      "tests": 15
+    },
+    {
+      "file": "manual-order/newManualOrder.spec.ts",
+      "ms": 161676,
+      "tests": 11
+    },
+    {
+      "file": "announcements/announcementsNewUI.spec.ts",
+      "ms": 160632,
+      "tests": 13
+    },
+    {
+      "file": "admin/adminReports.spec.ts",
+      "ms": 156330,
+      "tests": 23
+    },
+    {
+      "file": "product-qa/newProductQa.spec.ts",
+      "ms": 153945,
+      "tests": 10
+    },
+    {
+      "file": "stripe-express/stripeExpressSettings.spec.ts",
+      "ms": 153712,
+      "tests": 11
+    },
+    {
+      "file": "product-form-manager/newProductFormAdvanced.spec.ts",
+      "ms": 149125,
+      "tests": 13
+    },
+    {
+      "file": "admin/adminSetupGuide.spec.ts",
+      "ms": 148143,
+      "tests": 17
+    },
+    {
+      "file": "vendor-return-request/newReturnRequest.spec.ts",
+      "ms": 145163,
+      "tests": 10
+    },
+    {
+      "file": "vendor-auction/newAuction.spec.ts",
+      "ms": 142276,
+      "tests": 12
+    },
+    {
+      "file": "settings/settings.spec.ts",
+      "ms": 140559,
+      "tests": 34
+    },
+    {
+      "file": "vendor-booking/newBooking.spec.ts",
+      "ms": 140282,
+      "tests": 10
+    },
+    {
+      "file": "withdraws/newWithdraw.spec.ts",
+      "ms": 138556,
+      "tests": 12
+    },
+    {
+      "file": "vendor-verifications/newVendorVerifications.spec.ts",
+      "ms": 135063,
+      "tests": 10
+    },
+    {
+      "file": "seller-badges/newSellerBadge.spec.ts",
+      "ms": 132193,
+      "tests": 10
+    },
+    {
+      "file": "vendor-booking/vendorBooking.spec.ts",
+      "ms": 127163,
+      "tests": 25
+    },
+    {
+      "file": "admin/adminStoreSupport.spec.ts",
+      "ms": 126499,
+      "tests": 16
+    },
+    {
+      "file": "vendor-reports/vendorReports.spec.ts",
+      "ms": 120381,
+      "tests": 45
+    },
+    {
+      "file": "admin/adminRefundRequests.spec.ts",
+      "ms": 119762,
+      "tests": 14
+    },
+    {
+      "file": "admin/adminVendors.spec.ts",
+      "ms": 118395,
+      "tests": 15
+    },
+    {
+      "file": "admin/admin.spec.ts",
+      "ms": 118354,
+      "tests": 17
+    },
+    {
+      "file": "stripe-express/stripeExpress.spec.ts",
+      "ms": 117963,
+      "tests": 7
+    },
+    {
+      "file": "admin/adminProductQa.spec.ts",
+      "ms": 117621,
+      "tests": 16
+    },
+    {
+      "file": "admin/adminChangelog.spec.ts",
+      "ms": 117450,
+      "tests": 20
+    },
+    {
+      "file": "admin/adminExtensions.spec.ts",
+      "ms": 115587,
+      "tests": 18
+    },
+    {
+      "file": "admin/adminSellerBadges.spec.ts",
+      "ms": 111489,
+      "tests": 14
+    },
+    {
+      "file": "abuse-reports/abuseReportsSettings.spec.ts",
+      "ms": 107811,
+      "tests": 8
+    },
+    {
+      "file": "admin/adminModules.spec.ts",
+      "ms": 106574,
+      "tests": 17
+    },
+    {
+      "file": "vendor-auction/vendorAuction.spec.ts",
+      "ms": 102337,
+      "tests": 18
+    },
+    {
+      "file": "stripe-express/stripeExpressXss.spec.ts",
+      "ms": 101909,
+      "tests": 4
+    },
+    {
+      "file": "admin/adminVendorCreate.spec.ts",
+      "ms": 101179,
+      "tests": 14
+    },
+    {
+      "file": "admin/adminVendorEdit.spec.ts",
+      "ms": 101145,
+      "tests": 13
+    },
+    {
+      "file": "payments/payments.spec.ts",
+      "ms": 100681,
+      "tests": 33
+    },
+    {
+      "file": "admin/adminReverseWithdrawal.spec.ts",
+      "ms": 100131,
+      "tests": 15
+    },
+    {
+      "file": "admin/adminDummyData.spec.ts",
+      "ms": 100029,
+      "tests": 17
+    },
+    {
+      "file": "admin/adminWithdraw.spec.ts",
+      "ms": 99507,
+      "tests": 16
+    },
+    {
+      "file": "admin/adminWholesaleCustomer.spec.ts",
+      "ms": 98247,
+      "tests": 14
+    },
+    {
+      "file": "abuse-reports/abuseReportsSecurity.spec.ts",
+      "ms": 96944,
+      "tests": 9
+    },
+    {
+      "file": "admin/adminProductAdvertising.spec.ts",
+      "ms": 93805,
+      "tests": 15
+    },
+    {
+      "file": "seller-badges/sellerBadges.spec.ts",
+      "ms": 92200,
+      "tests": 21
+    },
+    {
+      "file": "admin/adminStoreReviews.spec.ts",
+      "ms": 91892,
+      "tests": 12
+    },
+    {
+      "file": "admin/adminDashboardHome.spec.ts",
+      "ms": 91602,
+      "tests": 14
+    },
+    {
+      "file": "request-for-quotes/newRequestedQuotes.spec.ts",
+      "ms": 90505,
+      "tests": 9
+    },
+    {
+      "file": "admin/adminVendorSingle.spec.ts",
+      "ms": 89974,
+      "tests": 14
+    },
+    {
+      "file": "stripe-express/stripeExpressAdvertisement.spec.ts",
+      "ms": 88997,
+      "tests": 2
+    },
+    {
+      "file": "admin/adminVendorSupport.spec.ts",
+      "ms": 88308,
+      "tests": 14
+    },
+    {
+      "file": "admin/adminAnnouncements.spec.ts",
+      "ms": 88175,
+      "tests": 13
+    },
+    {
+      "file": "admin/adminAbuseReports.spec.ts",
+      "ms": 87602,
+      "tests": 14
+    },
+    {
+      "file": "stripe-express/stripeExpressSecurity.spec.ts",
+      "ms": 87312,
+      "tests": 11
+    },
+    {
+      "file": "admin/adminRequestForQuote.spec.ts",
+      "ms": 86470,
+      "tests": 12
+    },
+    {
+      "file": "product-addons/newProductAddons.spec.ts",
+      "ms": 86037,
+      "tests": 7
+    },
+    {
+      "file": "reverse-withdraws/newReverseWithdraw.spec.ts",
+      "ms": 84481,
+      "tests": 10
+    },
+    {
+      "file": "reverse-withdraws/reverseWithdraws.spec.ts",
+      "ms": 77716,
+      "tests": 17
+    },
+    {
+      "file": "admin/adminSubscriptions.spec.ts",
+      "ms": 76046,
+      "tests": 12
+    },
+    {
+      "file": "product-addons/productAddons.spec.ts",
+      "ms": 74506,
+      "tests": 15
+    },
+    {
+      "file": "abuse-reports/abuseReportsCustomerForm.spec.ts",
+      "ms": 74186,
+      "tests": 11
+    },
+    {
+      "file": "setting/setting.spec.ts",
+      "ms": 72137,
+      "tests": 10
+    },
+    {
+      "file": "abuse-reports/abuseReportsModalDelete.spec.ts",
+      "ms": 71077,
+      "tests": 6
+    },
+    {
+      "file": "request-for-quotes/requestForQuotes.spec.ts",
+      "ms": 70344,
+      "tests": 23
+    },
+    {
+      "file": "store-reviews/newStoreReviews.spec.ts",
+      "ms": 69075,
+      "tests": 9
+    },
+    {
+      "file": "vendor-delivery-time/vendorDeliveryTime.spec.ts",
+      "ms": 67903,
+      "tests": 13
+    },
+    {
+      "file": "store-seo/newStoreSeo.spec.ts",
+      "ms": 66678,
+      "tests": 6
+    },
+    {
+      "file": "shipstation/newShipstation.spec.ts",
+      "ms": 66056,
+      "tests": 4
+    },
+    {
+      "file": "follow-store/newFollowers.spec.ts",
+      "ms": 65603,
+      "tests": 8
+    },
+    {
+      "file": "product-advertising/newProductAdvertising.spec.ts",
+      "ms": 63525,
+      "tests": 6
+    },
+    {
+      "file": "store-supports/storeSupports.spec.ts",
+      "ms": 63205,
+      "tests": 39
+    },
+    {
+      "file": "admin/adminLicense.spec.ts",
+      "ms": 61302,
+      "tests": 12
+    },
+    {
+      "file": "stores/stores.spec.ts",
+      "ms": 60539,
+      "tests": 18
+    },
+    {
+      "file": "product-reviews/productReviews.spec.ts",
+      "ms": 59890,
+      "tests": 12
+    },
+    {
+      "file": "announcements/newAnnouncements.spec.ts",
+      "ms": 59838,
+      "tests": 3
+    },
+    {
+      "file": "vendor-product-subscription/newUserSubscription.spec.ts",
+      "ms": 55030,
+      "tests": 6
+    },
+    {
+      "file": "products/newProductsProActions.spec.ts",
+      "ms": 54978,
+      "tests": 3
+    },
+    {
+      "file": "product-qa/productQA.spec.ts",
+      "ms": 54939,
+      "tests": 19
+    },
+    {
+      "file": "abuse-reports/abuseReportsList.spec.ts",
+      "ms": 54388,
+      "tests": 8
+    },
+    {
+      "file": "social-linking/newSocial.spec.ts",
+      "ms": 52810,
+      "tests": 5
+    },
+    {
+      "file": "product-advertising/productAdvertising.spec.ts",
+      "ms": 51595,
+      "tests": 14
+    },
+    {
+      "file": "admin/adminStatus.spec.ts",
+      "ms": 50884,
+      "tests": 11
+    },
+    {
+      "file": "withdraws/withdraws.spec.ts",
+      "ms": 50059,
+      "tests": 24
+    },
+    {
+      "file": "shipstation/shipstation.spec.ts",
+      "ms": 48865,
+      "tests": 6
+    },
+    {
+      "file": "stripe-express/stripeExpressVendorOnboarding.spec.ts",
+      "ms": 47187,
+      "tests": 5
+    },
+    {
+      "file": "vendor-settings/vendorSettings.spec.ts",
+      "ms": 45772,
+      "tests": 27
+    },
+    {
+      "file": "setup-guide/setupGuide.spec.ts",
+      "ms": 44920,
+      "tests": 5
+    },
+    {
+      "file": "customer/customer.spec.ts",
+      "ms": 44466,
+      "tests": 10
+    },
+    {
+      "file": "vendor-subscriptions/newSubscription.spec.ts",
+      "ms": 43400,
+      "tests": 6
+    },
+    {
+      "file": "eu-compliance/euCompliance.spec.ts",
+      "ms": 43136,
+      "tests": 21
+    },
+    {
+      "file": "orders/newOrdersGaps.spec.ts",
+      "ms": 40412,
+      "tests": 3
+    },
+    {
+      "file": "vendor/vendor.spec.ts",
+      "ms": 39960,
+      "tests": 8
+    },
+    {
+      "file": "printful/printful.spec.ts",
+      "ms": 39688,
+      "tests": 10
+    },
+    {
+      "file": "table-rate-shipping/newShippingRate.spec.ts",
+      "ms": 38522,
+      "tests": 4
+    },
+    {
       "file": "product-form-manager/newProductFormWholesale.spec.ts",
-      "ms": 38193,
+      "ms": 36731,
+      "tests": 2
+    },
+    {
+      "file": "vendor-shipping/vendorShipping.spec.ts",
+      "ms": 36543,
+      "tests": 4
+    },
+    {
+      "file": "admin/adminVerifications.spec.ts",
+      "ms": 34969,
+      "tests": 14
+    },
+    {
+      "file": "vendor-analytics/vendorAnalytics.spec.ts",
+      "ms": 34089,
+      "tests": 5
+    },
+    {
+      "file": "modules/modules.spec.ts",
+      "ms": 32933,
+      "tests": 10
+    },
+    {
+      "file": "vendor-return-request/vendorReturnRequest.spec.ts",
+      "ms": 32889,
+      "tests": 12
+    },
+    {
+      "file": "abuse-reports/abuseReportsPermissions.spec.ts",
+      "ms": 32746,
+      "tests": 10
+    },
+    {
+      "file": "wholesale/wholesale.spec.ts",
+      "ms": 31473,
+      "tests": 20
+    },
+    {
+      "file": "menu-manager/newMenuManager.spec.ts",
+      "ms": 30965,
+      "tests": 4
+    },
+    {
+      "file": "rank-math/rankMath.spec.ts",
+      "ms": 30694,
+      "tests": 16
+    },
+    {
+      "file": "vendor-product-subscription/vendorProductSubscription.spec.ts",
+      "ms": 30562,
+      "tests": 16
+    },
+    {
+      "file": "geolocation/geolocation.spec.ts",
+      "ms": 25705,
+      "tests": 15
+    },
+    {
+      "file": "colors/colors.spec.ts",
+      "ms": 24916,
+      "tests": 5
+    },
+    {
+      "file": "vendor-delivery-time/newDeliveryTime.spec.ts",
+      "ms": 24821,
+      "tests": 3
+    },
+    {
+      "file": "commission/commission.spec.ts",
+      "ms": 23128,
+      "tests": 3
+    },
+    {
+      "file": "withdraws/newWithdrawB15.spec.ts",
+      "ms": 23021,
+      "tests": 2
+    },
+    {
+      "file": "license/license.spec.ts",
+      "ms": 21946,
+      "tests": 4
+    },
+    {
+      "file": "intelligence/intelligence.spec.ts",
+      "ms": 21902,
+      "tests": 2
+    },
+    {
+      "file": "follow-store/followStore.spec.ts",
+      "ms": 21372,
+      "tests": 10
+    },
+    {
+      "file": "store-appearance/storeAppearance.spec.ts",
+      "ms": 21213,
+      "tests": 2
+    },
+    {
+      "file": "vendor-staff/vendorStaff.spec.ts",
+      "ms": 21056,
+      "tests": 11
+    },
+    {
+      "file": "product-variations/productVariations.spec.ts",
+      "ms": 20356,
+      "tests": 2
+    },
+    {
+      "file": "table-rate-shipping/tableRateShipping.spec.ts",
+      "ms": 20250,
+      "tests": 2
+    },
+    {
+      "file": "stripe-express/stripeExpressWallet.spec.ts",
+      "ms": 20145,
+      "tests": 5
+    },
+    {
+      "file": "store-seo/storeSeo.spec.ts",
+      "ms": 19704,
+      "tests": 2
+    },
+    {
+      "file": "export-import/exportImport.spec.ts",
+      "ms": 19622,
+      "tests": 2
+    },
+    {
+      "file": "social-linking/socialLinking.spec.ts",
+      "ms": 19407,
+      "tests": 2
+    },
+    {
+      "file": "store-listing/storeListing.spec.ts",
+      "ms": 19380,
+      "tests": 13
+    },
+    {
+      "file": "diagnostic-notice/diagnosticNotice.spec.ts",
+      "ms": 19263,
+      "tests": 2
+    },
+    {
+      "file": "product-bulk-edit/productBulkEdit.spec.ts",
+      "ms": 19192,
+      "tests": 2
+    },
+    {
+      "file": "manual-order-pro/manualOrderPro.spec.ts",
+      "ms": 19150,
       "tests": 2
     },
     {
       "file": "product-form-manager/newProductFormTypes.spec.ts",
-      "ms": 18080,
+      "ms": 18507,
       "tests": 1
     },
     {
-      "file": "product-form-manager/newProductForm.spec.ts",
-      "ms": 231217,
-      "tests": 13
-    },
-    {
-      "file": "product-form-manager/newProductFormEdit.spec.ts",
-      "ms": 411381,
-      "tests": 10
-    },
-    {
-      "file": "product-form-manager/productFormManagerAdmin.spec.ts",
-      "ms": 200260,
-      "tests": 35
-    },
-    {
-      "file": "product-form-manager/newProductFormAdvanced.spec.ts",
-      "ms": 149988,
-      "tests": 13
-    },
-    {
-      "file": "setting/setting.spec.ts",
-      "ms": 77095,
-      "tests": 11
-    },
-    {
-      "file": "social-linking/newSocial.spec.ts",
-      "ms": 51233,
-      "tests": 5
-    },
-    {
-      "file": "social-linking/socialLinking.spec.ts",
-      "ms": 18809,
-      "tests": 2
-    },
-    {
-      "file": "modules/modules.spec.ts",
-      "ms": 31468,
-      "tests": 10
-    },
-    {
-      "file": "follow-store/newFollowers.spec.ts",
-      "ms": 66000,
+      "file": "vendor-tools/vendorTools.spec.ts",
+      "ms": 18454,
       "tests": 9
     },
     {
-      "file": "follow-store/followStore.spec.ts",
-      "ms": 20834,
+      "file": "vendor-subscriptions/vendorSubscriptions.spec.ts",
+      "ms": 18365,
+      "tests": 16
+    },
+    {
+      "file": "catalog-mode/catalogMode.spec.ts",
+      "ms": 16810,
+      "tests": 5
+    },
+    {
+      "file": "refunds/refunds.spec.ts",
+      "ms": 15834,
+      "tests": 9
+    },
+    {
+      "file": "shortcodes/shortcodes.spec.ts",
+      "ms": 15394,
+      "tests": 13
+    },
+    {
+      "file": "spmv/spmv.spec.ts",
+      "ms": 15212,
+      "tests": 18
+    },
+    {
+      "file": "vendor-reports-admin/vendorReportsAdmin.spec.ts",
+      "ms": 14767,
       "tests": 10
     },
     {
+      "file": "single-store/singleStore.spec.ts",
+      "ms": 13700,
+      "tests": 9
+    },
+    {
+      "file": "adminDataViewsMigration.spec.ts",
+      "ms": 10089,
+      "tests": 19
+    },
+    {
+      "file": "min-max-quantities/minMaxQuantities.spec.ts",
+      "ms": 9364,
+      "tests": 3
+    },
+    {
+      "file": "plugin/plugin.spec.ts",
+      "ms": 9098,
+      "tests": 8
+    },
+    {
+      "file": "manual-order/manualOrder.spec.ts",
+      "ms": 8596,
+      "tests": 3
+    },
+    {
+      "file": "store-reviews/storeReviews.spec.ts",
+      "ms": 8485,
+      "tests": 17
+    },
+    {
+      "file": "product-tabs/productTabs.spec.ts",
+      "ms": 8457,
+      "tests": 2
+    },
+    {
+      "file": "notice-and-promotion/noticeAndPromotion.spec.ts",
+      "ms": 6969,
+      "tests": 2
+    },
+    {
+      "file": "help/help.spec.ts",
+      "ms": 6902,
+      "tests": 1
+    },
+    {
+      "file": "brand-filter/brandFilter.spec.ts",
+      "ms": 6160,
+      "tests": 2
+    },
+    {
       "file": "store-categories/storeCategories.spec.ts",
-      "ms": 5669,
-      "tests": 11
-    },
-    {
-      "file": "abuse-reports/abuseReportsCustomerForm.spec.ts",
-      "ms": 73193,
-      "tests": 14
-    },
-    {
-      "file": "abuse-reports/abuseReports.spec.ts",
-      "ms": 297800,
-      "tests": 44
-    },
-    {
-      "file": "abuse-reports/abuseReportsPermissions.spec.ts",
-      "ms": 32913,
+      "ms": 5707,
       "tests": 11
     },
     {
       "file": "abuse-reports/abuseReportsRest.spec.ts",
-      "ms": 4599,
+      "ms": 5624,
       "tests": 7
     },
     {
-      "file": "abuse-reports/abuseReportsSecurity.spec.ts",
-      "ms": 102481,
-      "tests": 9
-    },
-    {
-      "file": "abuse-reports/abuseReportsList.spec.ts",
-      "ms": 53829,
-      "tests": 8
-    },
-    {
-      "file": "abuse-reports/abuseReportsModalDelete.spec.ts",
-      "ms": 68473,
-      "tests": 6
-    },
-    {
-      "file": "abuse-reports/abuseReportsSettings.spec.ts",
-      "ms": 106999,
-      "tests": 9
-    },
-    {
-      "file": "reverse-withdraws/reverseWithdraws.spec.ts",
-      "ms": 79777,
-      "tests": 17
-    },
-    {
-      "file": "reverse-withdraws/newReverseWithdraw.spec.ts",
-      "ms": 86052,
-      "tests": 10
-    },
-    {
-      "file": "product-addons/newProductAddons.spec.ts",
-      "ms": 84582,
-      "tests": 7
-    },
-    {
-      "file": "product-addons/productAddons.spec.ts",
-      "ms": 75999,
-      "tests": 15
-    },
-    {
-      "file": "store-listing/storeListing.spec.ts",
-      "ms": 19471,
-      "tests": 13
-    },
-    {
-      "file": "request-for-quote-rules/requestForQuoteRules.spec.ts",
-      "ms": 58,
-      "tests": 7
-    },
-    {
-      "file": "shipstation/newShipstation.spec.ts",
-      "ms": 65207,
+      "file": "email-verification/emailVerification.spec.ts",
+      "ms": 5517,
       "tests": 4
     },
     {
-      "file": "shipstation/shipstation.spec.ts",
-      "ms": 49126,
-      "tests": 6
-    },
-    {
-      "file": "vendor-products/addProduct.spec.ts",
-      "ms": 191391,
-      "tests": 22
-    },
-    {
-      "file": "vendor-reports/vendorReports.spec.ts",
-      "ms": 120842,
-      "tests": 45
-    },
-    {
-      "file": "onboarding/onboarding.spec.ts",
-      "ms": 3641,
+      "file": "frontend-badges/frontendBadges.spec.ts",
+      "ms": 4444,
       "tests": 2
     },
     {
-      "file": "vendor-booking-fast/vendorBookingFast.spec.ts",
-      "ms": 165921,
-      "tests": 17
+      "file": "live-search/liveSearch.spec.ts",
+      "ms": 3766,
+      "tests": 7
     },
     {
-      "file": "help/help.spec.ts",
-      "ms": 7375,
-      "tests": 1
-    },
-    {
-      "file": "customer/customer.spec.ts",
-      "ms": 51983,
-      "tests": 10
-    },
-    {
-      "file": "vendor/vendor.spec.ts",
-      "ms": 40597,
-      "tests": 8
+      "file": "onboarding/onboarding.spec.ts",
+      "ms": 3630,
+      "tests": 2
     },
     {
       "file": "live-chat/liveChat.spec.ts",
-      "ms": 3184,
-      "tests": 13
+      "ms": 3123,
+      "tests": 12
     },
     {
-      "file": "vendor-subscriptions/vendorSubscriptions.spec.ts",
-      "ms": 18060,
-      "tests": 17
+      "file": "single-product/singleProduct.spec.ts",
+      "ms": 3045,
+      "tests": 8
     },
     {
-      "file": "vendor-subscriptions/newSubscription.spec.ts",
-      "ms": 43649,
+      "file": "privacy-policy/privacyPolicy.spec.ts",
+      "ms": 1494,
+      "tests": 4
+    },
+    {
+      "file": "products-details-bookings/productsDetailsBookings.spec.ts",
+      "ms": 274,
+      "tests": 2
+    },
+    {
+      "file": "product-enquiry/productEnquiry.spec.ts",
+      "ms": 151,
+      "tests": 4
+    },
+    {
+      "file": "shipping/shipping.spec.ts",
+      "ms": 88,
+      "tests": 10
+    },
+    {
+      "file": "shop/shop.spec.ts",
+      "ms": 54,
       "tests": 7
+    },
+    {
+      "file": "menu-manager/menuManager.spec.ts",
+      "ms": 53,
+      "tests": 8
+    },
+    {
+      "file": "request-for-quote-rules/requestForQuoteRules.spec.ts",
+      "ms": 50,
+      "tests": 6
+    },
+    {
+      "file": "my-orders/myOrders.spec.ts",
+      "ms": 42,
+      "tests": 6
+    },
+    {
+      "file": "stripe-express/stripeExpress3ds.spec.ts",
+      "ms": 42,
+      "tests": 5
+    },
+    {
+      "file": "seller-vacation/sellerVacation.spec.ts",
+      "ms": 23,
+      "tests": 2
+    },
+    {
+      "file": "tax/tax.spec.ts",
+      "ms": 23,
+      "tests": 2
+    },
+    {
+      "file": "stripe-express/stripeExpressPreflight.spec.ts",
+      "ms": 9,
+      "tests": 1
+    },
+    {
+      "file": "stripe-express/stripeExpressSubscriptions.spec.ts",
+      "ms": 6,
+      "tests": 11
+    },
+    {
+      "file": "admin/adminTools.spec.ts",
+      "ms": 0,
+      "tests": 16
+    },
+    {
+      "file": "tools/tools.spec.ts",
+      "ms": 0,
+      "tests": 9
+    },
+    {
+      "file": "visual/visual.spec.ts",
+      "ms": 0,
+      "tests": 57
     }
-  ],
-  "note": "rebuilt from REAL CI per-spec durations (run 29332121500); stripe-express uses clean test-count estimate (retry-inflated in CI); tools+adminTools floored (skipped)"
+  ]
 }


### PR DESCRIPTION
### Summary

Refreshes `tests/pw/utils/shard-durations.json` from the `shard-durations-baseline` artifact aggregated by [run 30346616808](https://github.com/getdokan/dokan/actions/runs/30346616808)'s merge-reports job — **with a skip-guard** (second commit): specs the source run recorded at under 1 s/test were *skipped* in that run, not fast, so they keep the larger of the fresh and prior baseline weights. Concretely that preserves ~29 min of real weight for `visual.spec.ts` (57 tests, recorded 0 ms), `stripeExpress3ds`, `stripeExpressPreflight`, `stripeExpressSubscriptions`, and the `tools`/`adminTools` floors the old file's `note` documented. The `note` field is restored and now also records the refresh rule: only regenerate from non-PR (nightly/dispatch) runs.

### Why

The committed baseline (2026-07-15) badly over-estimates the stripe-express specs that *did* execute — 13–22 min each in the baseline vs 2.6–10.6 min measured now (`stripeExpressWebhooks` alone: 22.0 → 6.5 min). The greedy bin-pack in `getShardSpecs.js` therefore front-loads those shards and the real durations come out lopsided: in run 30346616808 the slowest shard ran **35 min of tests** while the fastest ran ~18 min, making the whole matrix wait on a 39-minute tail job.

### Effect

Re-simulating the bin-pack against the measured durations:

| Packing baseline | Actual per-shard test minutes |
|---|---|
| old (committed) | 34.2, 29.5, 27.8, … 18.1 |
| refreshed (this PR) | ~24 across all 12 shards |

Slowest e2e job drops from ~39 min to ~29 min (24 min tests + ~4.5 min setup) — about 10 minutes off the wall-clock of every full run, with no coverage change. The skip-guarded specs add head-room on whichever shards they land on only when they actually execute.

New specs added since July 15 (e.g. `product-form-manager/newProductFormAuction.spec.ts`) are now measured instead of defaulting to the global mean. The `_*.setup.ts` entries in the aggregated file are inert — `getShardSpecs.js` only looks up weights for `*.spec.ts` files discovered on disk.

### Test

`node tests/pw/utils/getShardSpecs.js 9 12` resolves a spec list correctly with the new file.

https://claude.ai/code/session_01LXEChqUMQa2pybdkxzHasP