### PR TITLE
fix(analytics): drop deprecated woocommerce_rest_api_option_permissions hook

### DIFF
--- a/includes/Analytics/Settings.php
+++ b/includes/Analytics/Settings.php
@@ -29,9 +29,43 @@ class Settings implements Hookable {
         $settings['isAnalyticsEnabled'] = ReportUtil::is_analytics_enabled();
         $settings['lastDayOfTheMonth']  = dokan_current_datetime()->format( 'Y-m-d' );
         $settings['firstDayOfTheMonth'] = dokan_current_datetime()->modify( 'first day of this month' )->format( 'Y-m-d' );
+        $settings['preloadOptions']     = $this->get_preload_options();
         $settings = array_merge( $settings, $this->load_data_endpoints() );
 
         return $settings;
+    }
+
+    /**
+     * Get the options hydrated into the client side options data store.
+     *
+     * WooCommerce resolves these options through `/wc-admin/options`, an endpoint
+     * vendors are not permitted to read. Hydrating the store on page load keeps the
+     * values available without the REST round trip.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return array Option name => option value.
+     */
+    protected function get_preload_options(): array {
+        /**
+         * Filters the option names hydrated into the vendor analytics options store.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array $option_names Option names to preload.
+         */
+        $option_names = apply_filters(
+            'dokan_analytics_reports_preload_options',
+            [ 'woocommerce_admin_install_timestamp' ]
+        );
+
+        $preloaded = [];
+
+        foreach ( $option_names as $option_name ) {
+            $preloaded[ $option_name ] = get_option( $option_name );
+        }
+
+        return $preloaded;
     }
 
     /**

--- a/includes/Analytics/Settings.php
+++ b/includes/Analytics/Settings.php
@@ -56,7 +56,10 @@ class Settings implements Hookable {
          */
         $option_names = apply_filters(
             'dokan_analytics_reports_preload_options',
-            [ 'woocommerce_admin_install_timestamp' ]
+            [
+                'woocommerce_admin_install_timestamp',
+                'woocommerce_date_type',
+            ]
         );
 
         $preloaded = [];

--- a/includes/Analytics/VendorDashboardManager.php
+++ b/includes/Analytics/VendorDashboardManager.php
@@ -4,7 +4,6 @@ namespace WeDevs\Dokan\Analytics;
 
 use WeDevs\Dokan\Contracts\Hookable;
 use WP_REST_Request;
-use WP_REST_Server;
 
 class VendorDashboardManager implements Hookable {
     public function register_hooks(): void {
@@ -18,8 +17,6 @@ class VendorDashboardManager implements Hookable {
         // add_filter( 'woocommerce_rest_report_orders_stats_schema', [ $this, 'revenue_stats_schema' ] );
 
         add_filter( 'woocommerce_rest_report_sort_performance_indicators', [ $this, 'sort_performance_indicators' ] );
-        // TODO: Need to review latest woocommerce release to resolve deprecated code usage.
-        add_filter( 'woocommerce_rest_api_option_permissions', [ $this, 'add_option_check_permissions' ], 10, 2 );
 
         add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ), 20 );
     }
@@ -46,16 +43,6 @@ class VendorDashboardManager implements Hookable {
             $current_user_id = dokan_get_current_user_id();
             $permission      = dokan_is_user_seller( $current_user_id );
         }
-
-        return $permission;
-    }
-
-    public function add_option_check_permissions( array $permission, WP_REST_Request $request ) {
-        if ( $request->get_method() !== WP_REST_Server::READABLE ) {
-            return $permission;
-        }
-
-        $permission['woocommerce_admin_install_timestamp'] = current_user_can( 'dokandar' );
 
         return $permission;
     }

--- a/src/vendor-dashboard/reports/index.js
+++ b/src/vendor-dashboard/reports/index.js
@@ -4,7 +4,10 @@
 import '@wordpress/notices';
 import { createRoot } from '@wordpress/element';
 
+import { dispatch } from '@wordpress/data';
+
 import {
+    OPTIONS_STORE_NAME,
     withCurrentUserHydration,
     withSettingsHydration,
     // @ts-ignore
@@ -25,9 +28,30 @@ const settingsGroup = 'wc_admin';
 const hydrateUser = getAdminSetting( 'currentUserData' );
 const mountElementId = 'dokan-analytics-app';
 
+/**
+ * Seed the options data store with the values localized by PHP.
+ *
+ * Vendors are not permitted to read `/wc-admin/options`, so any component that
+ * resolves an option through the store would fire a request that 403s. Hydrating
+ * from a component effect lands too late — children start resolution during the
+ * first render — so the store is seeded before the app mounts.
+ */
+const hydratePreloadedOptions = () => {
+    const preloadOptions = getAdminSetting( 'preloadOptions', {} );
+    const optionsStore = dispatch( OPTIONS_STORE_NAME );
+
+    Object.entries( preloadOptions ).forEach( ( [ name, value ] ) => {
+        optionsStore.startResolution( 'getOption', [ name ] );
+        optionsStore.receiveOptions( { [ name ]: value } );
+        optionsStore.finishResolution( 'getOption', [ name ] );
+    } );
+};
+
 domReady( () => {
     const appRoot = document.getElementById( mountElementId );
     if ( appRoot ) {
+        hydratePreloadedOptions();
+
         const root = createRoot( appRoot );
 
         let HydratedPageLayout = withSettingsHydration(

--- a/src/vendor-dashboard/reports/layout/index.js
+++ b/src/vendor-dashboard/reports/layout/index.js
@@ -268,12 +268,12 @@ const _PageLayout = () => {
     );
 };
 
+// Hydrated unconditionally: the vendor dashboard runs on the frontend, where
+// `window.wcSettings.admin` is absent, and vendors cannot read `/wc-admin/options`.
 export const PageLayout = compose(
-    window.wcSettings?.admin
-        ? withOptionsHydration( {
-              ...getAdminSetting( 'preloadOptions', {} ),
-          } )
-        : identity
+    withOptionsHydration( {
+        ...getAdminSetting( 'preloadOptions', {} ),
+    } )
 )( _PageLayout );
 
 const _EmbedLayout = () => (


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

`VendorDashboardManager` attached to `woocommerce_rest_api_option_permissions`, a filter WooCommerce deprecated in 6.3.0. WooCommerce fires it through `apply_filters_deprecated()`, which only calls `_deprecated_hook()` when something is listening — Dokan Lite was the only attacher in the tree, so Dokan's own listener was what flooded `debug.log` on every vendor analytics page load.

The filter existed to grant vendors read access to a single option:

```php
$permission['woocommerce_admin_install_timestamp'] = current_user_can( 'dokandar' );
```

`Automattic\WooCommerce\Admin\API\Options::get_default_option_permissions()` fills its whole legacy whitelist with one value — `Homescreen::is_admin_user()`, i.e. `edit_others_shop_orders || manage_woocommerce`. Vendors hold neither, so without the override `/wc-admin/options?options=woocommerce_admin_install_timestamp` returns `woocommerce_rest_cannot_view`. The request comes from `<CustomerEffortScoreModalContainer />`, rendered by the reports layout.

WooCommerce offers no replacement filter, and the entire `Options` controller is `@deprecated` since 6.2.0. The supported direction is to preload the value into the client store instead of authorizing a REST read, so this PR:

1. Adds `Settings::get_preload_options()`, exposing `preloadOptions` in `vendorSharedSettings`, behind a new `dokan_analytics_reports_preload_options` filter. Preloads `woocommerce_admin_install_timestamp` (read by CES) and `woocommerce_date_type` (read by the revenue table).
2. Seeds the options data store at app boot in `reports/index.js`, before `createRoot()`.
3. Drops the dead `window.wcSettings?.admin` gate on `withOptionsHydration` in the reports layout (that global only exists in wp-admin, so the HOC was always `identity` on the vendor dashboard).
4. Removes the deprecated `add_filter()` call and its now-unused `add_option_check_permissions()` callback and `WP_REST_Server` import.

Hydration had to move to app boot: `withOptionsHydration` seeds the store from a `useEffect`, which runs *after* children render, and CES starts resolution during that first render. A build with only steps 1 and 3 still fired the request — verified in the browser before adding step 2.

`woocommerce_date_type` is preloaded for the same reason. `analytics/report/revenue/table.js` resolves it through the options store, so the Revenue report fired a second `/wc-admin/options` request that 403s for vendors, leaving the table on its `date_paid` fallback. Confirmed in the browser on `/analytics/revenue` before and after.

Scope note: `woocommerce_ces_shown_for_actions` and `woocommerce_allow_tracking` still 403 for vendors, exactly as they did before this PR — they were never covered by the removed filter. Preloading them would make CES fully functional on the vendor dashboard, but that exposes store tracking preferences to vendors and belongs in its own PR.

### Related Pull Request(s)

* https://github.com/getdokan/dokan-pro/pull/6018

### Closes

* Closes getdokan/dokan-pro#5981

### How to test the changes in this Pull Request:

1. Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
2. Log in as a vendor whose account has no stray capabilities (a plain `seller` role — check `wp_capabilities` user meta for extras like `edit_others_shop_orders`, which would mask the behaviour).
3. Open the vendor dashboard analytics pages — both `/dashboard/reports/?path=%2Fanalytics%2Fproducts` and `/dashboard/reports/?path=%2Fanalytics%2Frevenue`.
4. DevTools → Network: there should be **no** request to `/wp-json/wc-admin/options` on either route. All `wc-analytics/*` requests return 200 and the reports render as before.
5. `tail -f wp-content/debug.log` — no `Hook woocommerce_rest_api_option_permissions is deprecated` entries.
6. In the console, `wp.data.select( 'wc/admin/options' ).getOption( 'woocommerce_admin_install_timestamp' )` returns the timestamp, and `hasFinishedResolution( 'getOption', [ 'woocommerce_admin_install_timestamp' ] )` is `true` — proving the store was hydrated rather than fetched.

### Changelog entry

*Fix: Stop the deprecated `woocommerce_rest_api_option_permissions` hook from flooding `debug.log` on vendor analytics pages*

Previously, every vendor dashboard analytics page load emitted several `PHP Deprecated: Hook woocommerce_rest_api_option_permissions is deprecated since version 6.3.0` notices, because Dokan attached to a WooCommerce filter removed from the supported API. The filter was needed only so vendors could read `woocommerce_admin_install_timestamp` over the REST options endpoint. Now that option is preloaded into the client-side data store when the analytics app boots, so the deprecated hook is gone, the REST round trip is gone, and the notices stop.

### Before Changes

`debug.log` on every analytics page load:

```
PHP Deprecated:  Hook woocommerce_rest_api_option_permissions is deprecated since version 6.3.0 with no alternative available. in /wp-includes/functions.php on line 6170
```

Network tab: `GET /wp-json/wc-admin/options?options=woocommerce_admin_install_timestamp` on every load — 200 for admins, `403 woocommerce_rest_cannot_view` for vendors once the deprecated filter is dropped.

### After Changes

No deprecation notices. No `/wc-admin/options` request. Reports render unchanged — verified on `/dashboard/reports/?path=%2Fanalytics%2Fproducts` with all five `wc-analytics/*` requests returning 200 and the options store resolved from hydration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Vendor dashboard reports now preload selected settings before rendering, improving initial dashboard loading and reducing unnecessary data requests.
  * Dashboard settings are hydrated consistently before the reports interface appears.

* **Bug Fixes**
  * Improved reliability of dashboard settings availability during initial load.
  * Removed outdated permission handling for vendor access to an installation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->