### PR TITLE
fix(product-list): show the real product type instead of labeling every unknown type Simple

### DIFF
--- a/src/dashboard/products/ProductList.tsx
+++ b/src/dashboard/products/ProductList.tsx
@@ -4,7 +4,17 @@ import { useToast } from '@getdokan/dokan-ui';
 import { addAction, applyFilters, removeAction } from '@wordpress/hooks';
 import { Fill } from '@wordpress/components';
 import { useNavigate } from 'react-router-dom';
-import { Boxes, Package, ExternalLink, LayoutGrid, Plus } from 'lucide-react';
+import {
+    Boxes,
+    Package,
+    ExternalLink,
+    LayoutGrid,
+    Plus,
+    RefreshCw,
+    Repeat,
+    Hammer,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import {
     DataViews,
     DokanBadge,
@@ -92,53 +102,80 @@ const getStatusLabel = ( status: string ) => {
     ) as string;
 };
 
+/**
+ * Product types the current vendor may use, as a `{ slug: label }` map.
+ *
+ * Localized from PHP through the `dokan_product_types` filter, so types that
+ * come from modules — subscriptions, auctions, … — carry their own translated
+ * label. Lite alone localizes a plain slug list, which yields an empty map.
+ */
+const getVendorProductTypes = (): Record< string, string > => {
+    const types = ( window as any ).dokan?.product_types;
+
+    return types && ! Array.isArray( types ) ? types : {};
+};
+
+const PRODUCT_TYPE_LABELS: Record< string, string > = {
+    simple: __( 'Simple', 'dokan-lite' ),
+    variable: __( 'Variable', 'dokan-lite' ),
+    grouped: __( 'Grouped', 'dokan-lite' ),
+    external: __( 'External/Affiliate', 'dokan-lite' ),
+};
+
+/**
+ * Icon per product type.
+ *
+ * Types owned by a module are listed too: the products keep their type when the
+ * module is deactivated, so this is the baseline that keeps such a row from
+ * looking like a simple product. A module that needs richer output (the auction
+ * one greys the icon for closed auctions) still overrides the whole cell
+ * through `dokan_product_list_table_fields`.
+ */
+const PRODUCT_TYPE_ICONS: Record< string, LucideIcon > = {
+    simple: Package,
+    variable: Boxes,
+    grouped: LayoutGrid,
+    external: ExternalLink,
+    subscription: RefreshCw,
+    'variable-subscription': Repeat,
+    // Matches the auction module's own icon, so toggling it doesn't change the
+    // glyph — only the extras the module layers on.
+    auction: Hammer,
+};
+
 const getProductTypeLabel = ( item: ProductItem ) => {
-    if ( item.type === 'grouped' ) {
-        return __( 'Grouped', 'dokan-lite' );
-    }
-    if ( item.type === 'external' ) {
-        return __( 'External/Affiliate', 'dokan-lite' );
-    }
-    if ( item.type === 'variable' ) {
-        return __( 'Variable', 'dokan-lite' );
-    }
-    return __( 'Simple', 'dokan-lite' );
+    // The REST payload is typed, not guaranteed: a row without a type must not
+    // take the whole listing down with it.
+    const type = item.type || 'simple';
+
+    const label =
+        PRODUCT_TYPE_LABELS[ type ] ??
+        getVendorProductTypes()[ type ] ??
+        // Unknown type: humanize the slug rather than mislabel it as Simple.
+        type.replace( /[-_]/g, ' ' ).replace( /^./, ( c ) => c.toUpperCase() );
+
+    /**
+     * Filter the human-readable label for a product type.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param {string} label Default label.
+     * @param {string} type  Product type slug.
+     */
+    return applyFilters( 'dokan_product_type_label', label, type ) as string;
 };
 
 const ProductTypeIcon = ( { item }: { item: ProductItem } ) => {
-    const cls = 'w-5 h-5 text-gray-500';
-    if ( item.type === 'variable' ) {
-        return <Boxes className={ cls } />;
-    }
-    if ( item.type === 'grouped' ) {
-        return <LayoutGrid className={ cls } />;
-    }
-    if ( item.type === 'external' ) {
-        return <ExternalLink className={ cls } />;
-    }
-    return <Package className={ cls } />;
+    const Icon = PRODUCT_TYPE_ICONS[ item.type ] ?? Package;
+
+    return <Icon className="w-5 h-5 text-gray-500" />;
 };
 
 // ── Product type options ──────────────────────────────────────────────────────
 
-const PRODUCT_TYPE_OPTIONS = [
-    {
-        value: 'simple',
-        label: __( 'Simple', 'dokan-lite' ),
-    },
-    {
-        value: 'variable',
-        label: __( 'Variable', 'dokan-lite' ),
-    },
-    {
-        value: 'grouped',
-        label: __( 'Grouped', 'dokan-lite' ),
-    },
-    {
-        value: 'external',
-        label: __( 'External/Affiliate', 'dokan-lite' ),
-    },
-];
+const PRODUCT_TYPE_OPTIONS = Object.entries( PRODUCT_TYPE_LABELS ).map(
+    ( [ value, label ] ) => ( { value, label } )
+);
 
 // ── Product listing localized data from PHP ───────────────────────────────────
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

The vendor dashboard product list (`/dashboard/new/#products/`) reported **every** product type it did not recognise as "Simple", with the `Package` icon. A vendor who created a subscription product saw it listed as a simple product.

`getProductTypeLabel()` branched on `grouped` / `external` / `variable` and returned `__( 'Simple' )` for everything else; `ProductTypeIcon()` did the same with `Package`. The legacy PHP row template never had this bug — [`products-listing-row.php`](https://github.com/getdokan/dokan/blob/develop/templates/products/products-listing-row.php) falls back to the type slug (`ucfirst()`) for types it does not know. The React port dropped that fallback.

This PR restores it and improves on it:

* **Label** resolves in three tiers — Lite's own labels → the vendor's localized `dokan_product_types` map → a humanized slug. The middle tier is the important one: that map is already localized to JS from PHP, so a module-registered type carries the module's own translated label (`subscription` → "Simple subscription"), with no per-type code in Lite and no duplicated strings.
* **Icon** becomes a map lookup, with entries for the module-owned types whose products remain in the catalog after the module is deactivated (`subscription`, `variable-subscription`, `auction`). `auction` uses the same `Hammer` glyph the auction module uses, so toggling that module doesn't change the icon — only the extras the module layers on top.
* **New filter** `dokan_product_type_label` for overrides, matching the existing `dokan_product_status_label` pattern.
* **Guard**: a row arriving without a `type` now falls back to `simple` rather than throwing inside the cell renderer and blanking the whole listing.
* `PRODUCT_TYPE_OPTIONS` is derived from the same label map instead of repeating the four strings, so the Type column and the Type filter cannot drift apart. Same four options, same order, same text domain — verified the strings still extract with `wp i18n make-pot`.

Modules that need richer output keep overriding the whole cell through `dokan_product_list_table_fields`, unchanged — the auction module still supplies its own tooltip and greys the icon for closed and failed auctions.

**No behaviour change for bookings.** `useProducts.ts` is untouched, so `exclude_types: [ 'booking' ]` is unchanged and booking products still never appear in this list. The booking module renders through its own `ProductsTab` component, which imports nothing from `ProductList`.

### Related Pull Request(s)

* N/A

### Closes

* Closes getdokan/plugin-internal-tasks#2183
### How to test the changes in this Pull Request:

1. Activate WooCommerce Subscriptions and the **Product Subscription** (`vsp`) module.
2. As a vendor, go to `/dashboard/new/#products/` and create a Simple subscription product.
3. **Before:** the Type column shows the simple-product icon, tooltip "Simple". **After:** a recurring icon, tooltip "Simple subscription".
4. Deactivate the `vsp` module and reload. The row stays correct — tooltip falls back to "Subscription" (the module's own translated string is gone with the module) and the icon remains the subscription glyph rather than reverting to the simple one.
5. Repeat with an auction product and the `simple-auction` module toggled off: the row shows a hammer and "Auction" instead of claiming to be Simple. With the module on, the auction module's own column override applies exactly as before.
6. Confirm the four core types (simple, variable, grouped, external) are unchanged in both the Type column and the Type filter dropdown.
7. Confirm booking products still do not appear in this list.

### Changelog entry

*Fix: vendor dashboard product list labelled every non-core product type as "Simple"*

Previously, the new vendor dashboard product list recognised only simple, variable, grouped and external products. Every other type — subscriptions, auctions and any type added by a module or third-party plugin — was displayed as "Simple" with the simple-product icon, so vendors could not tell what a product actually was.

Now the list shows the real product type. Types registered through `dokan_product_types` display the registering module's own translated label, and any other unrecognised type falls back to a readable name derived from its slug instead of being misreported as Simple. Product types whose module has been deactivated keep a meaningful icon, since their products remain in the catalog.

### Before Changes

A Simple subscription product listed in the vendor dashboard shows the simple-product icon with the tooltip "Simple". Auction products do the same.

### After Changes

The same product shows a recurring icon with the tooltip "Simple subscription"; auction products show a hammer with "Auction".

### PR Self Review Checklist:

* [x] Code follows the code style guidelines
* [x] Naming is clear
* [x] KISS — three-tier lookup with a documented reason for each tier
* [x] DRY — the four core labels exist once and feed both the column and the filter
* [x] Readable — the nested `if` chains are replaced by two lookup maps
* [x] No performance concerns — map lookups per row, no added requests
* [x] No grammar errors

### Notes for the reviewer

Two deliberate limitations, both matching the legacy template's behaviour:

1. The humanized-slug fallback is not translatable — there is no `__()` call site for a slug Lite has never seen. It applies only when no module has registered a label for that type. The legacy template has the identical gap (`ucfirst()` with no `__()`).
2. The Type **filter** dropdown still lists only the four core types plus whatever modules append via `dokan_product_list_type_options`. So a type whose module is deactivated is visible in the list but not filterable. Fixing that needs a server-side change and is out of scope here.

`PRODUCT_TYPE_ICONS` naming module-owned type slugs in Lite is a conscious trade-off: a deactivated module's JS never runs, so the module cannot supply an icon for products that still exist. The alternative — letting those rows fall back to the generic icon — reintroduces a milder version of the reported bug. A future `dokan_product_type_icon` filter would let modules own this properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product lists now support additional product types, including subscriptions, variable subscriptions, auctions, and other variants.
  * Product type icons and labels are displayed dynamically based on the available product types.
  * Unknown product types are presented with readable names instead of raw identifiers.
  * Product filters now automatically include all supported product types.
* **Bug Fixes**
  * Improved consistency between product type labels, icons, and filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
