### PR TITLE
feat(blocks): add the single store page blocks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,6 +21,13 @@ settings, the REST `/stores` resource. Exactly one Store per Vendor — a facet 
 the Vendor, not a separate entity.
 _Avoid_: Shop, storefront
 
+**Store tab**:
+A named section of a Store's public page — Products and Terms and Conditions in
+Lite, plus Reviews and Biography with Pro. Extensions add tabs to a Store rather
+than pages beside it: every tab resolves to the same Store, distinguished by a
+query var.
+_Avoid_: Store page, vendor tab, store section
+
 ### Orders
 
 **Order**:

--- a/docs/adr/0005-store-header-blocks-emit-fresh-markup.md
+++ b/docs/adr/0005-store-header-blocks-emit-fresh-markup.md
@@ -1,0 +1,38 @@
+# Store header blocks emit fresh markup, not the classic store header template
+
+The FSE work for store pages follows a template-reuse-first principle: every block is
+server-rendered and reuses the Dokan template it replaces, so Pro and third parties keep
+working unchanged. The five header blocks — `dokan/store-name`, `dokan/store-banner`,
+`dokan/store-avatar`, `dokan/store-info` and `dokan/store-social` — are the deliberate
+exception. They emit their own markup, scoped to `.wp-block-dokan-*`, and ship their own
+styles with the standard colour, typography and spacing block supports enabled.
+
+Two things make reuse impossible here rather than merely inconvenient. `store-header.php`
+is a single monolithic tree, and its styles hang off a seven-level selector chain
+(`.dokan-single-store .profile-frame .profile-info-box .profile-info-summery-wrapper
+.profile-info-summery .profile-info .store-name`). Independent sibling blocks cannot
+reproduce one nesting chain between them. And those rules encode the classic layout's
+assumption that the header overlays the banner — the store name is `color: #fff` — while
+three of the four header patterns we ship move the name off the banner entirely, where
+that rule renders white on white.
+
+Consequences worth knowing before "fixing" any of this:
+
+- A block-built store page is **data**-identical to the classic page, not pixel-identical.
+  Acceptance criteria that say "compare against the classic store page" mean data parity.
+- `templates/store-header.php` and `assets/src/less/store.less` are untouched, so classic
+  themes render byte-identically. The two stylesheets are independent **by design** —
+  changes to `store.less` will not reach the blocks, and should not.
+- The `store_header_template` appearance option (`default`/`layout1`/`layout2`/`layout3`)
+  does not affect blocks. On block themes the equivalent choice is made by picking one of
+  the four header patterns in the Site Editor.
+- This ADR is scoped to the header. The composite blocks — `dokan/store-tab-content`, the
+  product sections, and the sidebar widget-parity blocks — *do* reuse their templates
+  verbatim, and every legacy action the classic templates fire still fires from the
+  equivalent block.
+
+The alternative was a `dokan/store-header` container block emitting the full wrapper chain
+with the five leaf blocks nested inside, which would have been pixel-identical for almost
+no new CSS. It was rejected because it locks the header into a single nesting — defeating
+the four freely-arranged header patterns that are the point of granular blocks — and
+carries the banner-overlay assumptions into every layout that does not have a banner.

--- a/docs/adr/0006-pro-store-tabs-render-as-bodies-not-template-takeovers.md
+++ b/docs/adr/0006-pro-store-tabs-render-as-bodies-not-template-takeovers.md
@@ -1,0 +1,37 @@
+# Pro store tabs render as tab bodies, not template takeovers
+
+Pro's Reviews and Biography tabs are implemented as `template_include` takeovers: when the
+tab's query var is present, `Store::store_review_template()` and
+`Store::load_vendor_biography_template()` return a whole classic template that calls
+`get_header( 'shop' )` / `get_footer( 'shop' )` and renders the store header itself. On
+block themes those templates are broken for exactly the reason `store.php` is — block
+themes ship no `header.php`/`footer.php` and WordPress no longer provides a theme-compat
+fallback.
+
+On block themes, Pro's tab callbacks now stand down and contribute only the tab **body**,
+through the `dokan_block_store_tab_content` action that `dokan/store-tab-content` fires.
+Lite owns the action and the page; Pro fills in a section of it. Classic themes keep the
+template takeover unchanged.
+
+Consequences worth knowing before "fixing" any of this:
+
+- Lite's `Rewrites::store_template()` and both Pro callbacks are all on `template_include`
+  at priority **99**. Lite registers first because Pro depends on it, so Pro's callback
+  runs *last* and wins. Pro standing down is therefore not optional — without it the
+  registered `dokan//single-store` block template is bypassed on every Pro tab URL, and
+  the guard must be Pro's own, not something Lite can impose.
+- The guard is the `dokan_use_store_block_template` filter (equivalently
+  `WeDevs\Dokan\Blocks\Templates::is_available()`), which Pro must call defensively so it
+  degrades to the classic path against a Lite version that does not define it.
+- The body of each classic template is extracted into its own partial so the classic and
+  block paths render from one source. Every hook fired inside those bodies keeps firing,
+  with unchanged signatures.
+- Any future Pro module adding a store tab must render through the action. A module that
+  reaches for `template_include` will silently bypass the block template again, and the
+  failure mode — an unstyled fragment on one tab only — is easy to miss in review.
+
+The alternatives were both worse. Leaving Pro untouched keeps a pre-existing bug, but once
+the rest of the store page renders correctly on block themes, two tabs dropping to an
+unstyled fragment reads as a regression we introduced. Filtering those tabs out of
+`dokan/store-tabs` so they are never offered would hide the breakage at the cost of
+silently removing two Pro features from every block-theme marketplace.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1280,6 +1280,56 @@ function dokan_get_store_tabs( $store_id ) {
 }
 
 /**
+ * Get the store tab the current request is viewing.
+ *
+ * The classic store page has no notion of an active tab — each tab is its own
+ * template takeover — so there is nothing to read. Block themes render every tab
+ * through one template, which means the tab navigation and the tab body both
+ * need to agree on which tab is current, from one source.
+ *
+ * Lite only knows its own tabs. Extensions that add a tab register their query
+ * var through the `dokan_current_store_tab` filter.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $store_id Store (vendor) id the tabs belong to.
+ *
+ * @return string A key from `dokan_get_store_tabs()`, or an empty string when the
+ *                request is not viewing that store's page.
+ */
+function dokan_get_current_store_tab( $store_id = 0 ) {
+    $store_id = absint( $store_id );
+    $tab      = '';
+
+    /*
+     * A store page is only "current" for the vendor it belongs to. A block pinned
+     * to another vendor sits on somebody else's store page, and must not adopt
+     * that page's active tab.
+     */
+    $viewed_slug = get_query_var( dokan_get_option( 'custom_store_url', 'dokan_general', 'store' ) );
+    $store_user  = $store_id ? get_userdata( $store_id ) : false;
+    $is_viewed   = ! empty( $viewed_slug ) && $store_user && $viewed_slug === $store_user->user_nicename;
+
+    if ( $is_viewed ) {
+        $tab = get_query_var( 'toc' ) ? 'terms_and_conditions' : 'products';
+    }
+
+    /**
+     * Filters the store tab the current request is viewing.
+     *
+     * Pro and third parties resolve their own tabs here — the query vars that
+     * mark them are registered outside Lite, so Lite cannot detect them.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $tab       Tab key, or an empty string outside a store page.
+     * @param int    $store_id  Store (vendor) id.
+     * @param bool   $is_viewed Whether this store's own page is being viewed.
+     */
+    return apply_filters( 'dokan_current_store_tab', $tab, $store_id, $is_viewed );
+}
+
+/**
  * Get withdraw email method based on seller ID and type
  *
  * @param int    $seller_id

--- a/patterns/single-store-default.php
+++ b/patterns/single-store-default.php
@@ -11,10 +11,16 @@
  * @package dokan
  * @since   DOKAN_SINCE
  *
- * The registered `dokan//single-store` block template renders this pattern, so
- * this file is the single source of truth for the default store layout. A
- * merchant swapping layouts replaces the header group above with one of the
- * other three header patterns; everything below it stays put.
+ * templates/block-templates/single-store.html deliberately does NOT reference
+ * this pattern, and its header differs by design: the template ships the panel
+ * header fully exploded so every block is selectable on first open (a
+ * `wp:pattern` reference gets stamped with `metadata.patternName` and
+ * content-locked, and the single `dokan/store-header` block seals its pieces).
+ * The cost, accepted knowingly: on the shipped template the Appearance ->
+ * Store Header Template setting has no effect until the site owner swaps the
+ * loose header for the `dokan/store-header` block. Keep the template's tabs +
+ * sidebar body in step with this pattern when the default layout changes; this
+ * pattern remains what gets inserted on ordinary pages.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/patterns/single-store-default.php
+++ b/patterns/single-store-default.php
@@ -51,16 +51,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
     <!-- wp:dokan/store-tabs {"align":"wide"} /-->
 
+    <?php
+    /*
+     * Sidebar first, at a third of the width: the arrangement every Elementor
+     * store template uses and the one the classic `store_layout` theme mod
+     * defaults to, so a store keeps the shape it already had. Kept as a PHP
+     * comment so it does not travel into the rendered page.
+     */
+    ?>
     <!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
     <div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40)">
-        <!-- wp:column {"width":"70%"} -->
-        <div class="wp-block-column" style="flex-basis:70%">
-            <!-- wp:dokan/store-tab-content /-->
-        </div>
-        <!-- /wp:column -->
-
-        <!-- wp:column {"width":"30%"} -->
-        <div class="wp-block-column" style="flex-basis:30%">
+        <!-- wp:column {"width":"33%"} -->
+        <div class="wp-block-column" style="flex-basis:33%">
             <!-- wp:dokan/store-sidebar -->
             <!-- wp:dokan/store-category-menu /-->
 
@@ -70,6 +72,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
             <!-- wp:dokan/store-contact-form /-->
             <!-- /wp:dokan/store-sidebar -->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"width":"67%"} -->
+        <div class="wp-block-column" style="flex-basis:67%">
+            <!-- wp:dokan/store-tab-content /-->
         </div>
         <!-- /wp:column -->
     </div>

--- a/patterns/single-store-default.php
+++ b/patterns/single-store-default.php
@@ -23,31 +23,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- wp:group {"align":"full","className":"dokan-single-store","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull dokan-single-store">
-    <!-- wp:dokan/store-banner {"align":"full"} /-->
-
-    <!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-    <div class="wp-block-columns alignwide are-vertically-aligned-center" style="margin-bottom:var(--wp--preset--spacing--40)">
-        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
-            <!-- wp:dokan/store-avatar {"shape":"circle","size":150} /-->
-        </div>
-        <!-- /wp:column -->
-
-        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-            <!-- wp:dokan/store-name {"level":1} /-->
-
-            <!-- wp:dokan/store-info /-->
-        </div>
-        <!-- /wp:column -->
-
-        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
-            <!-- wp:dokan/store-social /-->
-        </div>
-        <!-- /wp:column -->
-    </div>
-    <!-- /wp:columns -->
+    <?php
+    /*
+     * A single header block rather than the header's blocks loose, so changing
+     * layout is a dropdown in the block's sidebar — and, left on its default,
+     * follows the marketplace's Store Header Template setting. A merchant who
+     * wants to arrange the header themselves replaces this one block with any
+     * of the header patterns, which insert as ordinary editable blocks.
+     */
+    ?>
+    <!-- wp:dokan/store-header /-->
 
     <!-- wp:dokan/store-tabs {"align":"wide"} /-->
 

--- a/patterns/single-store-default.php
+++ b/patterns/single-store-default.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Title: Single Store Page
+ * Slug: dokan/single-store-default
+ * Description: A complete vendor store page: header, tab navigation, products and a store sidebar.
+ * Categories: dokan-store
+ * Block Types: dokan/store-tab-content
+ * Keywords: store, vendor, page, layout
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ *
+ * The registered `dokan//single-store` block template renders this pattern, so
+ * this file is the single source of truth for the default store layout. A
+ * merchant swapping layouts replaces the header group above with one of the
+ * other three header patterns; everything below it stays put.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"full","className":"dokan-single-store","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull dokan-single-store">
+    <!-- wp:dokan/store-banner {"align":"full"} /-->
+
+    <!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+    <div class="wp-block-columns alignwide are-vertically-aligned-center" style="margin-bottom:var(--wp--preset--spacing--40)">
+        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
+            <!-- wp:dokan/store-avatar {"shape":"circle","size":150} /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+            <!-- wp:dokan/store-name {"level":1} /-->
+
+            <!-- wp:dokan/store-info /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
+            <!-- wp:dokan/store-social /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+
+    <!-- wp:dokan/store-tabs {"align":"wide"} /-->
+
+    <!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+    <div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40)">
+        <!-- wp:column {"width":"70%"} -->
+        <div class="wp-block-column" style="flex-basis:70%">
+            <!-- wp:dokan/store-tab-content /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"width":"30%"} -->
+        <div class="wp-block-column" style="flex-basis:30%">
+            <!-- wp:dokan/store-sidebar -->
+            <!-- wp:dokan/store-category-menu /-->
+
+            <!-- wp:dokan/store-location-map /-->
+
+            <!-- wp:dokan/store-open-close-hours /-->
+
+            <!-- wp:dokan/store-contact-form /-->
+            <!-- /wp:dokan/store-sidebar -->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/single-store-header-default.php
+++ b/patterns/single-store-header-default.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Title: Store Header
+ * Slug: dokan/single-store-header-default
+ * Description: Store banner with the profile picture, name, info and social links below it.
+ * Categories: dokan-store
+ * Block Types: dokan/store-banner, dokan/store-name
+ * Keywords: store, vendor, header, banner
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"full","className":"dokan-single-store-header","style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull dokan-single-store-header" style="margin-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:dokan/store-banner {"align":"full"} /-->
+
+    <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+    <div class="wp-block-columns alignwide are-vertically-aligned-center">
+        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
+            <!-- wp:dokan/store-avatar {"shape":"circle","size":150} /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+            <!-- wp:dokan/store-name {"level":1} /-->
+
+            <!-- wp:dokan/store-info /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
+            <!-- wp:dokan/store-social /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/single-store-header-minimal.php
+++ b/patterns/single-store-header-minimal.php
@@ -20,15 +20,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wp-block-group alignwide dokan-single-store-header" style="margin-bottom:var(--wp--preset--spacing--50)">
     <!-- wp:columns {"verticalAlignment":"center"} -->
     <div class="wp-block-columns are-vertically-aligned-center">
-        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-            <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
+        <!-- wp:column {"verticalAlignment":"center","width":"65%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:65%">
+            <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"center"}} -->
             <div class="wp-block-group">
-                <!-- wp:dokan/store-avatar {"shape":"square","size":100} /-->
+                <!-- wp:dokan/store-avatar {"shape":"square","size":90} /-->
 
                 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
                 <div class="wp-block-group">
-                    <!-- wp:dokan/store-name {"level":1} /-->
+                    <!-- wp:dokan/store-name {"level":1,"style":{"typography":{"fontSize":"1.75rem"}}} /-->
 
                     <!-- wp:dokan/store-info /-->
                 </div>
@@ -38,8 +38,8 @@ if ( ! defined( 'ABSPATH' ) ) {
         </div>
         <!-- /wp:column -->
 
-        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+        <!-- wp:column {"verticalAlignment":"center","width":"35%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:35%">
             <!-- wp:dokan/store-social {"showLabels":false} /-->
         </div>
         <!-- /wp:column -->

--- a/patterns/single-store-header-minimal.php
+++ b/patterns/single-store-header-minimal.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Title: Store Header, No Banner
+ * Slug: dokan/single-store-header-minimal
+ * Description: A compact store header with no banner: profile picture, name and info on the left, social links on the right.
+ * Categories: dokan-store
+ * Block Types: dokan/store-name
+ * Keywords: store, vendor, header, compact
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"wide","className":"dokan-single-store-header","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide dokan-single-store-header" style="margin-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:columns {"verticalAlignment":"center"} -->
+    <div class="wp-block-columns are-vertically-aligned-center">
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+            <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
+            <div class="wp-block-group">
+                <!-- wp:dokan/store-avatar {"shape":"square","size":100} /-->
+
+                <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:dokan/store-name {"level":1} /-->
+
+                    <!-- wp:dokan/store-info /-->
+                </div>
+                <!-- /wp:group -->
+            </div>
+            <!-- /wp:group -->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+            <!-- wp:dokan/store-social {"showLabels":false} /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/single-store-header-panel.php
+++ b/patterns/single-store-header-panel.php
@@ -22,12 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 ?>
-<!-- wp:group {"align":"full","className":"dokan-single-store-header is-panel","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"0","bottom":"0"}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained","contentSize":"100%"}} -->
-<div class="wp-block-group alignfull dokan-single-store-header is-panel has-base-color has-contrast-background-color has-text-color has-background" style="padding-top:0;padding-bottom:0;margin-bottom:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"wide","className":"dokan-single-store-header is-panel","style":{"color":{"background":"#1f2937","text":"#ffffff"},"spacing":{"margin":{"bottom":"2.5rem"},"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide dokan-single-store-header is-panel has-text-color has-background" style="color:#ffffff;background-color:#1f2937;margin-bottom:2.5rem;padding-top:0;padding-bottom:0">
     <!-- wp:columns {"verticalAlignment":"stretch","isStackedOnMobile":true,"style":{"spacing":{"blockGap":{"left":"0"}}}} -->
     <div class="wp-block-columns are-vertically-aligned-stretch">
-        <!-- wp:column {"verticalAlignment":"center","width":"38%","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"}}} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:38%">
+        <!-- wp:column {"verticalAlignment":"center","width":"38%","style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem","left":"2rem","right":"2rem"},"blockGap":"1rem"}}} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="padding-top:2rem;padding-right:2rem;padding-bottom:2rem;padding-left:2rem;flex-basis:38%">
             <!-- wp:dokan/store-avatar {"shape":"circle","size":110} /-->
 
             <!-- wp:dokan/store-name {"level":1,"style":{"typography":{"fontSize":"1.75rem"}}} /-->

--- a/patterns/single-store-header-panel.php
+++ b/patterns/single-store-header-panel.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Title: Store Header, Panel
+ * Slug: dokan/single-store-header-panel
+ * Description: The classic default store header: a panel holding the profile picture, name and details beside the store banner.
+ * Categories: dokan-store
+ * Block Types: dokan/store-banner, dokan/store-name
+ * Keywords: store, vendor, header, panel, classic, default
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ *
+ * Stands in for the classic `store_header_template` "Default Layout", which is
+ * what every store using the classic template renders today. That layout floats
+ * the panel over the banner with a diagonal edge; blocks place the two side by
+ * side instead, which reads the same without the fixed-position markup the
+ * classic stylesheet needs. See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"full","className":"dokan-single-store-header is-panel","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"0","bottom":"0"}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained","contentSize":"100%"}} -->
+<div class="wp-block-group alignfull dokan-single-store-header is-panel has-base-color has-contrast-background-color has-text-color has-background" style="padding-top:0;padding-bottom:0;margin-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:columns {"verticalAlignment":"stretch","isStackedOnMobile":true,"style":{"spacing":{"blockGap":{"left":"0"}}}} -->
+    <div class="wp-block-columns are-vertically-aligned-stretch">
+        <!-- wp:column {"verticalAlignment":"center","width":"38%","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|20"}}} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);flex-basis:38%">
+            <!-- wp:dokan/store-avatar {"shape":"circle","size":110} /-->
+
+            <!-- wp:dokan/store-name {"level":1,"style":{"typography":{"fontSize":"1.75rem"}}} /-->
+
+            <!-- wp:dokan/store-info /-->
+
+            <!-- wp:dokan/store-social /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"stretch","width":"62%"} -->
+        <div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:62%">
+            <!-- wp:dokan/store-banner {"height":420} /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/single-store-header-split.php
+++ b/patterns/single-store-header-split.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Title: Store Header, Split
+ * Slug: dokan/single-store-header-split
+ * Description: A store header with no banner: a large profile picture beside the name, info and social links.
+ * Categories: dokan-store
+ * Block Types: dokan/store-name, dokan/store-avatar
+ * Keywords: store, vendor, header, split
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"wide","className":"dokan-single-store-header","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide dokan-single-store-header" style="margin-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:columns {"verticalAlignment":"center"} -->
+    <div class="wp-block-columns are-vertically-aligned-center">
+        <!-- wp:column {"verticalAlignment":"center","width":"30%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%">
+            <!-- wp:dokan/store-avatar {"shape":"circle","size":180} /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"center","width":"70%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:70%">
+            <!-- wp:dokan/store-name {"level":1} /-->
+
+            <!-- wp:dokan/store-info /-->
+
+            <!-- wp:dokan/store-social /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/single-store-header-stacked.php
+++ b/patterns/single-store-header-stacked.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Store Header, Stacked
+ * Slug: dokan/single-store-header-stacked
+ * Description: A centred store header: banner, then profile picture, name, info and social links stacked beneath it.
+ * Categories: dokan-store
+ * Block Types: dokan/store-banner, dokan/store-name
+ * Keywords: store, vendor, header, centered, stacked
+ * Viewport Width: 1200
+ *
+ * @package dokan
+ * @since   DOKAN_SINCE
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+<!-- wp:group {"align":"full","className":"dokan-single-store-header","style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull dokan-single-store-header" style="margin-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:dokan/store-banner {"align":"full"} /-->
+
+    <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+    <div class="wp-block-group">
+        <!-- wp:dokan/store-avatar {"shape":"circle","size":150,"align":"center"} /-->
+
+        <!-- wp:dokan/store-name {"level":1,"textAlign":"center"} /-->
+
+        <!-- wp:dokan/store-info /-->
+
+        <!-- wp:dokan/store-social /-->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/src/blocks/shared/ssr-edit.tsx
+++ b/src/blocks/shared/ssr-edit.tsx
@@ -1,9 +1,13 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { getBlockType } from '@wordpress/blocks';
+import { Button, Disabled, PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 
 type SSREditProps = {
     name: string;
     attributes: Record< string, unknown >;
+    setAttributes?: ( attrs: Record< string, unknown > ) => void;
     children?: any;
 };
 
@@ -11,18 +15,95 @@ type SSREditProps = {
  * Shared editor canvas for Dokan's dynamic store blocks: the server render
  * (with preview-vendor data outside a store context) plus optional
  * InspectorControls passed as children.
+ *
+ * The preview is wrapped in <Disabled> so its links, images and forms cannot
+ * swallow pointer events — a click anywhere on the block selects the block.
+ * The trade-off is that hover-driven previews (the store-hours popover) only
+ * behave on the front end.
+ *
+ * When setAttributes is passed, a "Reset block settings" control is appended
+ * to the inspector: it returns every attribute — including the style, colour
+ * and typography ones the block supports add — to its block.json default, the
+ * per-block counterpart of the template's own Reset.
  * @param root0
  * @param root0.name
  * @param root0.attributes
+ * @param root0.setAttributes
  * @param root0.children
  */
-const SSREdit = ( { name, attributes, children }: SSREditProps ) => {
+const SSREdit = ( {
+    name,
+    attributes,
+    setAttributes,
+    children,
+}: SSREditProps ) => {
     const blockProps = useBlockProps();
+
+    const resetAll = () => {
+        const type = getBlockType( name );
+
+        if ( ! type || ! setAttributes ) {
+            return;
+        }
+
+        /*
+         * Only the block's own settings reset. Every attribute these blocks
+         * declare carries a default, which is what separates them from the
+         * editor-injected ones (lock, metadata, className, align, style…) a
+         * reset must not touch — wiping those would unlock locked blocks and
+         * throw away template alignment. The pinned vendor survives too: it is
+         * a data binding, not a setting.
+         */
+        const defaults: Record< string, unknown > = {};
+
+        for ( const [ key, def ] of Object.entries( type.attributes ?? {} ) ) {
+            if ( key === 'storeId' ) {
+                continue;
+            }
+
+            if ( def && typeof def === 'object' && 'default' in def ) {
+                const value = ( def as { default: unknown } ).default;
+
+                if ( attributes[ key ] !== value ) {
+                    defaults[ key ] = value;
+                }
+            }
+        }
+
+        if ( Object.keys( defaults ).length ) {
+            setAttributes( defaults );
+        }
+    };
 
     return (
         <div { ...blockProps }>
             { children }
-            <ServerSideRender block={ name } attributes={ attributes } />
+            { setAttributes && (
+                <InspectorControls>
+                    <PanelBody
+                        title={ __( 'Reset', 'dokan-lite' ) }
+                        initialOpen={ false }
+                    >
+                        <Button
+                            variant="secondary"
+                            isDestructive
+                            onClick={ resetAll }
+                            __next40pxDefaultSize
+                        >
+                            { __( 'Reset block settings', 'dokan-lite' ) }
+                        </Button>
+                        <p>
+                            { __(
+                                'Returns this block\u2019s own settings to their defaults. The store selection is kept, and colors or typography set through the style panels reset from those panels.',
+                                'dokan-lite'
+                            ) }
+                        </p>
+                    </PanelBody>
+                </InspectorControls>
+            ) }
+            <Disabled>
+                <ServerSideRender block={ name } attributes={ attributes } />
+            </Disabled>
         </div>
     );
 };

--- a/src/blocks/store-avatar/block.json
+++ b/src/blocks/store-avatar/block.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-avatar",
+    "version": "1.0.0",
+    "title": "Store Profile Picture",
+    "category": "dokan",
+    "description": "Displays the vendor's store profile picture.",
+    "keywords": [
+        "dokan",
+        "store",
+        "vendor",
+        "avatar",
+        "profile",
+        "picture",
+        "logo"
+    ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "shape": {
+            "type": "string",
+            "default": "circle"
+        },
+        "size": {
+            "type": "number",
+            "default": 150
+        },
+        "isLink": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "left", "center", "right" ],
+        "shadow": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "style": true,
+            "width": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-avatar/index.tsx
+++ b/src/blocks/store-avatar/index.tsx
@@ -1,0 +1,67 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    RangeControl,
+    SelectControl,
+    ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody
+                    title={ __( 'Profile Picture Settings', 'dokan-lite' ) }
+                >
+                    <SelectControl
+                        label={ __( 'Shape', 'dokan-lite' ) }
+                        value={ attributes.shape ?? 'circle' }
+                        options={ [
+                            {
+                                value: 'circle',
+                                label: __( 'Circle', 'dokan-lite' ),
+                            },
+                            {
+                                value: 'square',
+                                label: __( 'Square', 'dokan-lite' ),
+                            },
+                        ] }
+                        onChange={ ( shape ) => setAttributes( { shape } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={ __( 'Size (px)', 'dokan-lite' ) }
+                        value={ attributes.size ?? 150 }
+                        onChange={ ( size ) =>
+                            setAttributes( { size: Number( size ) || 150 } )
+                        }
+                        min={ 32 }
+                        max={ 400 }
+                        step={ 2 }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={ __( 'Link to store page', 'dokan-lite' ) }
+                        checked={ !! attributes.isLink }
+                        onChange={ ( isLink ) => setAttributes( { isLink } ) }
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-avatar/index.tsx
+++ b/src/blocks/store-avatar/index.tsx
@@ -14,7 +14,11 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody
                     title={ __( 'Profile Picture Settings', 'dokan-lite' ) }

--- a/src/blocks/store-avatar/render.php
+++ b/src/blocks/store-avatar/render.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Render `dokan/store-avatar`.
+ *
+ * See docs/adr/0005-store-header-blocks-emit-fresh-markup.md for why this block
+ * does not reuse `templates/store-header.php`.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'shape'   => 'circle',
+        'size'    => 150,
+        'isLink'  => false,
+    ]
+);
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$avatar_url = $vendor->get_avatar();
+
+if ( empty( $avatar_url ) ) {
+    return;
+}
+
+// Attributes are client-supplied: clamp the size and allowlist the shape before
+// either reaches markup.
+$size      = min( 400, max( 32, absint( $attributes['size'] ) ) );
+$shape     = 'square' === $attributes['shape'] ? 'square' : 'circle';
+$avatar_id = absint( $vendor->get_avatar_id() );
+$alt       = $vendor->get_shop_name();
+$img_style = sprintf( 'width:%1$dpx;height:%1$dpx;', $size );
+
+if ( $avatar_id ) {
+    $image = wp_get_attachment_image(
+        $avatar_id,
+        [ $size, $size ],
+        false,
+        [
+            'class'    => 'wp-block-dokan-store-avatar__image',
+            'alt'      => $alt,
+            'style'    => $img_style,
+            'loading'  => 'lazy',
+            'decoding' => 'async',
+        ]
+    );
+} else {
+    // Gravatar or the marketplace default — a URL with no attachment behind it.
+    $image = sprintf(
+        '<img class="wp-block-dokan-store-avatar__image" src="%1$s" alt="%2$s" width="%3$d" height="%3$d" style="%4$s" loading="lazy" decoding="async">',
+        esc_url( $avatar_url ),
+        esc_attr( $alt ),
+        (int) $size,
+        esc_attr( $img_style )
+    );
+}
+
+if ( ! empty( $attributes['isLink'] ) ) {
+    $image = sprintf(
+        '<a class="wp-block-dokan-store-avatar__link" href="%1$s">%2$s</a>',
+        esc_url( $vendor->get_shop_url() ),
+        $image
+    );
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    wp_kses_data( get_block_wrapper_attributes( [ 'class' => 'is-shape-' . $shape ] ) ),
+    $image // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
+);

--- a/src/blocks/store-avatar/render.php
+++ b/src/blocks/store-avatar/render.php
@@ -28,6 +28,14 @@ $attributes = wp_parse_args(
     ]
 );
 
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );
 
@@ -83,6 +91,6 @@ if ( ! empty( $attributes['isLink'] ) ) {
 
 printf(
     '<div %1$s>%2$s</div>',
-    wp_kses_data( get_block_wrapper_attributes( [ 'class' => 'is-shape-' . $shape ] ) ),
+    get_block_wrapper_attributes( [ 'class' => 'is-shape-' . $shape ] ),
     $image // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 );

--- a/src/blocks/store-avatar/render.php
+++ b/src/blocks/store-avatar/render.php
@@ -34,7 +34,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-avatar/style.scss
+++ b/src/blocks/store-avatar/style.scss
@@ -1,0 +1,49 @@
+/*
+ * Front-end + editor styles for dokan/store-avatar.
+ *
+ * Ports only the round-mask idea from the classic `.profile-img-circle img`.
+ * The fixed 80px box, the white background and the square variant's white frame
+ * stay behind: the `size` attribute owns dimensions, the align support owns
+ * centring, and borders are the merchant's through block supports.
+ * See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ */
+
+.wp-block-dokan-store-avatar {
+	line-height: 0;
+
+	&__image {
+		display: block;
+		object-fit: cover;
+		border-radius: inherit;
+	}
+
+	&__link {
+		display: inline-block;
+		border-radius: inherit;
+	}
+
+	&.is-shape-circle {
+		.wp-block-dokan-store-avatar__image {
+			border-radius: 50%;
+		}
+	}
+
+	/* Align support centres the block itself; the image is inline-level inside it. */
+	&.aligncenter {
+		text-align: center;
+
+		.wp-block-dokan-store-avatar__image,
+		.wp-block-dokan-store-avatar__link {
+			margin-inline: auto;
+		}
+	}
+
+	&.alignright {
+		text-align: end;
+
+		.wp-block-dokan-store-avatar__image,
+		.wp-block-dokan-store-avatar__link {
+			margin-inline-start: auto;
+		}
+	}
+}

--- a/src/blocks/store-avatar/style.scss
+++ b/src/blocks/store-avatar/style.scss
@@ -23,12 +23,14 @@
 	}
 
 	&.is-shape-circle {
+
 		.wp-block-dokan-store-avatar__image {
 			border-radius: 50%;
 		}
 	}
 
-	/* Align support centres the block itself; the image is inline-level inside it. */
+	/* Align support centres the block itself; the image is inline-level inside it.
+	 * */
 	&.aligncenter {
 		text-align: center;
 

--- a/src/blocks/store-banner/block.json
+++ b/src/blocks/store-banner/block.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-banner",
+    "version": "1.0.0",
+    "title": "Store Banner",
+    "category": "dokan",
+    "description": "Displays the vendor's store banner image.",
+    "keywords": [ "dokan", "store", "vendor", "banner", "cover" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "height": {
+            "type": "number",
+            "default": 0
+        },
+        "isLink": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "wide", "full" ],
+        "shadow": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true,
+            "__experimentalDefaultControls": {
+                "radius": true
+            }
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-banner/block.json
+++ b/src/blocks/store-banner/block.json
@@ -21,6 +21,14 @@
         "isLink": {
             "type": "boolean",
             "default": false
+        },
+        "focalX": {
+            "type": "number",
+            "default": 50
+        },
+        "focalY": {
+            "type": "number",
+            "default": 50
         }
     },
     "supports": {

--- a/src/blocks/store-banner/index.tsx
+++ b/src/blocks/store-banner/index.tsx
@@ -1,0 +1,47 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Store Banner Settings', 'dokan-lite' ) }>
+                    <RangeControl
+                        label={ __( 'Height (px)', 'dokan-lite' ) }
+                        help={ __(
+                            'Set to 0 to use the marketplace default banner height.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.height ?? 0 }
+                        onChange={ ( height ) =>
+                            setAttributes( { height: Number( height ) || 0 } )
+                        }
+                        min={ 0 }
+                        max={ 800 }
+                        step={ 10 }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={ __( 'Link to store page', 'dokan-lite' ) }
+                        checked={ !! attributes.isLink }
+                        onChange={ ( isLink ) => setAttributes( { isLink } ) }
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-banner/index.tsx
+++ b/src/blocks/store-banner/index.tsx
@@ -9,7 +9,11 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody
                     title={ __( 'Store Banner Settings', 'dokan-lite' ) }
@@ -27,6 +31,38 @@ registerBlockType( metadata.name, {
                         min={ 0 }
                         max={ 800 }
                         step={ 10 }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={ __( 'Focal point — horizontal', 'dokan-lite' ) }
+                        help={ __(
+                            'Which part of the banner stays visible when it is cropped.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.focalX ?? 50 }
+                        onChange={ ( focalX ) => {
+                            const value = Number( focalX );
+                            setAttributes( {
+                                focalX: Number.isFinite( value ) ? value : 50,
+                            } );
+                        } }
+                        min={ 0 }
+                        max={ 100 }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={ __( 'Focal point — vertical', 'dokan-lite' ) }
+                        value={ attributes.focalY ?? 50 }
+                        onChange={ ( focalY ) => {
+                            const value = Number( focalY );
+                            setAttributes( {
+                                focalY: Number.isFinite( value ) ? value : 50,
+                            } );
+                        } }
+                        min={ 0 }
+                        max={ 100 }
                         __next40pxDefaultSize
                         __nextHasNoMarginBottom
                     />

--- a/src/blocks/store-banner/render.php
+++ b/src/blocks/store-banner/render.php
@@ -24,6 +24,8 @@ $attributes = wp_parse_args(
         'storeId' => 0,
         'height'  => 0,
         'isLink'  => false,
+        'focalX'  => 50,
+        'focalY'  => 50,
     ]
 );
 
@@ -70,7 +72,15 @@ if ( empty( $banner_url ) ) {
 
 $banner_id = absint( $vendor->get_banner_id() );
 $alt       = $vendor->get_shop_name();
-$img_style = sprintf( 'height:%dpx;', $height );
+
+// The banner crops through object-fit: cover; the focal point decides which
+// part of the image survives the crop, exactly as on the core Cover block.
+$img_style = sprintf(
+    'height:%1$dpx;object-position:%2$d%% %3$d%%;',
+    $height,
+    min( 100, max( 0, absint( $attributes['focalX'] ) ) ),
+    min( 100, max( 0, absint( $attributes['focalY'] ) ) )
+);
 
 if ( $banner_id ) {
     $image = wp_get_attachment_image(

--- a/src/blocks/store-banner/render.php
+++ b/src/blocks/store-banner/render.php
@@ -27,6 +27,14 @@ $attributes = wp_parse_args(
     ]
 );
 
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );
 
@@ -48,7 +56,7 @@ if ( empty( $banner_url ) ) {
 
     printf(
         '<div %1$s><div class="wp-block-dokan-store-banner__placeholder" style="height:%2$dpx">%3$s</div></div>',
-        wp_kses_data( get_block_wrapper_attributes() ),
+        get_block_wrapper_attributes(),
         (int) $height,
         esc_html__( 'Store banner', 'dokan-lite' )
     );
@@ -95,6 +103,6 @@ if ( ! empty( $attributes['isLink'] ) ) {
 
 printf(
     '<figure %1$s>%2$s</figure>',
-    wp_kses_data( get_block_wrapper_attributes() ),
+    get_block_wrapper_attributes(),
     $image // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 );

--- a/src/blocks/store-banner/render.php
+++ b/src/blocks/store-banner/render.php
@@ -33,7 +33,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-banner/render.php
+++ b/src/blocks/store-banner/render.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Render `dokan/store-banner`.
+ *
+ * See docs/adr/0005-store-header-blocks-emit-fresh-markup.md for why this block
+ * does not reuse `templates/store-header.php`.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'height'  => 0,
+        'isLink'  => false,
+    ]
+);
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$banner_url = $vendor->get_banner();
+$height     = absint( $attributes['height'] );
+$height     = $height > 0 ? $height : absint( dokan_get_vendor_store_banner_height() );
+$width      = absint( dokan_get_vendor_store_banner_width() );
+
+// A vendor with no banner renders nothing on the front end; the editor needs a
+// visible frame so the block can still be selected and positioned.
+if ( empty( $banner_url ) ) {
+    if ( ! $resolver->is_editor_preview() ) {
+        return;
+    }
+
+    printf(
+        '<div %1$s><div class="wp-block-dokan-store-banner__placeholder" style="height:%2$dpx">%3$s</div></div>',
+        wp_kses_data( get_block_wrapper_attributes() ),
+        (int) $height,
+        esc_html__( 'Store banner', 'dokan-lite' )
+    );
+
+    return;
+}
+
+$banner_id = absint( $vendor->get_banner_id() );
+$alt       = $vendor->get_shop_name();
+$img_style = sprintf( 'height:%dpx;', $height );
+
+if ( $banner_id ) {
+    $image = wp_get_attachment_image(
+        $banner_id,
+        'full',
+        false,
+        [
+            'class'    => 'wp-block-dokan-store-banner__image',
+            'alt'      => $alt,
+            'style'    => $img_style,
+            'loading'  => 'lazy',
+            'decoding' => 'async',
+        ]
+    );
+} else {
+    // Marketplace default banner (or the preview stand-in) — a URL with no attachment.
+    $image = sprintf(
+        '<img class="wp-block-dokan-store-banner__image" src="%1$s" alt="%2$s" width="%3$d" height="%4$d" style="%5$s" loading="lazy" decoding="async">',
+        esc_url( $banner_url ),
+        esc_attr( $alt ),
+        (int) $width,
+        (int) $height,
+        esc_attr( $img_style )
+    );
+}
+
+if ( ! empty( $attributes['isLink'] ) ) {
+    $image = sprintf(
+        '<a class="wp-block-dokan-store-banner__link" href="%1$s">%2$s</a>',
+        esc_url( $vendor->get_shop_url() ),
+        $image
+    );
+}
+
+printf(
+    '<figure %1$s>%2$s</figure>',
+    wp_kses_data( get_block_wrapper_attributes() ),
+    $image // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
+);

--- a/src/blocks/store-banner/style.scss
+++ b/src/blocks/store-banner/style.scss
@@ -1,0 +1,38 @@
+/*
+ * Front-end + editor styles for dokan/store-banner.
+ *
+ * Ports only the intent of the classic `.profile-info-img { width:100%; height:auto }`.
+ * The overlay plumbing around it in store.less — the `.dummy-image` CSS background,
+ * the `height:100% !important` of `profile-layout-default`, the absolute positioning —
+ * stays behind: PHP already resolves the default banner, and the block can sit in any
+ * layout. See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ */
+
+.wp-block-dokan-store-banner {
+	margin: 0;
+
+	&__image {
+		display: block;
+		width: 100%;
+		object-fit: cover;
+		border-radius: inherit;
+	}
+
+	&__link {
+		display: block;
+		border-radius: inherit;
+	}
+
+	/* Editor-only frame for a vendor with no banner, so the block stays selectable. */
+	&__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		min-height: 80px;
+		border: 1px dashed currentColor;
+		border-radius: inherit;
+		opacity: 0.6;
+		font-size: 0.875em;
+	}
+}

--- a/src/blocks/store-banner/style.scss
+++ b/src/blocks/store-banner/style.scss
@@ -1,10 +1,14 @@
 /*
  * Front-end + editor styles for dokan/store-banner.
  *
- * Ports only the intent of the classic `.profile-info-img { width:100%; height:auto }`.
- * The overlay plumbing around it in store.less — the `.dummy-image` CSS background,
- * the `height:100% !important` of `profile-layout-default`, the absolute positioning —
- * stays behind: PHP already resolves the default banner, and the block can sit in any
+ * Ports only the intent of the classic `.profile-info-img { width:100%;
+ * height:auto }`.
+ * The overlay plumbing around it in store.less — the `.dummy-image` CSS
+ * background,
+ * the `height:100% !important` of `profile-layout-default`, the absolute
+ * positioning —
+ * stays behind: PHP already resolves the default banner, and the block can sit
+ * in any
  * layout. See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
  */
 
@@ -23,14 +27,15 @@
 		border-radius: inherit;
 	}
 
-	/* Editor-only frame for a vendor with no banner, so the block stays selectable. */
+	/* Editor-only frame for a vendor with no banner, so the block stays
+	 * selectable. */
 	&__placeholder {
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		width: 100%;
 		min-height: 80px;
-		border: 1px dashed currentColor;
+		border: 1px dashed currentcolor;
 		border-radius: inherit;
 		opacity: 0.6;
 		font-size: 0.875em;

--- a/src/blocks/store-category-menu/block.json
+++ b/src/blocks/store-category-menu/block.json
@@ -6,7 +6,14 @@
     "title": "Store Categories",
     "category": "dokan",
     "description": "The product categories this vendor sells in.",
-    "keywords": ["dokan", "store", "vendor", "categories", "menu", "navigation"],
+    "keywords": [
+        "dokan",
+        "store",
+        "vendor",
+        "categories",
+        "menu",
+        "navigation"
+    ],
     "textdomain": "dokan-lite",
     "usesContext": [ "dokan/storeId" ],
     "attributes": {
@@ -17,6 +24,10 @@
         "title": {
             "type": "string",
             "default": ""
+        },
+        "showTitle": {
+            "type": "boolean",
+            "default": true
         }
     },
     "supports": {
@@ -28,7 +39,9 @@
         },
         "typography": {
             "fontSize": true,
-            "__experimentalDefaultControls": { "fontSize": true }
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
         },
         "spacing": {
             "margin": true,

--- a/src/blocks/store-category-menu/block.json
+++ b/src/blocks/store-category-menu/block.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-category-menu",
+    "version": "1.0.0",
+    "title": "Store Categories",
+    "category": "dokan",
+    "description": "The product categories this vendor sells in.",
+    "keywords": ["dokan", "store", "vendor", "categories", "menu", "navigation"],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "__experimentalDefaultControls": { "fontSize": true }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-category-menu/index.tsx
+++ b/src/blocks/store-category-menu/index.tsx
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
+                    <TextControl
+                        label={ __( 'Title', 'dokan-lite' ) }
+                        help={ __(
+                            'Leave empty to use the default title.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.title ?? '' }
+                        onChange={ ( title ) => setAttributes( { title } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-category-menu/index.tsx
+++ b/src/blocks/store-category-menu/index.tsx
@@ -1,6 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -9,20 +9,34 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
-                    <TextControl
-                        label={ __( 'Title', 'dokan-lite' ) }
-                        help={ __(
-                            'Leave empty to use the default title.',
-                            'dokan-lite'
-                        ) }
-                        value={ attributes.title ?? '' }
-                        onChange={ ( title ) => setAttributes( { title } ) }
-                        __next40pxDefaultSize
+                    <ToggleControl
+                        label={ __( 'Show title', 'dokan-lite' ) }
+                        checked={ !! attributes.showTitle }
+                        onChange={ ( showTitle ) =>
+                            setAttributes( { showTitle } )
+                        }
                         __nextHasNoMarginBottom
                     />
+                    { !! attributes.showTitle && (
+                        <TextControl
+                            label={ __( 'Title', 'dokan-lite' ) }
+                            help={ __(
+                                'Leave empty to use the default title.',
+                                'dokan-lite'
+                            ) }
+                            value={ attributes.title ?? '' }
+                            onChange={ ( title ) => setAttributes( { title } ) }
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                        />
+                    ) }
                 </PanelBody>
             </InspectorControls>
 

--- a/src/blocks/store-category-menu/render.php
+++ b/src/blocks/store-category-menu/render.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $attributes = wp_parse_args(
     $attributes,
     [
-        'storeId' => 0,
-        'title'   => '',
+        'storeId'   => 0,
+        'title'     => '',
+        'showTitle' => true,
     ]
 );
 
@@ -48,9 +49,18 @@ if ( ! $vendor ) {
     return; // Not a store context and not an editor preview — render nothing.
 }
 
-$widget_title = '' !== trim( (string) $attributes['title'] )
-    ? $attributes['title']
-    : __( 'Store Categories', 'dokan-lite' );
+/*
+ * An empty title is a one-way door without this toggle: the widget falls back
+ * to its default heading, so there would be no way to render it heading-less.
+ * The widgets themselves already suppress the heading for an empty title.
+ */
+$widget_title = '';
+
+if ( ! empty( $attributes['showTitle'] ) ) {
+    $widget_title = '' !== trim( (string) $attributes['title'] )
+        ? $attributes['title']
+        : __( 'Store Categories', 'dokan-lite' );
+}
 
 // The preview vendor has no id, so the widget would bail — show why instead.
 if ( ! $vendor->get_id() ) {

--- a/src/blocks/store-category-menu/render.php
+++ b/src/blocks/store-category-menu/render.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Render `dokan/store-category-menu`.
+ *
+ * Reuses the `StoreCategoryMenu` widget verbatim, so the markup, the settings it
+ * reads and the hooks it fires stay identical to the classic store sidebar.
+ * The widget gates on `dokan_is_store_page()` and reads the `author` query var,
+ * both of which `VendorResolver::render_in_store_context()` supplies — which is
+ * what lets the block work on an ordinary page with a pinned vendor.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'title'   => '',
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$widget_title = '' !== trim( (string) $attributes['title'] )
+    ? $attributes['title']
+    : __( 'Store Categories', 'dokan-lite' );
+
+// The preview vendor has no id, so the widget would bail — show why instead.
+if ( ! $vendor->get_id() ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+        esc_html__( 'The vendor\'s product categories appear here on the store page.', 'dokan-lite' )
+    );
+
+    return;
+}
+
+$widget_output = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $widget_title ) {
+        the_widget(
+            'WeDevs\\Dokan\\Widgets\\StoreCategoryMenu',
+            [ 'title' => $widget_title ],
+            [
+                'before_widget' => '<aside class="widget dokan-store-widget %1$s">',
+                'after_widget'  => '</aside>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+    }
+);
+
+if ( '' === trim( $widget_output ) ) {
+    return; // Nothing configured for this vendor — the classic sidebar shows nothing either.
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes(),
+    $widget_output // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped widget templates.
+);

--- a/src/blocks/store-category-menu/render.php
+++ b/src/blocks/store-category-menu/render.php
@@ -35,7 +35,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-category-menu/style.scss
+++ b/src/blocks/store-category-menu/style.scss
@@ -1,0 +1,22 @@
+/*
+ * Front-end + editor styles for dokan/store-category-menu.
+ *
+ * The widget markup is the classic one, so it keeps the classic
+ * `.widget.dokan-store-widget` classes and whatever styles those already carry.
+ * Only the block wrapper and the editor placeholder are styled here.
+ */
+
+.wp-block-dokan-store-category-menu {
+
+	.widget-title {
+		margin-block-start: 0;
+	}
+
+	&.is-editor-placeholder .dokan-info {
+		padding: 1.5em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-contact-form/block.json
+++ b/src/blocks/store-contact-form/block.json
@@ -6,7 +6,7 @@
     "title": "Store Contact Form",
     "category": "dokan",
     "description": "A form letting customers message the vendor.",
-    "keywords": ["dokan", "store", "vendor", "contact", "form", "message"],
+    "keywords": [ "dokan", "store", "vendor", "contact", "form", "message" ],
     "textdomain": "dokan-lite",
     "usesContext": [ "dokan/storeId" ],
     "attributes": {
@@ -17,6 +17,10 @@
         "title": {
             "type": "string",
             "default": ""
+        },
+        "showTitle": {
+            "type": "boolean",
+            "default": true
         }
     },
     "supports": {
@@ -28,7 +32,9 @@
         },
         "typography": {
             "fontSize": true,
-            "__experimentalDefaultControls": { "fontSize": true }
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
         },
         "spacing": {
             "margin": true,

--- a/src/blocks/store-contact-form/block.json
+++ b/src/blocks/store-contact-form/block.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-contact-form",
+    "version": "1.0.0",
+    "title": "Store Contact Form",
+    "category": "dokan",
+    "description": "A form letting customers message the vendor.",
+    "keywords": ["dokan", "store", "vendor", "contact", "form", "message"],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "__experimentalDefaultControls": { "fontSize": true }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-contact-form/index.tsx
+++ b/src/blocks/store-contact-form/index.tsx
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
+                    <TextControl
+                        label={ __( 'Title', 'dokan-lite' ) }
+                        help={ __(
+                            'Leave empty to use the default title.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.title ?? '' }
+                        onChange={ ( title ) => setAttributes( { title } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-contact-form/index.tsx
+++ b/src/blocks/store-contact-form/index.tsx
@@ -1,6 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -9,20 +9,34 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
-                    <TextControl
-                        label={ __( 'Title', 'dokan-lite' ) }
-                        help={ __(
-                            'Leave empty to use the default title.',
-                            'dokan-lite'
-                        ) }
-                        value={ attributes.title ?? '' }
-                        onChange={ ( title ) => setAttributes( { title } ) }
-                        __next40pxDefaultSize
+                    <ToggleControl
+                        label={ __( 'Show title', 'dokan-lite' ) }
+                        checked={ !! attributes.showTitle }
+                        onChange={ ( showTitle ) =>
+                            setAttributes( { showTitle } )
+                        }
                         __nextHasNoMarginBottom
                     />
+                    { !! attributes.showTitle && (
+                        <TextControl
+                            label={ __( 'Title', 'dokan-lite' ) }
+                            help={ __(
+                                'Leave empty to use the default title.',
+                                'dokan-lite'
+                            ) }
+                            value={ attributes.title ?? '' }
+                            onChange={ ( title ) => setAttributes( { title } ) }
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                        />
+                    ) }
                 </PanelBody>
             </InspectorControls>
 

--- a/src/blocks/store-contact-form/render.php
+++ b/src/blocks/store-contact-form/render.php
@@ -35,13 +35,36 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );
 
 if ( ! $vendor ) {
     return; // Not a store context and not an editor preview — render nothing.
+}
+
+/*
+ * "Contact Seller" is a marketplace-level switch. The widget itself does not
+ * check it — the classic sidebar gates the widget from outside, in
+ * dokan_store_sidebar_args() — so a block placing the widget directly has to
+ * apply the gate itself, or turning the feature off would leave the form
+ * reachable through any block-built store page.
+ */
+if ( 'on' !== dokan_get_option( 'contact_seller', 'dokan_general', 'on' ) ) {
+    if ( $resolver->is_editor_preview() ) {
+        printf(
+            '<div %1$s><p class="dokan-info">%2$s</p></div>',
+            get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+            esc_html__( 'Contacting vendors is switched off in Dokan settings, so this block will not appear on the store page.', 'dokan-lite' )
+        );
+    }
+
+    return;
 }
 
 $widget_title = '' !== trim( (string) $attributes['title'] )

--- a/src/blocks/store-contact-form/render.php
+++ b/src/blocks/store-contact-form/render.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Render `dokan/store-contact-form`.
+ *
+ * Reuses the `StoreContactForm` widget verbatim, so the markup, the settings it
+ * reads and the hooks it fires stay identical to the classic store sidebar.
+ * The widget gates on `dokan_is_store_page()` and reads the `author` query var,
+ * both of which `VendorResolver::render_in_store_context()` supplies — which is
+ * what lets the block work on an ordinary page with a pinned vendor.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'title'   => '',
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$widget_title = '' !== trim( (string) $attributes['title'] )
+    ? $attributes['title']
+    : __( 'Contact Vendor', 'dokan-lite' );
+
+// The preview vendor has no id, so the widget would bail — show why instead.
+if ( ! $vendor->get_id() ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+        esc_html__( 'The contact form appears here on the store page.', 'dokan-lite' )
+    );
+
+    return;
+}
+
+$widget_output = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $widget_title ) {
+        the_widget(
+            'WeDevs\\Dokan\\Widgets\\StoreContactForm',
+            [ 'title' => $widget_title ],
+            [
+                'before_widget' => '<aside class="widget dokan-store-widget %1$s">',
+                'after_widget'  => '</aside>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+    }
+);
+
+if ( '' === trim( $widget_output ) ) {
+    return; // Nothing configured for this vendor — the classic sidebar shows nothing either.
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes(),
+    $widget_output // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped widget templates.
+);

--- a/src/blocks/store-contact-form/render.php
+++ b/src/blocks/store-contact-form/render.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $attributes = wp_parse_args(
     $attributes,
     [
-        'storeId' => 0,
-        'title'   => '',
+        'storeId'   => 0,
+        'title'     => '',
+        'showTitle' => true,
     ]
 );
 
@@ -67,9 +68,18 @@ if ( 'on' !== dokan_get_option( 'contact_seller', 'dokan_general', 'on' ) ) {
     return;
 }
 
-$widget_title = '' !== trim( (string) $attributes['title'] )
-    ? $attributes['title']
-    : __( 'Contact Vendor', 'dokan-lite' );
+/*
+ * An empty title is a one-way door without this toggle: the widget falls back
+ * to its default heading, so there would be no way to render it heading-less.
+ * The widgets themselves already suppress the heading for an empty title.
+ */
+$widget_title = '';
+
+if ( ! empty( $attributes['showTitle'] ) ) {
+    $widget_title = '' !== trim( (string) $attributes['title'] )
+        ? $attributes['title']
+        : __( 'Contact Vendor', 'dokan-lite' );
+}
 
 // The preview vendor has no id, so the widget would bail — show why instead.
 if ( ! $vendor->get_id() ) {

--- a/src/blocks/store-contact-form/style.scss
+++ b/src/blocks/store-contact-form/style.scss
@@ -1,0 +1,22 @@
+/*
+ * Front-end + editor styles for dokan/store-contact-form.
+ *
+ * The widget markup is the classic one, so it keeps the classic
+ * `.widget.dokan-store-widget` classes and whatever styles those already carry.
+ * Only the block wrapper and the editor placeholder are styled here.
+ */
+
+.wp-block-dokan-store-contact-form {
+
+	.widget-title {
+		margin-block-start: 0;
+	}
+
+	&.is-editor-placeholder .dokan-info {
+		padding: 1.5em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-header/block.json
+++ b/src/blocks/store-header/block.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-header",
+    "version": "1.0.0",
+    "title": "Store Header",
+    "category": "dokan",
+    "description": "The store header, in any of the layouts a marketplace can choose from.",
+    "keywords": [ "dokan", "store", "vendor", "header", "layout", "banner" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "layout": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "wide", "full" ],
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-header/index.tsx
+++ b/src/blocks/store-header/index.tsx
@@ -1,0 +1,62 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+/*
+ * Switching layouts is a dropdown here rather than deleting the header and
+ * inserting a different pattern, which is the whole reason this block exists.
+ * The patterns remain for merchants who want to compose a header themselves.
+ */
+const LAYOUTS = [
+    {
+        value: '',
+        label: __( 'Use the marketplace default', 'dokan-lite' ),
+    },
+    { value: 'panel', label: __( 'Panel — beside the banner', 'dokan-lite' ) },
+    {
+        value: 'default',
+        label: __( 'Banner above, details below', 'dokan-lite' ),
+    },
+    { value: 'stacked', label: __( 'Stacked and centred', 'dokan-lite' ) },
+    { value: 'split', label: __( 'Split — no banner', 'dokan-lite' ) },
+    { value: 'minimal', label: __( 'Compact — no banner', 'dokan-lite' ) },
+];
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Header Layout', 'dokan-lite' ) }>
+                    <SelectControl
+                        label={ __( 'Layout', 'dokan-lite' ) }
+                        value={ attributes.layout ?? '' }
+                        options={ LAYOUTS }
+                        onChange={ ( layout ) => setAttributes( { layout } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+
+                    { ! attributes.layout && (
+                        <Notice status="info" isDismissible={ false }>
+                            { __(
+                                'Following the layout chosen in Dokan settings. Pick one here to override it for this template only.',
+                                'dokan-lite'
+                            ) }
+                        </Notice>
+                    ) }
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-header/index.tsx
+++ b/src/blocks/store-header/index.tsx
@@ -29,7 +29,11 @@ const LAYOUTS = [
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Header Layout', 'dokan-lite' ) }>
                     <SelectControl

--- a/src/blocks/store-header/render.php
+++ b/src/blocks/store-header/render.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Render `dokan/store-header`.
+ *
+ * One block that renders whichever store header layout the marketplace has
+ * chosen, so switching layouts is a dropdown rather than deleting blocks and
+ * inserting a pattern. It renders the header patterns themselves rather than
+ * reimplementing them, so the two can never drift apart.
+ *
+ * Precedence follows the rule the rest of the blocks use: the Appearance
+ * setting supplies the default, and the block attribute overrides it locally.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'layout'  => '',
+    ]
+);
+
+wp_enqueue_style( 'dokan-style' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$layout = sanitize_key( $attributes['layout'] );
+
+if ( '' === $layout ) {
+    /*
+     * Follow the classic Appearance setting, so a marketplace that picked a
+     * header before moving to a block theme keeps the look it had. The classic
+     * keys do not match the pattern names, because the classic "default" is the
+     * panel layout and the others shift along by one.
+     */
+    $classic = dokan_get_option( 'store_header_template', 'dokan_appearance', 'default' );
+
+    $layout = [
+        'default' => 'panel',
+        'layout1' => 'default',
+        'layout2' => 'stacked',
+        'layout3' => 'minimal',
+    ][ $classic ] ?? 'panel';
+}
+
+/**
+ * Header layouts this block can render, as pattern slug => label.
+ *
+ * Extensions add their own header patterns here to make them selectable from
+ * the block, without shipping a second copy of the markup.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array $layouts Map of layout key => registered pattern slug.
+ */
+$layouts = apply_filters(
+    'dokan_store_header_layouts',
+    [
+        'panel'   => 'dokan/single-store-header-panel',
+        'default' => 'dokan/single-store-header-default',
+        'stacked' => 'dokan/single-store-header-stacked',
+        'split'   => 'dokan/single-store-header-split',
+        'minimal' => 'dokan/single-store-header-minimal',
+    ]
+);
+
+if ( ! isset( $layouts[ $layout ] ) ) {
+    $layout = 'panel';
+}
+
+/*
+ * `dokan_store_header_layouts` is public, so a header pattern could be pointed
+ * at one that contains this block. Rendering that would recurse until memory
+ * runs out, which is a fatal rather than a broken layout — cheap to prevent.
+ */
+static $rendering = false;
+
+if ( $rendering ) {
+    return;
+}
+
+$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered( $layouts[ $layout ] );
+
+if ( ! $pattern || empty( $pattern['content'] ) ) {
+    return; // The pattern was deregistered — render nothing rather than a broken frame.
+}
+
+/*
+ * The pattern's blocks resolve their own vendor. Block context does not reach
+ * blocks parsed from a string, so run the whole thing in store context instead:
+ * that is what lets this block be pinned to a vendor on an ordinary page and
+ * have the header follow.
+ */
+$rendering = true;
+
+$header = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $pattern ) {
+        echo do_blocks( $pattern['content'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Rendered by the block renderer.
+    }
+);
+
+$rendering = false;
+
+if ( '' === trim( $header ) ) {
+    return;
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes( [ 'class' => 'is-header-' . $layout ] ),
+    $header // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Rendered by the block renderer.
+);

--- a/src/blocks/store-header/style.scss
+++ b/src/blocks/store-header/style.scss
@@ -1,0 +1,14 @@
+/*
+ * Front-end + editor styles for dokan/store-header.
+ *
+ * Almost nothing belongs here: the block renders one of the header patterns,
+ * and every visual rule already lives with the block that pattern contains.
+ * The layout class is exposed so a theme can target a specific arrangement.
+ */
+
+.wp-block-dokan-store-header {
+
+	> .wp-block-group:first-child:last-child {
+		margin-block: 0;
+	}
+}

--- a/src/blocks/store-info/block.json
+++ b/src/blocks/store-info/block.json
@@ -41,6 +41,14 @@
         "showOpenClose": {
             "type": "boolean",
             "default": true
+        },
+        "showIcons": {
+            "type": "boolean",
+            "default": true
+        },
+        "infoLayout": {
+            "type": "string",
+            "default": "list"
         }
     },
     "supports": {

--- a/src/blocks/store-info/block.json
+++ b/src/blocks/store-info/block.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-info",
+    "version": "1.0.0",
+    "title": "Store Info",
+    "category": "dokan",
+    "description": "Displays the vendor's address, phone, email, rating and opening hours.",
+    "keywords": [
+        "dokan",
+        "store",
+        "vendor",
+        "address",
+        "phone",
+        "rating",
+        "hours"
+    ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "showAddress": {
+            "type": "boolean",
+            "default": true
+        },
+        "showPhone": {
+            "type": "boolean",
+            "default": true
+        },
+        "showEmail": {
+            "type": "boolean",
+            "default": true
+        },
+        "showRating": {
+            "type": "boolean",
+            "default": true
+        },
+        "showOpenClose": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-info/index.tsx
+++ b/src/blocks/store-info/index.tsx
@@ -1,0 +1,51 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+const FIELDS = [
+    { key: 'showAddress', label: __( 'Show address', 'dokan-lite' ) },
+    { key: 'showPhone', label: __( 'Show phone', 'dokan-lite' ) },
+    { key: 'showEmail', label: __( 'Show email', 'dokan-lite' ) },
+    { key: 'showRating', label: __( 'Show rating', 'dokan-lite' ) },
+    { key: 'showOpenClose', label: __( 'Show opening hours', 'dokan-lite' ) },
+];
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Store Info Settings', 'dokan-lite' ) }>
+                    { FIELDS.map( ( field ) => (
+                        <ToggleControl
+                            key={ field.key }
+                            label={ field.label }
+                            checked={ !! attributes[ field.key ] }
+                            onChange={ ( value ) =>
+                                setAttributes( { [ field.key ]: value } )
+                            }
+                            __nextHasNoMarginBottom
+                        />
+                    ) ) }
+
+                    <Notice status="info" isDismissible={ false }>
+                        { __(
+                            'These toggles can only hide a field. Fields hidden by the marketplace privacy settings, or by the vendor, stay hidden regardless.',
+                            'dokan-lite'
+                        ) }
+                    </Notice>
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-info/index.tsx
+++ b/src/blocks/store-info/index.tsx
@@ -1,6 +1,11 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
+import {
+    PanelBody,
+    SelectControl,
+    ToggleControl,
+    Notice,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -17,7 +22,11 @@ const FIELDS = [
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Store Info Settings', 'dokan-lite' ) }>
                     { FIELDS.map( ( field ) => (
@@ -31,6 +40,34 @@ registerBlockType( metadata.name, {
                             __nextHasNoMarginBottom
                         />
                     ) ) }
+
+                    <ToggleControl
+                        label={ __( 'Show icons', 'dokan-lite' ) }
+                        checked={ !! attributes.showIcons }
+                        onChange={ ( showIcons ) =>
+                            setAttributes( { showIcons } )
+                        }
+                        __nextHasNoMarginBottom
+                    />
+                    <SelectControl
+                        label={ __( 'Layout', 'dokan-lite' ) }
+                        value={ attributes.infoLayout ?? 'list' }
+                        options={ [
+                            {
+                                value: 'list',
+                                label: __( 'List', 'dokan-lite' ),
+                            },
+                            {
+                                value: 'inline',
+                                label: __( 'Inline', 'dokan-lite' ),
+                            },
+                        ] }
+                        onChange={ ( infoLayout ) =>
+                            setAttributes( { infoLayout } )
+                        }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
 
                     <Notice status="info" isDismissible={ false }>
                         { __(

--- a/src/blocks/store-info/render.php
+++ b/src/blocks/store-info/render.php
@@ -31,6 +31,8 @@ $attributes = wp_parse_args(
         'showEmail'     => true,
         'showRating'    => true,
         'showOpenClose' => true,
+        'showIcons'     => true,
+        'infoLayout'    => 'list',
     ]
 );
 
@@ -56,13 +58,19 @@ if ( ! $vendor ) {
 $store_id = $vendor->get_id();
 $items    = '';
 
+// Icons are markup this block emits itself, so hiding them is a plain subtraction.
+$dokan_info_icon = static function ( $classes ) use ( $attributes ) {
+    return empty( $attributes['showIcons'] ) ? '' : '<i class="' . esc_attr( $classes ) . '"></i>';
+};
+
 // Address — admin privacy gate.
 if ( ! empty( $attributes['showAddress'] ) && ! dokan_is_vendor_info_hidden( 'address' ) ) {
     $store_address = dokan_get_seller_short_address( $store_id, false );
 
     if ( ! empty( $store_address ) ) {
         $items .= sprintf(
-            '<li class="dokan-store-address"><i class="fas fa-map-marker-alt"></i>%s</li>',
+            '<li class="dokan-store-address">%1$s%2$s</li>',
+            $dokan_info_icon( 'fas fa-map-marker-alt' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the closure.
             wp_kses_post( $store_address )
         );
     }
@@ -74,7 +82,8 @@ if ( ! empty( $attributes['showPhone'] ) && ! dokan_is_vendor_info_hidden( 'phon
 
     if ( ! empty( $phone ) ) {
         $items .= sprintf(
-            '<li class="dokan-store-phone"><i class="fas fa-mobile-alt"></i><a href="tel:%1$s">%2$s</a></li>',
+            '<li class="dokan-store-phone">%1$s<a href="tel:%2$s">%3$s</a></li>',
+            $dokan_info_icon( 'fas fa-mobile-alt' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the closure.
             esc_attr( $phone ),
             esc_html( $phone )
         );
@@ -87,7 +96,8 @@ if ( ! empty( $attributes['showEmail'] ) && ! dokan_is_vendor_info_hidden( 'emai
 
     if ( ! empty( $email ) ) {
         $items .= sprintf(
-            '<li class="dokan-store-email"><i class="far fa-envelope"></i><a href="mailto:%1$s">%1$s</a></li>',
+            '<li class="dokan-store-email">%1$s<a href="mailto:%2$s">%2$s</a></li>',
+            $dokan_info_icon( 'far fa-envelope' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the closure.
             esc_attr( antispambot( $email ) )
         );
     }
@@ -110,7 +120,8 @@ if ( ! empty( $attributes['showRating'] ) ) {
      * has to carry it. Scoped to this row so no other Woo rule applies.
      */
     $items .= sprintf(
-        '<li class="dokan-store-rating woocommerce"><i class="fas fa-star"></i>%s</li>',
+        '<li class="dokan-store-rating woocommerce">%1$s%2$s</li>',
+        $dokan_info_icon( 'fas fa-star' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the closure.
         wp_kses_post( $vendor->get_readable_rating( false ) )
     );
 }
@@ -147,8 +158,10 @@ if (
     $times = ob_get_clean();
 
     $items .= sprintf(
-        '<li class="dokan-store-open-close"><i class="fas fa-shopping-cart"></i><div class="store-open-close-notice"><span class="store-notice">%1$s</span><span class="fas fa-angle-down"></span>%2$s</div></li>',
+        '<li class="dokan-store-open-close">%1$s<div class="store-open-close-notice"><span class="store-notice">%2$s</span>%3$s%4$s</div></li>',
+        $dokan_info_icon( 'fas fa-shopping-cart' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the closure.
         esc_html( $notice ),
+        empty( $attributes['showIcons'] ) ? '' : '<span class="fas fa-angle-down"></span>',
         $times // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by the template part.
     );
 }
@@ -171,6 +184,8 @@ if ( '' === trim( $items ) ) {
 
 printf(
     '<ul %1$s>%2$s</ul>',
-    get_block_wrapper_attributes( [ 'class' => 'dokan-store-info' ] ),
+    get_block_wrapper_attributes(
+        [ 'class' => 'inline' === $attributes['infoLayout'] ? 'dokan-store-info is-inline' : 'dokan-store-info' ]
+    ),
     $items // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each item is escaped as it is built.
 );

--- a/src/blocks/store-info/render.php
+++ b/src/blocks/store-info/render.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Render `dokan/store-info`.
+ *
+ * Reproduces `ul.dokan-store-info` from `templates/store-header.php` as
+ * block-scoped markup. See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ *
+ * Every field carries the same server-side gate the classic template applies.
+ * Block attributes are client-supplied, so a toggle may only ever *subtract* a
+ * field — never reveal one the marketplace or the vendor has hidden.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId'       => 0,
+        'showAddress'   => true,
+        'showPhone'     => true,
+        'showEmail'     => true,
+        'showRating'    => true,
+        'showOpenClose' => true,
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$store_id = $vendor->get_id();
+$items    = '';
+
+// Address — admin privacy gate.
+if ( ! empty( $attributes['showAddress'] ) && ! dokan_is_vendor_info_hidden( 'address' ) ) {
+    $store_address = dokan_get_seller_short_address( $store_id, false );
+
+    if ( ! empty( $store_address ) ) {
+        $items .= sprintf(
+            '<li class="dokan-store-address"><i class="fas fa-map-marker-alt"></i>%s</li>',
+            wp_kses_post( $store_address )
+        );
+    }
+}
+
+// Phone — admin privacy gate.
+if ( ! empty( $attributes['showPhone'] ) && ! dokan_is_vendor_info_hidden( 'phone' ) ) {
+    $phone = $vendor->get_phone();
+
+    if ( ! empty( $phone ) ) {
+        $items .= sprintf(
+            '<li class="dokan-store-phone"><i class="fas fa-mobile-alt"></i><a href="tel:%1$s">%2$s</a></li>',
+            esc_attr( $phone ),
+            esc_html( $phone )
+        );
+    }
+}
+
+// Email — two independent gates: the admin privacy option and the vendor's own setting.
+if ( ! empty( $attributes['showEmail'] ) && ! dokan_is_vendor_info_hidden( 'email' ) && $vendor->show_email() ) {
+    $email = $vendor->get_email();
+
+    if ( ! empty( $email ) ) {
+        $items .= sprintf(
+            '<li class="dokan-store-email"><i class="far fa-envelope"></i><a href="mailto:%1$s">%1$s</a></li>',
+            esc_attr( antispambot( $email ) )
+        );
+    }
+}
+
+// Rating — the classic header has no server-side gate here, so do not invent one.
+if ( ! empty( $attributes['showRating'] ) ) {
+    $items .= sprintf(
+        '<li class="dokan-store-rating"><i class="fas fa-star"></i>%s</li>',
+        wp_kses_post( dokan_get_readable_seller_rating( $store_id ) )
+    );
+}
+
+// Opening hours — the marketplace appearance option AND the vendor's own toggle.
+if (
+    ! empty( $attributes['showOpenClose'] )
+    && 'on' === dokan_get_option( 'store_open_close', 'dokan_appearance', 'on' )
+    && $vendor->is_store_time_enabled()
+) {
+    $current_time = dokan_current_datetime();
+    $is_open      = dokan_is_store_open( $store_id );
+    $notice       = $is_open
+        ? $vendor->get_store_open_notice( __( 'Store Open', 'dokan-lite' ) )
+        : $vendor->get_store_close_notice( __( 'Store Closed', 'dokan-lite' ) );
+
+    ob_start();
+
+    // The weekly hours popover is the classic template verbatim — it is opened by a
+    // CSS :hover rule this block's stylesheet reproduces, so there is no script.
+    dokan_get_template_part(
+        'store-header-times',
+        '',
+        [
+            'dokan_store_times' => $vendor->get_store_time(),
+            'today'             => strtolower( $current_time->format( 'l' ) ),
+            'dokan_days'        => dokan_get_translated_days(),
+            'current_time'      => $current_time,
+            'times_heading'     => __( 'Weekly Store Timing', 'dokan-lite' ),
+            'closed_status'     => __( 'CLOSED', 'dokan-lite' ),
+        ]
+    );
+
+    $times = ob_get_clean();
+
+    $items .= sprintf(
+        '<li class="dokan-store-open-close"><i class="fas fa-shopping-cart"></i><div class="store-open-close-notice"><span class="store-notice">%1$s</span><span class="fas fa-angle-down"></span>%2$s</div></li>',
+        esc_html( $notice ),
+        $times // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by the template part.
+    );
+}
+
+/*
+ * Extensions add their own rows here — Pro's Germanized module is one. It fires
+ * unconditionally, exactly as the classic template does; its listeners apply
+ * their own privacy gates. Buffered so an otherwise-empty list can be detected.
+ */
+ob_start();
+
+/** This action is documented in templates/store-header.php */
+do_action( 'dokan_store_header_info_fields', $store_id );
+
+$items .= ob_get_clean();
+
+if ( '' === trim( $items ) ) {
+    return; // Every field is hidden — emit nothing rather than an empty list.
+}
+
+printf(
+    '<ul %1$s>%2$s</ul>',
+    get_block_wrapper_attributes( [ 'class' => 'dokan-store-info' ] ),
+    $items // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each item is escaped as it is built.
+);

--- a/src/blocks/store-info/render.php
+++ b/src/blocks/store-info/render.php
@@ -91,9 +91,14 @@ if ( ! empty( $attributes['showEmail'] ) && ! dokan_is_vendor_info_hidden( 'emai
 
 // Rating — the classic header has no server-side gate here, so do not invent one.
 if ( ! empty( $attributes['showRating'] ) ) {
+    /*
+     * Read through the resolved vendor rather than dokan_get_readable_seller_rating(),
+     * which builds a fresh Vendor from the id and would discard the preview stand-in —
+     * making the editor query real ratings for user 0 instead of showing dummy data.
+     */
     $items .= sprintf(
         '<li class="dokan-store-rating"><i class="fas fa-star"></i>%s</li>',
-        wp_kses_post( dokan_get_readable_seller_rating( $store_id ) )
+        wp_kses_post( $vendor->get_readable_rating( false ) )
     );
 }
 

--- a/src/blocks/store-info/render.php
+++ b/src/blocks/store-info/render.php
@@ -96,8 +96,15 @@ if ( ! empty( $attributes['showRating'] ) ) {
      * which builds a fresh Vendor from the id and would discard the preview stand-in —
      * making the editor query real ratings for user 0 instead of showing dummy data.
      */
+    /*
+     * The `woocommerce` class is load-bearing, not decoration: wc_get_rating_html()
+     * renders stars through `.woocommerce .star-rating`, and without that ancestor
+     * the element falls back to showing its own screen-reader text. The classic
+     * page inherits the class from store.php's `#dokan-content` wrapper; a block
+     * has to carry it itself. Scoped to this row so no other Woo rule applies.
+     */
     $items .= sprintf(
-        '<li class="dokan-store-rating"><i class="fas fa-star"></i>%s</li>',
+        '<li class="dokan-store-rating woocommerce"><i class="fas fa-star"></i>%s</li>',
         wp_kses_post( $vendor->get_readable_rating( false ) )
     );
 }

--- a/src/blocks/store-info/render.php
+++ b/src/blocks/store-info/render.php
@@ -40,7 +40,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );
@@ -92,16 +96,18 @@ if ( ! empty( $attributes['showEmail'] ) && ! dokan_is_vendor_info_hidden( 'emai
 // Rating — the classic header has no server-side gate here, so do not invent one.
 if ( ! empty( $attributes['showRating'] ) ) {
     /*
-     * Read through the resolved vendor rather than dokan_get_readable_seller_rating(),
-     * which builds a fresh Vendor from the id and would discard the preview stand-in —
-     * making the editor query real ratings for user 0 instead of showing dummy data.
-     */
-    /*
-     * The `woocommerce` class is load-bearing, not decoration: wc_get_rating_html()
-     * renders stars through `.woocommerce .star-rating`, and without that ancestor
-     * the element falls back to showing its own screen-reader text. The classic
+     * Two things here are load-bearing rather than incidental.
+     *
+     * The rating is read through the resolved vendor, not
+     * dokan_get_readable_seller_rating(), which builds a fresh Vendor from the id
+     * and would discard the preview stand-in — making the editor query real
+     * ratings for user 0 instead of showing dummy data.
+     *
+     * The `woocommerce` class is what lets wc_get_rating_html() draw stars:
+     * WooCommerce scopes them as `.woocommerce .star-rating`, and without that
+     * ancestor the element falls back to its own screen-reader text. The classic
      * page inherits the class from store.php's `#dokan-content` wrapper; a block
-     * has to carry it itself. Scoped to this row so no other Woo rule applies.
+     * has to carry it. Scoped to this row so no other Woo rule applies.
      */
     $items .= sprintf(
         '<li class="dokan-store-rating woocommerce"><i class="fas fa-star"></i>%s</li>',

--- a/src/blocks/store-info/style.scss
+++ b/src/blocks/store-info/style.scss
@@ -1,0 +1,103 @@
+/*
+ * Front-end + editor styles for dokan/store-info.
+ *
+ * The weekly-hours popover has to be reproduced here rather than inherited: the
+ * classic rule lives under `.dokan-single-store .profile-frame .profile-info-
+ * box
+ * ...`, a chain this block can never match. It stays CSS-only — `:hover` opens
+ * it,
+ * exactly as on the classic page, which is why this block ships no JavaScript.
+ * Written with logical properties so RTL mirrors without a separate rule.
+ */
+
+.wp-block-dokan-store-info {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	> li {
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+		margin: 0 0 0.5em;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+
+		i {
+			flex: 0 0 auto;
+		}
+	}
+
+	a {
+		color: inherit;
+	}
+
+	.store-open-close-notice {
+		display: flex;
+		align-items: center;
+		position: relative;
+		z-index: 1;
+
+		.store-notice {
+			min-width: 96px;
+		}
+
+		#vendor-store-times {
+			display: none;
+			position: absolute;
+			inset-block-start: 110%;
+			inset-inline-start: 0;
+			z-index: 1;
+			width: 310px;
+			max-height: 435px;
+			overflow: auto;
+			padding: 1.5em 2em;
+			color: #3e474f;
+			background: #fff;
+			border-radius: 6px;
+			box-shadow:
+				0 10px 15px -3px #00000040,
+				0 4px 6px -4px #00000010;
+			text-align: start;
+
+			.store-times-heading {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				gap: 0.5em;
+				margin: 10px 0 25px;
+
+				h4 {
+					margin: 0;
+				}
+			}
+
+			.store-time-tags {
+				display: flex;
+				align-items: baseline;
+				justify-content: space-between;
+				gap: 1em;
+				margin-block-end: 0.75em;
+
+				.store-days.current_day {
+					font-weight: 700;
+				}
+
+				.store-times {
+					text-align: end;
+				}
+
+				.store-close {
+					opacity: 0.7;
+				}
+			}
+		}
+
+		/* CSS-only disclosure, matching the classic store page. */
+		&:hover #vendor-store-times {
+			display: block;
+		}
+	}
+}

--- a/src/blocks/store-info/style.scss
+++ b/src/blocks/store-info/style.scss
@@ -15,19 +15,32 @@
 	margin: 0;
 	padding: 0;
 
+	/*
+	 * Deliberately not a flex container. The address and rating rows are built
+	 * by dokan_get_seller_short_address() and get_readable_rating(), which emit
+	 * several sibling spans; flex would make each one its own column and break
+	 * them onto separate lines as soon as the block sits in a narrow column.
+	 * Block-level rows let those spans flow inline, exactly as the classic
+	 * store header does.
+	 */
 	> li {
-		display: flex;
-		align-items: center;
-		gap: 0.5em;
 		margin: 0 0 0.5em;
 
 		&:last-child {
 			margin-bottom: 0;
 		}
 
-		i {
-			flex: 0 0 auto;
+		> i {
+			margin-inline-end: 0.5em;
 		}
+	}
+
+	/* Safe to lay out: every child of this row is markup the
+	   block itself emits. */
+	> li.dokan-store-open-close {
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
 	}
 
 	a {

--- a/src/blocks/store-info/style.scss
+++ b/src/blocks/store-info/style.scss
@@ -113,4 +113,18 @@
 			display: block;
 		}
 	}
+
+	/* Inline layout: fields flow in one row, wrapping as needed. Flex sits on
+	   the list itself — the rows are the flex items, so the multi-span fields
+	   inside each row still flow as text. */
+	&.is-inline {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5em 1.5em;
+
+		> li {
+			margin: 0;
+		}
+	}
 }

--- a/src/blocks/store-location-map/block.json
+++ b/src/blocks/store-location-map/block.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-location-map",
+    "version": "1.0.0",
+    "title": "Store Location",
+    "category": "dokan",
+    "description": "A map of the vendor's store location.",
+    "keywords": ["dokan", "store", "vendor", "location", "map", "address"],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "__experimentalDefaultControls": { "fontSize": true }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-location-map/block.json
+++ b/src/blocks/store-location-map/block.json
@@ -6,7 +6,7 @@
     "title": "Store Location",
     "category": "dokan",
     "description": "A map of the vendor's store location.",
-    "keywords": ["dokan", "store", "vendor", "location", "map", "address"],
+    "keywords": [ "dokan", "store", "vendor", "location", "map", "address" ],
     "textdomain": "dokan-lite",
     "usesContext": [ "dokan/storeId" ],
     "attributes": {
@@ -17,6 +17,10 @@
         "title": {
             "type": "string",
             "default": ""
+        },
+        "showTitle": {
+            "type": "boolean",
+            "default": true
         }
     },
     "supports": {
@@ -28,7 +32,9 @@
         },
         "typography": {
             "fontSize": true,
-            "__experimentalDefaultControls": { "fontSize": true }
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
         },
         "spacing": {
             "margin": true,

--- a/src/blocks/store-location-map/index.tsx
+++ b/src/blocks/store-location-map/index.tsx
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
+                    <TextControl
+                        label={ __( 'Title', 'dokan-lite' ) }
+                        help={ __(
+                            'Leave empty to use the default title.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.title ?? '' }
+                        onChange={ ( title ) => setAttributes( { title } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-location-map/index.tsx
+++ b/src/blocks/store-location-map/index.tsx
@@ -1,6 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -9,20 +9,34 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
-                    <TextControl
-                        label={ __( 'Title', 'dokan-lite' ) }
-                        help={ __(
-                            'Leave empty to use the default title.',
-                            'dokan-lite'
-                        ) }
-                        value={ attributes.title ?? '' }
-                        onChange={ ( title ) => setAttributes( { title } ) }
-                        __next40pxDefaultSize
+                    <ToggleControl
+                        label={ __( 'Show title', 'dokan-lite' ) }
+                        checked={ !! attributes.showTitle }
+                        onChange={ ( showTitle ) =>
+                            setAttributes( { showTitle } )
+                        }
                         __nextHasNoMarginBottom
                     />
+                    { !! attributes.showTitle && (
+                        <TextControl
+                            label={ __( 'Title', 'dokan-lite' ) }
+                            help={ __(
+                                'Leave empty to use the default title.',
+                                'dokan-lite'
+                            ) }
+                            value={ attributes.title ?? '' }
+                            onChange={ ( title ) => setAttributes( { title } ) }
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                        />
+                    ) }
                 </PanelBody>
             </InspectorControls>
 

--- a/src/blocks/store-location-map/render.php
+++ b/src/blocks/store-location-map/render.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Render `dokan/store-location-map`.
+ *
+ * Reuses the `StoreLocation` widget verbatim, so the markup, the settings it
+ * reads and the hooks it fires stay identical to the classic store sidebar.
+ * The widget gates on `dokan_is_store_page()` and reads the `author` query var,
+ * both of which `VendorResolver::render_in_store_context()` supplies — which is
+ * what lets the block work on an ordinary page with a pinned vendor.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'title'   => '',
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$widget_title = '' !== trim( (string) $attributes['title'] )
+    ? $attributes['title']
+    : __( 'Store Location', 'dokan-lite' );
+
+// The preview vendor has no id, so the widget would bail — show why instead.
+if ( ! $vendor->get_id() ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+        esc_html__( 'The store location map appears here on the store page. It needs a map API key in Dokan settings and a location on the vendor\'s profile.', 'dokan-lite' )
+    );
+
+    return;
+}
+
+$widget_output = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $widget_title ) {
+        the_widget(
+            'WeDevs\\Dokan\\Widgets\\StoreLocation',
+            [ 'title' => $widget_title ],
+            [
+                'before_widget' => '<aside class="widget dokan-store-widget %1$s">',
+                'after_widget'  => '</aside>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+    }
+);
+
+if ( '' === trim( $widget_output ) ) {
+    return; // Nothing configured for this vendor — the classic sidebar shows nothing either.
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes(),
+    $widget_output // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped widget templates.
+);

--- a/src/blocks/store-location-map/render.php
+++ b/src/blocks/store-location-map/render.php
@@ -35,7 +35,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-location-map/render.php
+++ b/src/blocks/store-location-map/render.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $attributes = wp_parse_args(
     $attributes,
     [
-        'storeId' => 0,
-        'title'   => '',
+        'storeId'   => 0,
+        'title'     => '',
+        'showTitle' => true,
     ]
 );
 
@@ -48,9 +49,18 @@ if ( ! $vendor ) {
     return; // Not a store context and not an editor preview — render nothing.
 }
 
-$widget_title = '' !== trim( (string) $attributes['title'] )
-    ? $attributes['title']
-    : __( 'Store Location', 'dokan-lite' );
+/*
+ * An empty title is a one-way door without this toggle: the widget falls back
+ * to its default heading, so there would be no way to render it heading-less.
+ * The widgets themselves already suppress the heading for an empty title.
+ */
+$widget_title = '';
+
+if ( ! empty( $attributes['showTitle'] ) ) {
+    $widget_title = '' !== trim( (string) $attributes['title'] )
+        ? $attributes['title']
+        : __( 'Store Location', 'dokan-lite' );
+}
 
 // The preview vendor has no id, so the widget would bail — show why instead.
 if ( ! $vendor->get_id() ) {

--- a/src/blocks/store-location-map/style.scss
+++ b/src/blocks/store-location-map/style.scss
@@ -1,0 +1,22 @@
+/*
+ * Front-end + editor styles for dokan/store-location-map.
+ *
+ * The widget markup is the classic one, so it keeps the classic
+ * `.widget.dokan-store-widget` classes and whatever styles those already carry.
+ * Only the block wrapper and the editor placeholder are styled here.
+ */
+
+.wp-block-dokan-store-location-map {
+
+	.widget-title {
+		margin-block-start: 0;
+	}
+
+	&.is-editor-placeholder .dokan-info {
+		padding: 1.5em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-name/block.json
+++ b/src/blocks/store-name/block.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-name",
+    "version": "1.0.0",
+    "title": "Store Name",
+    "category": "dokan",
+    "description": "Displays the vendor's store name as a heading.",
+    "keywords": [ "dokan", "store", "vendor", "name", "heading" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "level": {
+            "type": "number",
+            "default": 1
+        },
+        "isLink": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "anchor": true,
+        "html": false,
+        "align": [ "wide", "full" ],
+        "color": {
+            "text": true,
+            "background": true,
+            "gradients": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "textAlign": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalTextTransform": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true,
+                "textAlign": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-name/index.tsx
+++ b/src/blocks/store-name/index.tsx
@@ -1,0 +1,46 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+const LEVELS = [ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
+    value: String( level ),
+    label: `H${ level }`,
+} ) );
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Store Name Settings', 'dokan-lite' ) }>
+                    <SelectControl
+                        label={ __( 'Heading level', 'dokan-lite' ) }
+                        value={ String( attributes.level ?? 1 ) }
+                        options={ LEVELS }
+                        onChange={ ( level ) =>
+                            setAttributes( { level: Number( level ) } )
+                        }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={ __( 'Link to store page', 'dokan-lite' ) }
+                        checked={ !! attributes.isLink }
+                        onChange={ ( isLink ) => setAttributes( { isLink } ) }
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-name/index.tsx
+++ b/src/blocks/store-name/index.tsx
@@ -14,7 +14,11 @@ const LEVELS = [ 1, 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Store Name Settings', 'dokan-lite' ) }>
                     <SelectControl

--- a/src/blocks/store-name/render.php
+++ b/src/blocks/store-name/render.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Render `dokan/store-name`.
+ *
+ * Emits its own markup rather than reusing `templates/store-header.php`: that
+ * template is one monolithic tree whose styles hang off a seven-level selector
+ * chain no sibling block can reproduce. See
+ * docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'level'   => 1,
+        'isLink'  => false,
+    ]
+);
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$shop_name = $vendor->get_shop_name();
+
+if ( '' === trim( (string) $shop_name ) ) {
+    return;
+}
+
+$level        = absint( $attributes['level'] );
+$heading_tag  = in_array( $level, [ 1, 2, 3, 4, 5, 6 ], true ) ? 'h' . $level : 'h1';
+
+/*
+ * Pro's verification badge renders from this action, and the classic template
+ * passes the Vendor object — not a WP_User and not an id. The listener calls
+ * $vendor->get_id(), so anything else is fatal. Run it inside store context so
+ * callbacks that gate on dokan_is_store_page() still produce output when the
+ * block sits on an ordinary page.
+ */
+$after_name = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $vendor ) {
+        /** This action is documented in templates/store-header.php */
+        do_action( 'dokan_store_header_after_store_name', $vendor );
+    }
+);
+
+printf( '<%1$s %2$s>', esc_html( $heading_tag ), wp_kses_data( get_block_wrapper_attributes() ) );
+
+if ( ! empty( $attributes['isLink'] ) ) {
+    printf(
+        '<a class="wp-block-dokan-store-name__link" href="%1$s">%2$s</a>',
+        esc_url( $vendor->get_shop_url() ),
+        esc_html( $shop_name )
+    );
+} else {
+    echo esc_html( $shop_name );
+}
+
+echo $after_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+
+printf( '</%s>', esc_html( $heading_tag ) );

--- a/src/blocks/store-name/render.php
+++ b/src/blocks/store-name/render.php
@@ -29,6 +29,14 @@ $attributes = wp_parse_args(
     ]
 );
 
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );
 
@@ -60,7 +68,7 @@ $after_name = $resolver->render_in_store_context(
     }
 );
 
-printf( '<%1$s %2$s>', esc_html( $heading_tag ), wp_kses_data( get_block_wrapper_attributes() ) );
+printf( '<%1$s %2$s>', esc_html( $heading_tag ), get_block_wrapper_attributes() );
 
 if ( ! empty( $attributes['isLink'] ) ) {
     printf(

--- a/src/blocks/store-name/render.php
+++ b/src/blocks/store-name/render.php
@@ -35,7 +35,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-name/style.scss
+++ b/src/blocks/store-name/style.scss
@@ -2,10 +2,12 @@
  * Front-end + editor styles for dokan/store-name.
  *
  * Deliberately NOT a port of the classic `.store-name` rules: those live seven
- * levels deep under `.dokan-single-store .profile-frame ...` and are `color: #fff`
+ * levels deep under `.dokan-single-store .profile-frame ...` and are `color:
+ * #fff`
  * because the classic header overlays the banner. Three of the four header
  * patterns place the name off the banner, where inheriting that would render
- * white on white. Colour and typography are the merchant's, through block supports.
+ * white on white. Colour and typography are the merchant's, through block
+ * supports.
  */
 
 .wp-block-dokan-store-name {

--- a/src/blocks/store-name/style.scss
+++ b/src/blocks/store-name/style.scss
@@ -1,0 +1,32 @@
+/*
+ * Front-end + editor styles for dokan/store-name.
+ *
+ * Deliberately NOT a port of the classic `.store-name` rules: those live seven
+ * levels deep under `.dokan-single-store .profile-frame ...` and are `color: #fff`
+ * because the classic header overlays the banner. Three of the four header
+ * patterns place the name off the banner, where inheriting that would render
+ * white on white. Colour and typography are the merchant's, through block supports.
+ */
+
+.wp-block-dokan-store-name {
+	margin-block: 0;
+
+	/* The badge Pro appends via dokan_store_header_after_store_name sits inline
+	   with the name and must not inherit the heading's own font size. */
+	> img,
+	> svg,
+	> .dokan-verification-icon {
+		vertical-align: middle;
+		margin-inline-start: 0.35em;
+	}
+
+	&__link {
+		color: inherit;
+		text-decoration: inherit;
+
+		&:hover,
+		&:focus {
+			color: inherit;
+		}
+	}
+}

--- a/src/blocks/store-open-close-hours/block.json
+++ b/src/blocks/store-open-close-hours/block.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-open-close-hours",
+    "version": "1.0.0",
+    "title": "Store Opening Hours",
+    "category": "dokan",
+    "description": "The vendor's weekly opening hours.",
+    "keywords": ["dokan", "store", "vendor", "hours", "opening", "time", "schedule"],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": true
+        },
+        "typography": {
+            "fontSize": true,
+            "__experimentalDefaultControls": { "fontSize": true }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-open-close-hours/block.json
+++ b/src/blocks/store-open-close-hours/block.json
@@ -6,7 +6,15 @@
     "title": "Store Opening Hours",
     "category": "dokan",
     "description": "The vendor's weekly opening hours.",
-    "keywords": ["dokan", "store", "vendor", "hours", "opening", "time", "schedule"],
+    "keywords": [
+        "dokan",
+        "store",
+        "vendor",
+        "hours",
+        "opening",
+        "time",
+        "schedule"
+    ],
     "textdomain": "dokan-lite",
     "usesContext": [ "dokan/storeId" ],
     "attributes": {
@@ -17,6 +25,10 @@
         "title": {
             "type": "string",
             "default": ""
+        },
+        "showTitle": {
+            "type": "boolean",
+            "default": true
         }
     },
     "supports": {
@@ -28,7 +40,9 @@
         },
         "typography": {
             "fontSize": true,
-            "__experimentalDefaultControls": { "fontSize": true }
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
         },
         "spacing": {
             "margin": true,

--- a/src/blocks/store-open-close-hours/index.tsx
+++ b/src/blocks/store-open-close-hours/index.tsx
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
+                    <TextControl
+                        label={ __( 'Title', 'dokan-lite' ) }
+                        help={ __(
+                            'Leave empty to use the default title.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.title ?? '' }
+                        onChange={ ( title ) => setAttributes( { title } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-open-close-hours/index.tsx
+++ b/src/blocks/store-open-close-hours/index.tsx
@@ -1,6 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -9,20 +9,34 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Settings', 'dokan-lite' ) }>
-                    <TextControl
-                        label={ __( 'Title', 'dokan-lite' ) }
-                        help={ __(
-                            'Leave empty to use the default title.',
-                            'dokan-lite'
-                        ) }
-                        value={ attributes.title ?? '' }
-                        onChange={ ( title ) => setAttributes( { title } ) }
-                        __next40pxDefaultSize
+                    <ToggleControl
+                        label={ __( 'Show title', 'dokan-lite' ) }
+                        checked={ !! attributes.showTitle }
+                        onChange={ ( showTitle ) =>
+                            setAttributes( { showTitle } )
+                        }
                         __nextHasNoMarginBottom
                     />
+                    { !! attributes.showTitle && (
+                        <TextControl
+                            label={ __( 'Title', 'dokan-lite' ) }
+                            help={ __(
+                                'Leave empty to use the default title.',
+                                'dokan-lite'
+                            ) }
+                            value={ attributes.title ?? '' }
+                            onChange={ ( title ) => setAttributes( { title } ) }
+                            __next40pxDefaultSize
+                            __nextHasNoMarginBottom
+                        />
+                    ) }
                 </PanelBody>
             </InspectorControls>
 

--- a/src/blocks/store-open-close-hours/render.php
+++ b/src/blocks/store-open-close-hours/render.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Render `dokan/store-open-close-hours`.
+ *
+ * Reuses the `StoreOpenClose` widget verbatim, so the markup, the settings it
+ * reads and the hooks it fires stay identical to the classic store sidebar.
+ * The widget gates on `dokan_is_store_page()` and reads the `author` query var,
+ * both of which `VendorResolver::render_in_store_context()` supplies — which is
+ * what lets the block work on an ordinary page with a pinned vendor.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId' => 0,
+        'title'   => '',
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$widget_title = '' !== trim( (string) $attributes['title'] )
+    ? $attributes['title']
+    : __( 'Store Time', 'dokan-lite' );
+
+// The preview vendor has no id, so the widget would bail — show why instead.
+if ( ! $vendor->get_id() ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+        esc_html__( 'The vendor\'s opening hours appear here on the store page.', 'dokan-lite' )
+    );
+
+    return;
+}
+
+$widget_output = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $widget_title ) {
+        the_widget(
+            'WeDevs\\Dokan\\Widgets\\StoreOpenClose',
+            [ 'title' => $widget_title ],
+            [
+                'before_widget' => '<aside class="widget dokan-store-widget %1$s">',
+                'after_widget'  => '</aside>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+    }
+);
+
+if ( '' === trim( $widget_output ) ) {
+    return; // Nothing configured for this vendor — the classic sidebar shows nothing either.
+}
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes(),
+    $widget_output // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped widget templates.
+);

--- a/src/blocks/store-open-close-hours/render.php
+++ b/src/blocks/store-open-close-hours/render.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $attributes = wp_parse_args(
     $attributes,
     [
-        'storeId' => 0,
-        'title'   => '',
+        'storeId'   => 0,
+        'title'     => '',
+        'showTitle' => true,
     ]
 );
 
@@ -48,9 +49,18 @@ if ( ! $vendor ) {
     return; // Not a store context and not an editor preview — render nothing.
 }
 
-$widget_title = '' !== trim( (string) $attributes['title'] )
-    ? $attributes['title']
-    : __( 'Store Time', 'dokan-lite' );
+/*
+ * An empty title is a one-way door without this toggle: the widget falls back
+ * to its default heading, so there would be no way to render it heading-less.
+ * The widgets themselves already suppress the heading for an empty title.
+ */
+$widget_title = '';
+
+if ( ! empty( $attributes['showTitle'] ) ) {
+    $widget_title = '' !== trim( (string) $attributes['title'] )
+        ? $attributes['title']
+        : __( 'Store Time', 'dokan-lite' );
+}
 
 // The preview vendor has no id, so the widget would bail — show why instead.
 if ( ! $vendor->get_id() ) {

--- a/src/blocks/store-open-close-hours/render.php
+++ b/src/blocks/store-open-close-hours/render.php
@@ -35,7 +35,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-open-close-hours/style.scss
+++ b/src/blocks/store-open-close-hours/style.scss
@@ -1,0 +1,22 @@
+/*
+ * Front-end + editor styles for dokan/store-open-close-hours.
+ *
+ * The widget markup is the classic one, so it keeps the classic
+ * `.widget.dokan-store-widget` classes and whatever styles those already carry.
+ * Only the block wrapper and the editor placeholder are styled here.
+ */
+
+.wp-block-dokan-store-open-close-hours {
+
+	.widget-title {
+		margin-block-start: 0;
+	}
+
+	&.is-editor-placeholder .dokan-info {
+		padding: 1.5em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-product-section/block.json
+++ b/src/blocks/store-product-section/block.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-product-section",
+    "version": "1.0.0",
+    "title": "Store Product Section",
+    "category": "dokan",
+    "description": "A curated section of the vendor's products: featured, latest, best selling or top rated.",
+    "keywords": [
+        "dokan",
+        "store",
+        "vendor",
+        "products",
+        "featured",
+        "latest",
+        "best selling",
+        "top rated"
+    ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "sectionId": {
+            "type": "string",
+            "default": "featured"
+        },
+        "title": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "wide", "full" ],
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-product-section/index.tsx
+++ b/src/blocks/store-product-section/index.tsx
@@ -24,7 +24,11 @@ const SECTIONS = [
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody
                     title={ __( 'Product Section Settings', 'dokan-lite' ) }

--- a/src/blocks/store-product-section/index.tsx
+++ b/src/blocks/store-product-section/index.tsx
@@ -1,0 +1,70 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    SelectControl,
+    TextControl,
+    Notice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+const SECTIONS = [
+    { value: 'featured', label: __( 'Featured Products', 'dokan-lite' ) },
+    { value: 'latest', label: __( 'Latest Products', 'dokan-lite' ) },
+    {
+        value: 'best_selling',
+        label: __( 'Best Selling Products', 'dokan-lite' ),
+    },
+    { value: 'top_rated', label: __( 'Top Rated Products', 'dokan-lite' ) },
+];
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody
+                    title={ __( 'Product Section Settings', 'dokan-lite' ) }
+                >
+                    <SelectControl
+                        label={ __( 'Section', 'dokan-lite' ) }
+                        value={ attributes.sectionId ?? 'featured' }
+                        options={ SECTIONS }
+                        onChange={ ( sectionId ) =>
+                            setAttributes( { sectionId } )
+                        }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <TextControl
+                        label={ __( 'Heading', 'dokan-lite' ) }
+                        help={ __(
+                            'Leave empty to use the section default.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.title ?? '' }
+                        onChange={ ( title ) => setAttributes( { title } ) }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+
+                    <Notice status="warning" isDismissible={ false }>
+                        { __(
+                            'Store pages already render every enabled product section automatically, above the product grid. To place this section yourself, first hide it under Appearance → Customize → Store, or it will appear twice.',
+                            'dokan-lite'
+                        ) }
+                    </Notice>
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-product-section/render.php
+++ b/src/blocks/store-product-section/render.php
@@ -40,7 +40,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-product-section/render.php
+++ b/src/blocks/store-product-section/render.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Render `dokan/store-product-section`.
+ *
+ * Reuses `templates/store-products-section.php`, so the section markup and its
+ * two dynamic actions are identical to the ones the classic store page renders
+ * from `dokan_store_profile_frame_after`.
+ *
+ * This block does NOT fire `dokan_store_profile_frame_after` itself: the
+ * ProductSections manager is already attached to it at priority 20 and would
+ * render every enabled section again. The block exists for merchants who want
+ * to place a section explicitly — see the editor notice about the overlap.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+use WeDevs\Dokan\ProductSections\AbstractProductSection;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId'   => 0,
+        'sectionId' => 'featured',
+        'title'     => '',
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$section_id = sanitize_key( $attributes['sectionId'] );
+$section    = dokan()->product_sections->{$section_id} ?? null;
+
+$dokan_section_placeholder = static function ( $message ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        get_block_wrapper_attributes( [ 'class' => 'is-editor-placeholder' ] ),
+        esc_html( $message )
+    );
+};
+
+if ( ! $section instanceof AbstractProductSection ) {
+    if ( $resolver->is_editor_preview() ) {
+        $dokan_section_placeholder(
+            __( 'This product section is no longer available. It may belong to an extension that is not active.', 'dokan-lite' )
+        );
+    }
+
+    return;
+}
+
+/*
+ * The marketplace gate, re-checked here regardless of block attributes. Note the
+ * inverted sense: the Customizer control reads "Hide <section>", so is_enabled()
+ * returns false when the merchant has switched the section off.
+ */
+if ( ! $section->is_enabled() ) {
+    if ( $resolver->is_editor_preview() ) {
+        $dokan_section_placeholder(
+            __( 'This product section is hidden in Appearance settings, so it will not appear on the store page.', 'dokan-lite' )
+        );
+    }
+
+    return;
+}
+
+// The preview vendor has no products to query.
+if ( ! $vendor->get_id() ) {
+    $dokan_section_placeholder(
+        __( "The vendor's products for this section appear here on the store page.", 'dokan-lite' )
+    );
+
+    return;
+}
+
+$products = $section->get_products( $vendor->get_id() );
+
+// No products means no section at all — not an empty heading, matching the classic page.
+if ( ! $products instanceof WP_Query || ! $products->have_posts() ) {
+    if ( $resolver->is_editor_preview() ) {
+        $dokan_section_placeholder(
+            __( 'This store has no products in this section yet.', 'dokan-lite' )
+        );
+    }
+
+    return;
+}
+
+$section_title = '' !== trim( (string) $attributes['title'] )
+    ? $attributes['title']
+    : $section->get_section_title();
+
+$section_output = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $section_id, $products, $section_title, $vendor ) {
+        dokan_get_template_part(
+            'store-products-section',
+            '',
+            [
+                'section_id'    => $section_id,
+                'products'      => $products,
+                'section_title' => $section_title,
+                'vendor'        => $vendor,
+            ]
+        );
+    }
+);
+
+printf(
+    '<div %1$s>%2$s</div>',
+    get_block_wrapper_attributes( [ 'class' => 'dokan-store-product-section-block woocommerce' ] ),
+    $section_output // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts.
+);

--- a/src/blocks/store-product-section/style.scss
+++ b/src/blocks/store-product-section/style.scss
@@ -1,0 +1,27 @@
+/*
+ * Front-end + editor styles for dokan/store-product-section.
+ *
+ * The section markup is templates/store-products-section.php verbatim, and its
+ * grid is WooCommerce's — styled through the `woocommerce` class render.php
+ * puts
+ * on the wrapper. Only the wrapper and the editor placeholder belong here.
+ */
+
+.wp-block-dokan-store-product-section {
+
+	.products-list-heading {
+		margin-block-start: 0;
+	}
+
+	.seller-items {
+		clear: both;
+	}
+
+	&.is-editor-placeholder .dokan-info {
+		padding: 1.5em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-sidebar/block.json
+++ b/src/blocks/store-sidebar/block.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-sidebar",
+    "version": "1.0.0",
+    "title": "Store Sidebar",
+    "category": "dokan",
+    "description": "A container for store widgets, replacing the classic store sidebar on block themes.",
+    "keywords": [ "dokan", "store", "vendor", "sidebar", "widgets", "aside" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "providesContext": {
+        "dokan/storeId": "storeId"
+    },
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-sidebar/index.tsx
+++ b/src/blocks/store-sidebar/index.tsx
@@ -1,0 +1,43 @@
+import { registerBlockType } from '@wordpress/blocks';
+import {
+    InnerBlocks,
+    useBlockProps,
+    useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+/*
+ * A container block, so it is edited live rather than server-rendered: the
+ * merchant arranges real child blocks inside it. render.php only wraps the
+ * already-rendered children and fires the two widget-area actions around them.
+ */
+const TEMPLATE = [
+    [ 'dokan/store-category-menu', {} ],
+    [ 'dokan/store-location-map', {} ],
+    [ 'dokan/store-open-close-hours', {} ],
+    [ 'dokan/store-contact-form', {} ],
+];
+
+const Edit = ( { attributes, setAttributes } ) => {
+    const blockProps = useBlockProps( { className: 'dokan-store-sidebar' } );
+    const innerBlocksProps = useInnerBlocksProps( blockProps, {
+        template: TEMPLATE,
+    } );
+
+    return (
+        <>
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+            <div { ...innerBlocksProps } />
+        </>
+    );
+};
+
+registerBlockType( metadata.name, {
+    edit: Edit,
+    save: () => <InnerBlocks.Content />,
+} );

--- a/src/blocks/store-sidebar/render.php
+++ b/src/blocks/store-sidebar/render.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Render `dokan/store-sidebar`.
+ *
+ * The block-theme replacement for the `sidebar-store` widget area. Its children
+ * are the content, so the widget-area plumbing of `templates/store-sidebar.php`
+ * is dropped — but both of its actions are preserved, because Pro's vendor
+ * verification widget renders from `dokan_sidebar_store_after` and would
+ * otherwise have nowhere to go on a block theme.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content — inner blocks, already rendered.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args( $attributes, [ 'storeId' => 0 ] );
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$before = '';
+$after  = '';
+
+/*
+ * Both actions take a WP_User and the shop-info array, exactly as
+ * templates/store-sidebar.php passes them — never the Vendor. Guarded so two
+ * sidebars on one page do not render Pro's verification widget twice.
+ */
+if ( $vendor->data instanceof WP_User ) {
+    $store_info = $vendor->get_shop_info();
+
+    if ( ! did_action( 'dokan_sidebar_store_before' ) ) {
+        $before = $resolver->render_in_store_context(
+            $vendor,
+            function () use ( $vendor, $store_info ) {
+                /** This action is documented in templates/store-sidebar.php */
+                do_action( 'dokan_sidebar_store_before', $vendor->data, $store_info );
+            }
+        );
+    }
+
+    if ( ! did_action( 'dokan_sidebar_store_after' ) ) {
+        $after = $resolver->render_in_store_context(
+            $vendor,
+            function () use ( $vendor, $store_info ) {
+                /** This action is documented in templates/store-sidebar.php */
+                do_action( 'dokan_sidebar_store_after', $vendor->data, $store_info );
+            }
+        );
+    }
+}
+
+printf(
+    '<div %1$s role="complementary"><div class="dokan-widget-area widget-collapse">%2$s%3$s%4$s</div></div>',
+    get_block_wrapper_attributes( [ 'class' => 'dokan-store-sidebar' ] ),
+    $before, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+    $content, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner blocks, already rendered by WP_Block::render().
+    $after // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+);

--- a/src/blocks/store-sidebar/render.php
+++ b/src/blocks/store-sidebar/render.php
@@ -29,7 +29,11 @@ $attributes = wp_parse_args( $attributes, [ 'storeId' => 0 ] );
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-sidebar/style.scss
+++ b/src/blocks/store-sidebar/style.scss
@@ -1,0 +1,26 @@
+/*
+ * Front-end + editor styles for dokan/store-sidebar.
+ *
+ * Keeps the classic `.dokan-widget-area` / `.widget-collapse` wrapper classes
+ * so
+ * widgets rendered into it by Pro — the vendor verification widget arrives
+ * through
+ * dokan_sidebar_store_after — style themselves exactly as on the classic page.
+ * The classic `id="dokan-secondary"` is deliberately not emitted: a block can
+ * be
+ * inserted more than once, and duplicate ids are invalid.
+ */
+
+.wp-block-dokan-store-sidebar {
+
+	.dokan-widget-area {
+		display: flex;
+		flex-direction: column;
+		gap: var(--wp--style--block-gap, 1.5em);
+	}
+
+	.widget,
+	.dokan-store-widget {
+		margin: 0;
+	}
+}

--- a/src/blocks/store-social/block.json
+++ b/src/blocks/store-social/block.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-social",
+    "version": "1.0.0",
+    "title": "Store Social Icons",
+    "category": "dokan",
+    "description": "Displays links to the vendor's social profiles.",
+    "keywords": [ "dokan", "store", "vendor", "social", "profile", "links" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "iconSize": {
+            "type": "number",
+            "default": 24
+        },
+        "showLabels": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "html": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "link": false,
+            "gradients": false
+        },
+        "typography": {
+            "textAlign": true
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-social/block.json
+++ b/src/blocks/store-social/block.json
@@ -21,6 +21,10 @@
         "showLabels": {
             "type": "boolean",
             "default": false
+        },
+        "openInNewTab": {
+            "type": "boolean",
+            "default": true
         }
     },
     "supports": {

--- a/src/blocks/store-social/index.tsx
+++ b/src/blocks/store-social/index.tsx
@@ -9,7 +9,11 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Social Icon Settings', 'dokan-lite' ) }>
                     <RangeControl
@@ -23,6 +27,14 @@ registerBlockType( metadata.name, {
                         min={ 10 }
                         max={ 96 }
                         __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={ __( 'Open in new tab', 'dokan-lite' ) }
+                        checked={ !! attributes.openInNewTab }
+                        onChange={ ( openInNewTab ) =>
+                            setAttributes( { openInNewTab } )
+                        }
                         __nextHasNoMarginBottom
                     />
                     <ToggleControl

--- a/src/blocks/store-social/index.tsx
+++ b/src/blocks/store-social/index.tsx
@@ -11,29 +11,30 @@ registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
         <SSREdit name={ metadata.name } attributes={ attributes }>
             <InspectorControls>
-                <PanelBody
-                    title={ __( 'Store Banner Settings', 'dokan-lite' ) }
-                >
+                <PanelBody title={ __( 'Social Icon Settings', 'dokan-lite' ) }>
                     <RangeControl
-                        label={ __( 'Height (px)', 'dokan-lite' ) }
-                        help={ __(
-                            'Set to 0 to use the marketplace default banner height.',
-                            'dokan-lite'
-                        ) }
-                        value={ attributes.height ?? 0 }
-                        onChange={ ( height ) =>
-                            setAttributes( { height: Number( height ) || 0 } )
+                        label={ __( 'Icon size (px)', 'dokan-lite' ) }
+                        value={ attributes.iconSize ?? 24 }
+                        onChange={ ( iconSize ) =>
+                            setAttributes( {
+                                iconSize: Number( iconSize ) || 24,
+                            } )
                         }
-                        min={ 0 }
-                        max={ 800 }
-                        step={ 10 }
+                        min={ 10 }
+                        max={ 96 }
                         __next40pxDefaultSize
                         __nextHasNoMarginBottom
                     />
                     <ToggleControl
-                        label={ __( 'Link to store page', 'dokan-lite' ) }
-                        checked={ !! attributes.isLink }
-                        onChange={ ( isLink ) => setAttributes( { isLink } ) }
+                        label={ __( 'Show network names', 'dokan-lite' ) }
+                        help={ __(
+                            'Names are always available to screen readers.',
+                            'dokan-lite'
+                        ) }
+                        checked={ !! attributes.showLabels }
+                        onChange={ ( showLabels ) =>
+                            setAttributes( { showLabels } )
+                        }
                         __nextHasNoMarginBottom
                     />
                 </PanelBody>

--- a/src/blocks/store-social/render.php
+++ b/src/blocks/store-social/render.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Render `dokan/store-social`.
+ *
+ * See docs/adr/0005-store-header-blocks-emit-fresh-markup.md for why this block
+ * does not reuse `templates/store-header.php`.
+ *
+ * This block is also the anchor Pro's follow, support, live-chat and share
+ * buttons attach to through Block Hooks — being a registered block type is all
+ * that requires, so nothing here needs to know about them.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId'    => 0,
+        'iconSize'   => 24,
+        'showLabels' => false,
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$social_fields = dokan_get_social_profile_fields();
+$social_info   = $vendor->get_social_profiles();
+
+if ( empty( $social_fields ) || empty( $social_info ) ) {
+    return;
+}
+
+$icon_size = min( 96, max( 10, absint( $attributes['iconSize'] ) ) );
+$items     = '';
+
+foreach ( $social_fields as $key => $field ) {
+    if ( empty( $social_info[ $key ] ) ) {
+        continue;
+    }
+
+    /*
+     * Most fields carry a bare Font Awesome name that needs the `fab fa-` prefix,
+     * but a few already ship a complete class string. Prefixing those blindly —
+     * as the classic template does — produces `fab fa-fa-brands fa-…`, which
+     * renders no icon at all.
+     */
+    $icon       = isset( $field['icon'] ) ? trim( (string) $field['icon'] ) : '';
+    $icon_class = ( '' !== $icon && false === strpos( $icon, 'fa-' ) ) ? 'fab fa-' . $icon : $icon;
+    $label      = isset( $field['title'] ) ? $field['title'] : $key;
+
+    $items .= sprintf(
+        '<li class="dokan-store-social-item dokan-store-social-item--%1$s"><a class="dokan-store-social-link" href="%2$s" target="_blank" rel="noopener noreferrer"><i class="%3$s" aria-hidden="true"></i><span class="dokan-store-social-label">%4$s</span></a></li>',
+        esc_attr( $key ),
+        esc_url( $social_info[ $key ] ),
+        esc_attr( $icon_class ),
+        esc_html( $label )
+    );
+}
+
+if ( '' === $items ) {
+    return;
+}
+
+printf(
+    '<div %1$s><ul class="dokan-store-social-list">%2$s</ul></div>',
+    get_block_wrapper_attributes(
+        [
+			'class' => empty( $attributes['showLabels'] ) ? 'has-icons-only' : '',
+			'style' => sprintf( '--dokan-social-icon-size:%dpx;', $icon_size ),
+		]
+    ),
+    $items // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each item is escaped as it is built.
+);

--- a/src/blocks/store-social/render.php
+++ b/src/blocks/store-social/render.php
@@ -26,8 +26,9 @@ $attributes = wp_parse_args(
     $attributes,
     [
         'storeId'    => 0,
-        'iconSize'   => 24,
-        'showLabels' => false,
+        'iconSize'     => 24,
+        'showLabels'   => false,
+        'openInNewTab' => true,
     ]
 );
 
@@ -60,6 +61,9 @@ if ( empty( $social_fields ) || empty( $social_info ) ) {
 $icon_size = min( 96, max( 10, absint( $attributes['iconSize'] ) ) );
 $items     = '';
 
+// The classic template always opened a new tab; the block makes it a choice.
+$dokan_link_target = empty( $attributes['openInNewTab'] ) ? '' : ' target="_blank" rel="noopener noreferrer"';
+
 foreach ( $social_fields as $key => $field ) {
     if ( empty( $social_info[ $key ] ) ) {
         continue;
@@ -76,11 +80,12 @@ foreach ( $social_fields as $key => $field ) {
     $label      = isset( $field['title'] ) ? $field['title'] : $key;
 
     $items .= sprintf(
-        '<li class="dokan-store-social-item dokan-store-social-item--%1$s"><a class="dokan-store-social-link" href="%2$s" target="_blank" rel="noopener noreferrer"><i class="%3$s" aria-hidden="true"></i><span class="dokan-store-social-label">%4$s</span></a></li>',
+        '<li class="dokan-store-social-item dokan-store-social-item--%1$s"><a class="dokan-store-social-link" href="%2$s"%5$s><i class="%3$s" aria-hidden="true"></i><span class="dokan-store-social-label">%4$s</span></a></li>',
         esc_attr( $key ),
         esc_url( $social_info[ $key ] ),
         esc_attr( $icon_class ),
-        esc_html( $label )
+        esc_html( $label ),
+        $dokan_link_target // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Static attribute string.
     );
 }
 

--- a/src/blocks/store-social/render.php
+++ b/src/blocks/store-social/render.php
@@ -37,7 +37,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-social/style.scss
+++ b/src/blocks/store-social/style.scss
@@ -1,0 +1,65 @@
+/*
+ * Front-end + editor styles for dokan/store-social.
+ *
+ * Fresh classes rather than the classic `.store-social-wrapper` / `.store-
+ * social`:
+ * every classic rule for those is nested under `.dokan-single-store`, a wrapper
+ * only templates/store.php emits, so an FSE store template can never match it.
+ * See docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ *
+ * The icon size travels as the --dokan-social-icon-size custom property that
+ * render.php prints on the wrapper.
+ */
+
+.wp-block-dokan-store-social {
+	--dokan-social-icon-size: 24px;
+
+	.dokan-store-social-list {
+		display: inline-flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--wp--style--block-gap, 0.75em);
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.dokan-store-social-item {
+		margin: 0;
+	}
+
+	.dokan-store-social-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4em;
+		color: inherit;
+		text-decoration: none;
+		line-height: 1;
+
+		i {
+			font-size: var(--dokan-social-icon-size);
+		}
+
+		&:hover,
+		&:focus {
+			color: inherit;
+			opacity: 0.75;
+		}
+	}
+
+	/*
+	 * Names stay in the accessibility tree when they are visually hidden — an
+	 * icon-only link with no accessible name is unusable with a screen reader.
+	 */
+	&.has-icons-only .dokan-store-social-label {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+}

--- a/src/blocks/store-tab-content/block.json
+++ b/src/blocks/store-tab-content/block.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-tab-content",
+    "version": "1.0.0",
+    "title": "Store Tab Content",
+    "category": "dokan",
+    "description": "Displays the body of the store's active tab: the vendor's products, terms and conditions, or an extension's tab.",
+    "keywords": [ "dokan", "store", "vendor", "products", "tab", "content" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        },
+        "columns": {
+            "type": "number",
+            "default": 0
+        },
+        "showPagination": {
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "wide", "full" ],
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-tab-content/index.tsx
+++ b/src/blocks/store-tab-content/index.tsx
@@ -1,0 +1,40 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            <InspectorControls>
+                <PanelBody title={ __( 'Tab Content Settings', 'dokan-lite' ) }>
+                    <ToggleControl
+                        label={ __( 'Show pagination', 'dokan-lite' ) }
+                        checked={ !! attributes.showPagination }
+                        onChange={ ( showPagination ) =>
+                            setAttributes( { showPagination } )
+                        }
+                        __nextHasNoMarginBottom
+                    />
+
+                    <Notice status="info" isDismissible={ false }>
+                        { __(
+                            'The editor always previews the products tab. Terms and Conditions, and any tabs added by extensions, render on the front end when their tab is open.',
+                            'dokan-lite'
+                        ) }
+                    </Notice>
+                </PanelBody>
+            </InspectorControls>
+
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-tab-content/index.tsx
+++ b/src/blocks/store-tab-content/index.tsx
@@ -1,6 +1,11 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
+import {
+    PanelBody,
+    RangeControl,
+    ToggleControl,
+    Notice,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SSREdit from '../shared/ssr-edit';
 import StorePanel from '../shared/store-panel';
@@ -9,9 +14,28 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             <InspectorControls>
                 <PanelBody title={ __( 'Tab Content Settings', 'dokan-lite' ) }>
+                    <RangeControl
+                        label={ __( 'Columns', 'dokan-lite' ) }
+                        help={ __(
+                            'Set to 0 to use the theme default.',
+                            'dokan-lite'
+                        ) }
+                        value={ attributes.columns ?? 0 }
+                        onChange={ ( columns ) =>
+                            setAttributes( { columns: Number( columns ) || 0 } )
+                        }
+                        min={ 0 }
+                        max={ 6 }
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
                     <ToggleControl
                         label={ __( 'Show pagination', 'dokan-lite' ) }
                         checked={ !! attributes.showPagination }

--- a/src/blocks/store-tab-content/render.php
+++ b/src/blocks/store-tab-content/render.php
@@ -186,6 +186,21 @@ ob_start();
 if ( $dokan_query->have_posts() ) {
     echo '<div class="seller-items">';
 
+    /*
+     * Columns is declared in block.json, so it must do something. Zero means
+     * "theme default", matching how WooCommerce itself resolves the loop. The
+     * loop prop is request-global, so everything here stays inside the guard:
+     * reading it outside would make WooCommerce materialise the whole loop
+     * state (a potential option write) even for blocks left on the default.
+     */
+    $dokan_columns      = min( 6, absint( $attributes['columns'] ) );
+    $dokan_prev_columns = null;
+
+    if ( $dokan_columns > 0 ) {
+        $dokan_prev_columns = wc_get_loop_prop( 'columns' );
+        wc_set_loop_prop( 'columns', $dokan_columns );
+    }
+
     woocommerce_product_loop_start();
 
     while ( $dokan_query->have_posts() ) {
@@ -194,6 +209,10 @@ if ( $dokan_query->have_posts() ) {
     }
 
     woocommerce_product_loop_end();
+
+    if ( null !== $dokan_prev_columns ) {
+        wc_set_loop_prop( 'columns', $dokan_prev_columns );
+    }
 
     echo '</div>';
 
@@ -215,8 +234,15 @@ if ( $dokan_query->have_posts() ) {
 
     // Only the block's own query needs resetting; doing it for the main query
     // would leave the global $post pointing at the last product in the loop.
+    // The WooCommerce loop state our loop seeded is reset for the same reason:
+    // left behind, a later [products] loop on the page would inherit this
+    // block's totals and print "Showing 0 results" with no pagination.
     if ( ! $dokan_own_page ) {
         wp_reset_postdata();
+
+        if ( function_exists( 'wc_reset_loop' ) ) {
+            wc_reset_loop();
+        }
     }
 } else {
     printf(

--- a/src/blocks/store-tab-content/render.php
+++ b/src/blocks/store-tab-content/render.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Render `dokan/store-tab-content`.
+ *
+ * Replaces the body of `templates/store.php` and `templates/store-toc.php`, and
+ * carries the hook-continuity guarantee of the whole FSE effort: Pro's coupons,
+ * vacation notice and order discount, plus Lite's own product sections and
+ * product sort form, all hang off `dokan_store_profile_frame_after` and keep
+ * working here before a single Pro block exists.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args(
+    $attributes,
+    [
+        'storeId'        => 0,
+        'columns'        => 0,
+        'showPagination' => true,
+    ]
+);
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$store_id = $vendor->get_id();
+
+/*
+ * The wrapper must carry `woocommerce`: every product-grid rule in WooCommerce is
+ * scoped as `.woocommerce ul.products`, and the classic page picked the class up
+ * from `<div id="dokan-content" class="store-page-wrap woocommerce">`.
+ */
+$dokan_tab_wrapper = static function ( $extra_class = '' ) {
+    return get_block_wrapper_attributes(
+        [ 'class' => trim( 'dokan-store-tab-content-block woocommerce ' . $extra_class ) ]
+    );
+};
+
+/*
+ * Editor preview. PreviewVendor has no products, and its `data` is null — firing
+ * dokan_store_profile_frame_after with that would hand null to five listeners
+ * that dereference it. Render a static stand-in and stop.
+ */
+if ( ! $store_id ) {
+    printf(
+        '<div %1$s><p class="dokan-info">%2$s</p></div>',
+        $dokan_tab_wrapper( 'is-editor-placeholder' ),
+        esc_html__( "The vendor's products appear here on the store page.", 'dokan-lite' )
+    );
+
+    return;
+}
+
+// Resolve before entering store context, which would otherwise make every
+// vendor look like the one being viewed.
+$current_tab = dokan_get_current_store_tab( $store_id );
+
+// Terms and conditions — the body of templates/store-toc.php.
+if ( 'terms_and_conditions' === $current_tab ) {
+    $dokan_tnc = $vendor->get_store_tnc();
+
+    // The classic template omits the heading entirely when the vendor has set
+    // no terms, rather than printing an empty section.
+    $dokan_toc_body = empty( $dokan_tnc )
+        ? ''
+        : sprintf(
+            '<h2 class="headline">%1$s</h2><div>%2$s</div>',
+            esc_html__( 'Terms And Conditions', 'dokan-lite' ),
+            wp_kses_post( wpautop( wptexturize( $dokan_tnc ) ) )
+        );
+
+    printf(
+        '<div %1$s><div id="store-toc-wrapper"><div id="store-toc">%2$s</div></div></div>',
+        $dokan_tab_wrapper( 'store-toc-wrap' ),
+        $dokan_toc_body // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
+    );
+
+    return;
+}
+
+/*
+ * Extensions render their tab bodies here. Pro's Reviews and Biography tabs use
+ * this instead of taking over `template_include`, which is broken on block
+ * themes — see docs/adr/0006-pro-store-tabs-render-as-bodies-not-template-takeovers.md.
+ */
+if ( '' !== $current_tab && 'products' !== $current_tab ) {
+    $tab_body = $resolver->render_in_store_context(
+        $vendor,
+        function () use ( $current_tab, $vendor, $attributes ) {
+            /**
+             * Renders the body of a store tab that is not one of Lite's own.
+             *
+             * @since DOKAN_SINCE
+             *
+             * @param string                       $current_tab Tab key from `dokan_get_store_tabs()`.
+             * @param \WeDevs\Dokan\Vendor\Vendor   $vendor      Vendor whose store is being rendered.
+             * @param array                        $attributes  Block attributes.
+             */
+            do_action( 'dokan_block_store_tab_content', $current_tab, $vendor, $attributes );
+        }
+    );
+
+    if ( '' !== trim( $tab_body ) ) {
+        printf(
+            '<div %1$s>%2$s</div>',
+            $dokan_tab_wrapper(),
+            $tab_body // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+        );
+
+        return;
+    }
+}
+
+// --- Products tab -------------------------------------------------------
+
+/*
+ * Fired at most once per request. Two tab-content blocks on a page would
+ * otherwise duplicate the vacation notice, coupons and product sections — the
+ * same guard the store listing filter bar uses for its own shared action.
+ *
+ * The signature is the classic one: a WP_User (Vendor::$data), never the Vendor.
+ */
+$dokan_before_products = '';
+
+if ( ! did_action( 'dokan_store_profile_frame_after' ) && $vendor->data instanceof WP_User ) {
+    $dokan_before_products = $resolver->render_in_store_context(
+        $vendor,
+        function () use ( $vendor ) {
+            /** This action is documented in templates/store.php */
+            do_action( 'dokan_store_profile_frame_after', $vendor->data, $vendor->get_shop_info() );
+        }
+    );
+}
+
+/*
+ * On the vendor's own store page the main query already carries their products,
+ * their ordering and their attribute filters — `Rewrites::store_query_filter()`
+ * shapes it on `pre_get_posts`, and reusing it is what keeps pagination, the
+ * sort form and Pro's filters working. Anywhere else the main query belongs to
+ * whatever page the block was dropped on, so it has to be queried explicitly.
+ */
+$dokan_own_page = '' !== $current_tab;
+
+if ( $dokan_own_page ) {
+    $dokan_query = $GLOBALS['wp_query'];
+} else {
+    $dokan_query = new WP_Query(
+        [
+            'post_type'      => 'product',
+            'post_status'    => 'publish',
+            'author'         => $store_id,
+            'posts_per_page' => absint( dokan_get_option( 'store_products_per_page', 'dokan_general', 12 ) ),
+            'paged'          => max( 1, absint( get_query_var( 'paged' ) ) ),
+        ]
+    );
+}
+
+ob_start();
+
+if ( $dokan_query->have_posts() ) {
+    echo '<div class="seller-items">';
+
+    woocommerce_product_loop_start();
+
+    while ( $dokan_query->have_posts() ) {
+        $dokan_query->the_post();
+        wc_get_template_part( 'content', 'product' );
+    }
+
+    woocommerce_product_loop_end();
+
+    echo '</div>';
+
+    if ( ! empty( $attributes['showPagination'] ) ) {
+        if ( $dokan_own_page ) {
+            dokan_content_nav( 'nav-below' );
+        } else {
+            echo wp_kses_post(
+                paginate_links(
+                    [
+                        'total'   => (int) $dokan_query->max_num_pages,
+                        'current' => max( 1, absint( get_query_var( 'paged' ) ) ),
+                        'type'    => 'list',
+                    ]
+                )
+            );
+        }
+    }
+
+    // Only the block's own query needs resetting; doing it for the main query
+    // would leave the global $post pointing at the last product in the loop.
+    if ( ! $dokan_own_page ) {
+        wp_reset_postdata();
+    }
+} else {
+    printf(
+        '<p class="dokan-info">%s</p>',
+        esc_html__( 'No products were found of this vendor!', 'dokan-lite' )
+    );
+}
+
+$dokan_products = ob_get_clean();
+
+printf(
+    '<div %1$s>%2$s%3$s</div>',
+    $dokan_tab_wrapper(),
+    $dokan_before_products, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+    $dokan_products // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped WooCommerce template parts.
+);

--- a/src/blocks/store-tab-content/render.php
+++ b/src/blocks/store-tab-content/render.php
@@ -36,7 +36,11 @@ $attributes = wp_parse_args(
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-tab-content/style.scss
+++ b/src/blocks/store-tab-content/style.scss
@@ -1,0 +1,31 @@
+/*
+ * Front-end + editor styles for dokan/store-tab-content.
+ *
+ * Deliberately minimal. The product grid is WooCommerce's, styled by
+ * woocommerce.css through the `woocommerce` class render.php puts on the
+ * wrapper; the vacation notice, coupons and product sections are styled by
+ * whatever registered them. Anything more here would fight those.
+ */
+
+.wp-block-dokan-store-tab-content {
+
+	.seller-items {
+		clear: both;
+	}
+
+	#store-toc {
+
+		.headline {
+			margin-block-start: 0;
+		}
+	}
+
+	/* Editor stand-in — the real products need a store page and a real query. */
+	&.is-editor-placeholder .dokan-info {
+		padding: 2em;
+		text-align: center;
+		border: 1px dashed currentcolor;
+		border-radius: 4px;
+		opacity: 0.7;
+	}
+}

--- a/src/blocks/store-tabs/block.json
+++ b/src/blocks/store-tabs/block.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dokan/store-tabs",
+    "version": "1.0.0",
+    "title": "Store Tabs",
+    "category": "dokan",
+    "description": "Navigation between the store's tabs, such as Products and Terms and Conditions.",
+    "keywords": [ "dokan", "store", "vendor", "tabs", "navigation", "menu" ],
+    "textdomain": "dokan-lite",
+    "usesContext": [ "dokan/storeId" ],
+    "attributes": {
+        "storeId": {
+            "type": "number",
+            "default": 0
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [ "wide" ],
+        "color": {
+            "text": true,
+            "background": true,
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "text": true,
+                "background": true
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalTextTransform": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "blockGap": true
+        }
+    },
+    "example": {},
+    "editorScript": "file:./index.js",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/store-tabs/index.tsx
+++ b/src/blocks/store-tabs/index.tsx
@@ -6,7 +6,11 @@ import './style.scss';
 
 registerBlockType( metadata.name, {
     edit: ( { attributes, setAttributes } ) => (
-        <SSREdit name={ metadata.name } attributes={ attributes }>
+        <SSREdit
+            name={ metadata.name }
+            attributes={ attributes }
+            setAttributes={ setAttributes }
+        >
             { /* The tab list itself comes from dokan_get_store_tabs(), which
                  extensions filter — there is nothing here for a merchant to
                  configure beyond which store the block follows. */ }

--- a/src/blocks/store-tabs/index.tsx
+++ b/src/blocks/store-tabs/index.tsx
@@ -1,0 +1,20 @@
+import { registerBlockType } from '@wordpress/blocks';
+import SSREdit from '../shared/ssr-edit';
+import StorePanel from '../shared/store-panel';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+    edit: ( { attributes, setAttributes } ) => (
+        <SSREdit name={ metadata.name } attributes={ attributes }>
+            { /* The tab list itself comes from dokan_get_store_tabs(), which
+                 extensions filter — there is nothing here for a merchant to
+                 configure beyond which store the block follows. */ }
+            <StorePanel
+                attributes={ attributes }
+                setAttributes={ setAttributes }
+            />
+        </SSREdit>
+    ),
+    save: () => null,
+} );

--- a/src/blocks/store-tabs/render.php
+++ b/src/blocks/store-tabs/render.php
@@ -28,7 +28,11 @@ $attributes = wp_parse_args( $attributes, [ 'storeId' => 0 ] );
  * Blocks\Manager never sees them. Enqueue here rather than relying on it.
  */
 wp_enqueue_style( 'dokan-style' );
-wp_enqueue_style( 'dokan-fontawesome' );
+
+// Font Awesome is opt-out in Appearance settings; honour that here too.
+if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
+    wp_enqueue_style( 'dokan-fontawesome' );
+}
 
 $resolver = dokan_get_container()->get( VendorResolver::class );
 $vendor   = $resolver->resolve( $block->context ?? [], $attributes );

--- a/src/blocks/store-tabs/render.php
+++ b/src/blocks/store-tabs/render.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Render `dokan/store-tabs`.
+ *
+ * Reproduces the `.dokan-store-tabs` region of `templates/store-header.php`.
+ * Because the tab list comes from `dokan_get_store_tabs()`, Pro's Reviews and
+ * Biography tabs appear here with no block-side work — the same as on the
+ * classic page.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+use WeDevs\Dokan\Blocks\VendorResolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+$attributes = wp_parse_args( $attributes, [ 'storeId' => 0 ] );
+
+/*
+ * Store pages already carry these, but a block can sit on any page — and blocks
+ * placed in a block template are not in post_content, so the content sniff in
+ * Blocks\Manager never sees them. Enqueue here rather than relying on it.
+ */
+wp_enqueue_style( 'dokan-style' );
+wp_enqueue_style( 'dokan-fontawesome' );
+
+$resolver = dokan_get_container()->get( VendorResolver::class );
+$vendor   = $resolver->resolve( $block->context ?? [], $attributes );
+
+if ( ! $vendor ) {
+    return; // Not a store context and not an editor preview — render nothing.
+}
+
+$store_id   = $vendor->get_id();
+$store_tabs = dokan_get_store_tabs( $store_id );
+
+if ( empty( $store_tabs ) ) {
+    return; // Mirrors the classic template, which omits the region entirely.
+}
+
+/*
+ * Resolve the active tab BEFORE entering store context: render_in_store_context()
+ * sets the store query var, after which "is this vendor's page being viewed?"
+ * would answer yes for every vendor.
+ */
+$active_tab = dokan_get_current_store_tab( $store_id );
+$is_preview = $resolver->is_editor_preview() && ! $store_id;
+
+if ( $is_preview && '' === $active_tab ) {
+    $active_tab = 'products'; // Give the preview something to highlight.
+}
+
+$items = '';
+
+foreach ( $store_tabs as $key => $store_tab ) {
+    $tab_url = isset( $store_tab['url'] ) ? $store_tab['url'] : '';
+
+    // The classic template skips url-less tabs; the preview vendor has no real
+    // urls at all, so give it inert ones rather than dropping every tab.
+    if ( empty( $tab_url ) ) {
+        if ( ! $is_preview ) {
+            continue;
+        }
+
+        $tab_url = '#';
+    }
+
+    $items .= sprintf(
+        '<li class="dokan-store-tab dokan-store-tab--%1$s%2$s"><a href="%3$s"%4$s>%5$s</a></li>',
+        esc_attr( $key ),
+        $key === $active_tab ? ' is-active' : '',
+        esc_url( $tab_url ),
+        $key === $active_tab ? ' aria-current="page"' : '',
+        esc_html( isset( $store_tab['title'] ) ? $store_tab['title'] : $key )
+    );
+}
+
+if ( '' === $items ) {
+    return;
+}
+
+/*
+ * Pro's share, support and live-chat buttons render from this action into the
+ * button row beside the tabs. It takes the store id — not the Vendor object.
+ * Run it in store context so callbacks gating on dokan_is_store_page() work
+ * when the block sits on an ordinary page.
+ */
+$buttons = $resolver->render_in_store_context(
+    $vendor,
+    function () use ( $store_id ) {
+        /** This action is documented in templates/store-header.php */
+        do_action( 'dokan_after_store_tabs', $store_id );
+    }
+);
+
+printf(
+    '<nav %1$s><ul class="dokan-modules-button">%2$s</ul><ul class="dokan-store-tab-list">%3$s</ul></nav>',
+    get_block_wrapper_attributes( [ 'class' => 'dokan-store-tabs' ] ),
+    $buttons, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Built from escaped template parts by the listeners.
+    $items // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each item is escaped as it is built.
+);

--- a/src/blocks/store-tabs/style.scss
+++ b/src/blocks/store-tabs/style.scss
@@ -1,0 +1,56 @@
+/*
+ * Front-end + editor styles for dokan/store-tabs.
+ *
+ * The `.dokan-modules-button` list is kept as a class name because Pro's share,
+ * support and live-chat buttons render their own markup into it and style
+ * themselves against it. The tab list is fresh — see
+ * docs/adr/0005-store-header-blocks-emit-fresh-markup.md.
+ */
+
+.wp-block-dokan-store-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wp--style--block-gap, 1em);
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--wp--style--block-gap, 1em);
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	/*
+	 * Pro's button row. It renders opposite the tabs, matching the classic page
+	 * and the Elementor templates — and stays out of the flow when Pro is absent.
+	 */
+	.dokan-modules-button {
+		order: 1;
+
+		&:empty {
+			display: none;
+		}
+	}
+
+	.dokan-store-tab {
+		margin: 0;
+
+		a {
+			display: inline-block;
+			color: inherit;
+			text-decoration: none;
+			padding-block: 0.5em;
+			border-block-end: 2px solid transparent;
+		}
+
+		&.is-active a,
+		a:hover,
+		a:focus {
+			border-block-end-color: currentcolor;
+		}
+	}
+}

--- a/templates/block-templates/single-store.html
+++ b/templates/block-templates/single-store.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:pattern {"slug":"dokan/single-store-default"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/block-templates/single-store.html
+++ b/templates/block-templates/single-store.html
@@ -1,9 +1,53 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:pattern {"slug":"dokan/single-store-default"} /-->
-</main>
+<main class="wp-block-group"><!-- wp:group {"align":"full","className":"dokan-single-store","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull dokan-single-store"><!-- wp:group {"align":"wide","className":"dokan-single-store-header is-panel","style":{"color":{"background":"#1f2937","text":"#ffffff"},"spacing":{"margin":{"bottom":"2.5rem"},"padding":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide dokan-single-store-header is-panel has-text-color has-background" style="color:#ffffff;background-color:#1f2937;margin-bottom:2.5rem;padding-top:0;padding-bottom:0">
+    <!-- wp:columns {"verticalAlignment":"stretch","isStackedOnMobile":true,"style":{"spacing":{"blockGap":{"left":"0"}}}} -->
+    <div class="wp-block-columns are-vertically-aligned-stretch">
+        <!-- wp:column {"verticalAlignment":"center","width":"38%","style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem","left":"2rem","right":"2rem"},"blockGap":"1rem"}}} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="padding-top:2rem;padding-right:2rem;padding-bottom:2rem;padding-left:2rem;flex-basis:38%">
+            <!-- wp:dokan/store-avatar {"shape":"circle","size":110} /-->
+
+            <!-- wp:dokan/store-name {"level":1,"style":{"typography":{"fontSize":"1.75rem"}}} /-->
+
+            <!-- wp:dokan/store-info /-->
+
+            <!-- wp:dokan/store-social /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column {"verticalAlignment":"stretch","width":"62%"} -->
+        <div class="wp-block-column is-vertically-aligned-stretch" style="flex-basis:62%">
+            <!-- wp:dokan/store-banner {"height":420} /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:dokan/store-tabs {"align":"wide"} /-->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40)"><!-- wp:column {"width":"33%"} -->
+<div class="wp-block-column" style="flex-basis:33%"><!-- wp:dokan/store-sidebar -->
+<!-- wp:dokan/store-category-menu /-->
+
+<!-- wp:dokan/store-location-map /-->
+
+<!-- wp:dokan/store-open-close-hours /-->
+
+<!-- wp:dokan/store-contact-form /-->
+<!-- /wp:dokan/store-sidebar --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"67%"} -->
+<div class="wp-block-column" style="flex-basis:67%"><!-- wp:dokan/store-tab-content /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
> **Base branch is `feat/fse-store-pages`** (#3356), not `develop`. Review that
> PR first — this one adds the single store blocks, patterns and template that
> register through its foundation.

### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [ ] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

**Fourteen blocks, six patterns, and the `dokan//single-store` template** — the
complete single store page for the Site Editor, with the classic page's full
hook surface preserved.

| Group | Blocks |
|---|---|
| Header | `dokan/store-name`, `dokan/store-banner`, `dokan/store-avatar`, `dokan/store-info`, `dokan/store-social` |
| Composite | `dokan/store-tabs`, `dokan/store-tab-content`, `dokan/store-product-section` |
| Sidebar | `dokan/store-sidebar` (InnerBlocks container), `dokan/store-contact-form`, `dokan/store-open-close-hours`, `dokan/store-location-map`, `dokan/store-category-menu` |
| Layout | `dokan/store-header` — renders any header pattern from a dropdown; on its default it follows Appearance → Store Header Template |

Every block is server rendered, resolves its vendor through the foundation's
`VendorResolver` (the store page being viewed, or a sample store in the
editor), and runs legacy templates inside `render_in_store_context()` so code
gating on `dokan_is_store_page()` keeps working. Blocks always follow the store
page being viewed — there is no per-block vendor picker (product decision). There
is **no JavaScript in the block set** — the store-hours popover is the classic
CSS `:hover`, reproduced in the block stylesheet.

**Hook continuity is the point.** The blocks fire the actions the classic
templates fire, with the arguments those templates pass — which are not
consistent between them, and getting one wrong breaks Pro silently at runtime:

| Action | Argument | Fired from |
|---|---|---|
| `dokan_store_header_after_store_name` | the `Vendor` **object** | `store-name` |
| `dokan_store_header_info_fields` | the store **id** | `store-info` |
| `dokan_after_store_tabs` | the store **id** | `store-tabs` |
| `dokan_store_profile_frame_after` | a **`WP_User`** + shop info, **once per request** (`did_action()` guard) | `store-tab-content` |
| `dokan_sidebar_store_before` / `_after` | a **`WP_User`** + shop info, guarded | `store-sidebar` |

**New extension points** (all `@since DOKAN_SINCE`):

* `dokan_block_store_tab_content` — `( string $tab, Vendor $vendor, array $attributes )`.
  Where Pro renders the Reviews/Biography bodies instead of taking over
  `template_include`, which is broken on block themes (ADR-0010) — implemented in
  getdokan/dokan-pro#6163.
* `dokan_current_store_tab` filter + `dokan_get_current_store_tab()` — the tab
  navigation and the tab body must agree on the active tab from one source.
* `dokan_store_header_layouts` — extensions add their own header patterns to
  the `store-header` block's dropdown (its attribute is `headerLayout`: `layout`
  is reserved by WordPress's layout block support).

**The six patterns** (category *Dokan Single Store*): five header arrangements
— including `single-store-header-panel`, the classic "Default Layout" that
neither the issue's Elementor ports nor Elementor itself covered — plus the
full-page `single-store-default`. The full-page pattern puts the sidebar
**left at 33%**, matching every Elementor store template and the classic
`store_layout` default.

**The template ships fully editable.** `single-store.html` carries the whole
layout as loose blocks — no `wp:pattern` reference (the editor content-locks
those via `metadata.patternName`) and no sealed header. First open of the
template selects and edits every block; the template's Reset returns exactly
there. The accepted cost, recorded in the pairing comment and below: on the
shipped template the Store Header Template setting has no effect until a site
owner swaps the loose header for the `dokan/store-header` block. The header is
`alignwide` with raw colors/spacing, because `contrast`/`base`/`spacing|40`
preset slugs are Twenty Twenty-Four/Five conventions other themes need not
define.

**Editor experience.** Previews are wrapped in `<Disabled>` so server-rendered
HTML cannot swallow selection clicks (trade-off: hover-driven previews behave
on the front end only). Every SSR block carries a scoped **Reset block
settings** control — block-declared attributes only, never editor-injected
`lock`/`metadata`/`align`.

**Real previews with sample data.** Outside a store page the editor renders a
sample store (`PreviewVendor`), and every block shows its real markup instead of
an "appears here" notice: sample categories, a weekly schedule, the contact form,
a static map card, the address and open/close status, and the shop's latest
products through the real WooCommerce loop. Store Tab Content has a **Preview
tab** setting — Products, Terms and Conditions, or a tab an extension adds
(with Pro: Reviews and Vendor Biography); it only affects the editor. Admin
gates still apply: a disabled map, store hours or contact form shows a notice
that the block will not appear.

**Styling and navigation.** Store Tab Content supports color, typography and
border, applied to whichever tab is showing. The template's and patterns' groups
and columns carry List View names (Store Header, Store Details, Store Body,
Sidebar Column, Content Column…).

**Per-block options with the admin-gates rule intact** (admin settings gate,
block attributes decorate — see the settings-precedence comment below):
`columns` on the product grid (with `wc_reset_loop()` hygiene so a later
`[products]` on the page is unharmed), `showTitle` on the four widget blocks,
`showIcons` + inline layout on store-info, `openInNewTab` on store-social,
focal point on store-banner, and marketplace gates honoured everywhere
(`disable_dokan_fontawesome`, `contact_seller`, `hide_vendor_info`,
`store_open_close`, `product_sections`, `store_map`).

**Decision records:** the full spec-divergence rationale is posted on the
issues (getdokan/plugin-internal-tasks#2156, getdokan/plugin-internal-tasks#2157)
and in this PR's decision-table comment; ADR-0009 and ADR-0010 in `docs/adr/`
carry the two hard-to-reverse calls.

### Related Pull Request(s)

* Base: #3356 — FSE foundation
* Pro: getdokan/dokan-pro#6163 — renders the Reviews and Vendor Biography tabs
  inside this template on block themes (ADR-0010). Merge this PR first.

### Closes

* Part of getdokan/plugin-internal-tasks#2153 — covers
  getdokan/plugin-internal-tasks#2156 and getdokan/plugin-internal-tasks#2157

### How to test the changes in this Pull Request:

1. Check out on top of #3356, `npm run build`, activate Twenty Twenty-Five.
2. Visit `/store/{slug}` — a complete themed page: theme header/footer, panel
   store header (contained, not edge-to-edge), tabs, product grid, left
   sidebar. On Storefront the classic page is byte-identical, no block markup.
3. **Appearance → Editor → Templates → Single Store**: every block — including
   avatar, name, info, social — selects with a click on first open. No
   Detach, no List View required.
4. Exercise the options: avatar shape/size, banner height + focal point,
   info field toggles / Show icons / Inline layout, social icon size /
   new-tab, widget Show title, tab-content Columns + pagination. Each toggle
   changes the editor preview, which shows sample data rather than notices.
5. **Reset ladder**: a block's own **Reset block settings** restores its
   defaults (block lock survives); Templates list → ⋮ → Reset restores the
   shipped template (needed to see the List View names on a site that already
   saved the template).
6. **Privacy matrix**: hide email/phone/address in Dokan → Settings →
   Appearance — the fields stay hidden with every block toggle on.
7. Insert the **Store Header** block in place of the loose header → its Layout
   dropdown switches all five arrangements, and on "marketplace default" the
   Appearance → Store Header Template picker drives the page.
8. Two Store Tab Content blocks on one page: coupons/sections render once.
   `/store/{slug}/toc` renders the terms tab.
9. Store Tab Content → **Preview tab**: Products and Terms and Conditions
   preview with sample data. With getdokan/dokan-pro#6163 active, Reviews and
   Vendor Biography are offered too, and `/store/{slug}/reviews/` and
   `/store/{slug}/biography/` render inside this template. Without Pro they are
   not offered.
10. Store Tab Content → Styles: color, typography and border apply on every tab.

### Changelog entry

*Add Gutenberg blocks, patterns and a block template for the single store page*

The single store page could only be composed with Elementor Pro, and on block
themes it rendered as an unstyled fragment. This PR adds fourteen
server-rendered blocks, six patterns and the `dokan//single-store` template,
so the page works out of the box on block themes and can be built in the Site
Editor with core WordPress alone. Every block reuses Dokan's data and keeps
firing the actions the classic page fires, so Dokan Pro and third-party
extensions keep working unchanged.

### Before Changes

* No blocks for the single store page; Elementor Pro was the only page-builder
  option; block themes rendered `/store/{slug}` as an unstyled fragment.

### After Changes

* Fourteen blocks under the **Dokan** inserter category, six patterns, and a
  registered template that renders complete themed store pages on block themes
  — with the classic path byte-identical.

### Pre-merge follow-ups

* [x] Rename `dokan/store-header`'s `layout` attribute → `headerLayout`.
* [x] Pro companion PR per ADR-0010 → getdokan/dokan-pro#6163.
* [ ] PHPUnit coverage — `dokan_get_current_store_tab()`, the `did_action()`
  guard, the privacy matrix.

### PR Self Review Checklist:

* [x] Code follows the project's style guidelines
* [x] No debugging statements or commented-out code left behind
* [x] Inline documentation explains *why*, not *what*
* [x] `composer phpcs` passes on every changed PHP file
* [x] `npx eslint src/blocks` is clean

