### PR TITLE
fix(rest): scope public store products to the store owner

### DIFF
--- a/includes/Abstracts/DokanRESTController.php
+++ b/includes/Abstracts/DokanRESTController.php
@@ -20,6 +20,37 @@ use WP_REST_Response;
 abstract class DokanRESTController extends WP_REST_Controller {
 
     /**
+     * Author id pinned by the route, overriding any caller supplied scope.
+     *
+     * `0` means no pinning, so the regular author gate in
+     * `prepare_objects_query()` applies.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @var int
+     */
+    protected $forced_author = 0;
+
+    /**
+     * Pin the listing to a single vendor, regardless of request params.
+     *
+     * Routes served with a public `permission_callback` cannot rely on the
+     * capability based author gate in `prepare_objects_query()`, because an
+     * anonymous caller resolves to author `0` and `WP_Query` silently drops the
+     * clause. Such routes must decide the scope themselves instead of widening
+     * the shared gate for every caller.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int $author_id Vendor id to scope the listing to.
+     *
+     * @return void
+     */
+    public function set_forced_author( int $author_id ) {
+        $this->forced_author = absint( $author_id );
+    }
+
+    /**
      * Get object.
      *
      * @param  int $id Object ID.
@@ -37,7 +68,14 @@ abstract class DokanRESTController extends WP_REST_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function get_items( $request ) {
-        $query_args   = $this->prepare_objects_query( $request );
+        $query_args = $this->prepare_objects_query( $request );
+
+        // Applied last so the route pinned scope wins over every request param,
+        // subclass override and `dokan_rest_{post_type}_object_query` callback.
+        if ( $this->forced_author ) {
+            $query_args['author'] = $this->forced_author;
+        }
+
         $query        = new WP_Query();
         $result       = $query->query( $query_args );
 
@@ -293,24 +331,14 @@ abstract class DokanRESTController extends WP_REST_Controller {
      * @return array
      */
     protected function prepare_objects_query( $request ) {
-        // Vendors are scoped to their own objects. Another vendor may be targeted via the id param
-        // only when the caller is a store admin, is that vendor, or the listing is limited to
-        // published (already-public) objects — the public stores/<id>/products route relies on the
-        // last case. Non-public statuses stay owner/admin-only, keeping the #3274 IDOR shut.
-        $current_user_id         = dokan_get_current_user_id();
-        $requested_id            = isset( $request['id'] ) ? absint( $request['id'] ) : 0;
-        $status                  = array_filter( (array) ( $request['status'] ?? $request['post_status'] ?? [] ) );
-        $is_public_only          = $status && array_diff( $status, [ 'publish' ] ) === [];
-        $can_target_other_vendor = $requested_id && (
-            current_user_can( dokan_admin_menu_capability() )
-            || $requested_id === $current_user_id
-            || $is_public_only
-        );
+        // Vendors are always scoped to their own objects; only a store admin may target another vendor via the id param.
+        $is_store_admin          = current_user_can( dokan_admin_menu_capability() );
+        $can_target_other_vendor = $is_store_admin && isset( $request['id'] );
 
         $args                        = array();
         $args['fields']              = 'ids';
         $args['post_status']         = ! isset( $request['post_status'] ) ? $this->post_status : $request['post_status'];
-        $args['author']              = $can_target_other_vendor ? $requested_id : $current_user_id;
+        $args['author']              = $can_target_other_vendor ? (int) $request['id'] : dokan_get_current_user_id();
         $args['offset']              = $request['offset'];
         $args['order']               = $request['order'];
         $args['orderby']             = $request['orderby'];
@@ -433,19 +461,23 @@ abstract class DokanRESTController extends WP_REST_Controller {
      * @return WP_REST_Response
      */
     public function format_collection_response( $response, $request, $total_items ) {
-        if ( intval( $total_items ) === 0 ) {
-            return $response;
-        }
+        $total_items = (int) $total_items;
 
         // Store pagation values for headers then unset for count query.
         $per_page = (int) ( ! empty( $request['per_page'] ) ? $request['per_page'] : 20 );
         $page     = (int) ( ! empty( $request['page'] ) ? $request['page'] : 1 );
 
-        $response->header( 'X-WP-Total', (int) $total_items );
+        $response->header( 'X-WP-Total', $total_items );
 
         $max_pages = ceil( $total_items / $per_page );
 
         $response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+        // An empty collection still reports its totals, it just has no prev/next link to offer.
+        if ( 0 === $total_items ) {
+            return $response;
+        }
+
         $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->base ) ) );
 
         if ( $page > 1 ) {

--- a/includes/Abstracts/DokanRESTController.php
+++ b/includes/Abstracts/DokanRESTController.php
@@ -293,14 +293,24 @@ abstract class DokanRESTController extends WP_REST_Controller {
      * @return array
      */
     protected function prepare_objects_query( $request ) {
-        // Vendors are always scoped to their own objects; only a store admin may target another vendor via the id param.
-        $is_store_admin          = current_user_can( dokan_admin_menu_capability() );
-        $can_target_other_vendor = $is_store_admin && isset( $request['id'] );
+        // Vendors are scoped to their own objects. Another vendor may be targeted via the id param
+        // only when the caller is a store admin, is that vendor, or the listing is limited to
+        // published (already-public) objects — the public stores/<id>/products route relies on the
+        // last case. Non-public statuses stay owner/admin-only, keeping the #3274 IDOR shut.
+        $current_user_id         = dokan_get_current_user_id();
+        $requested_id            = isset( $request['id'] ) ? absint( $request['id'] ) : 0;
+        $status                  = array_filter( (array) ( $request['status'] ?? $request['post_status'] ?? [] ) );
+        $is_public_only          = $status && array_diff( $status, [ 'publish' ] ) === [];
+        $can_target_other_vendor = $requested_id && (
+            current_user_can( dokan_admin_menu_capability() )
+            || $requested_id === $current_user_id
+            || $is_public_only
+        );
 
         $args                        = array();
         $args['fields']              = 'ids';
         $args['post_status']         = ! isset( $request['post_status'] ) ? $this->post_status : $request['post_status'];
-        $args['author']              = $can_target_other_vendor ? (int) $request['id'] : dokan_get_current_user_id();
+        $args['author']              = $can_target_other_vendor ? $requested_id : $current_user_id;
         $args['offset']              = $request['offset'];
         $args['order']               = $request['order'];
         $args['orderby']             = $request['orderby'];

--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -102,6 +102,10 @@ class Manager {
         $args = wp_parse_args( $args, $default );
 
         $query_args = [
+            // Without this, `wc_get_orders()` falls back to its own default of
+            // `[ 'shop_order', 'shop_order_refund' ]` and the collection comes
+            // back with `WC_Order_Refund` objects mixed in.
+            'type'       => $args['type'],
             'limit'      => $args['limit'],
             'paged'      => $args['paged'],
             'offset'     => $args['offset'],

--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -600,10 +600,24 @@ class StoreController extends WP_REST_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function get_store_products( $request ) {
+        $store_id = absint( $request['id'] );
+
+        if ( ! $store_id ) {
+            return new WP_Error( 'no_store_found', __( 'No store found', 'dokan-lite' ), [ 'status' => 404 ] );
+        }
+
         $product_controller = new ProductController();
 
+        /**
+         * This route is served with a public `permission_callback`, so the author scope is pinned
+         * here instead of being left to the capability based gate in `prepare_objects_query()`.
+         * An anonymous caller resolves to author `0` there, and `WP_Query` drops the clause
+         * altogether — which used to return the whole catalogue for every store id.
+         */
+        $product_controller->set_forced_author( $store_id );
+
         $request->set_param( 'status', [ 'publish' ] );
-        $request->set_param( 'author', $request['id'] );
+        $request->set_param( 'author', $store_id );
         $request->set_param( 'per_page', $request['per_page'] );
         $request->set_param( 'paged', $request['page'] );
 

--- a/tests/php/src/Orders/OrderManagerRefundTypeTest.php
+++ b/tests/php/src/Orders/OrderManagerRefundTypeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Orders;
+
+use WC_Order_Refund;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Order\Manager::all() must only ever return real orders.
+ *
+ * `get_backward_compatibility_args()` declares `'type' => 'shop_order'` but used to
+ * drop the key while building `$query_args`, so `wc_get_orders()` fell back to its
+ * own default of `[ 'shop_order', 'shop_order_refund' ]`. Any caller that did not
+ * scope by `seller_id` — the admin branch of `OrderController::get_items()` being
+ * the one in the plugin — then got `WC_Order_Refund` objects mixed into the
+ * collection and fatalled on `$object->get_refunds()`.
+ *
+ * Regressed in #1833 (3.8.0), reported as dokan-pro#6059.
+ *
+ * @group orders
+ * @group order-manager
+ */
+class OrderManagerRefundTypeTest extends DokanTestCase {
+
+    /**
+     * Order id carrying the refund.
+     *
+     * @var int
+     */
+    private $order_id;
+
+    /**
+     * Refund id created against the order.
+     *
+     * @var int
+     */
+    private $refund_id;
+
+    public function set_up() {
+        parent::set_up();
+
+        $this->order_id = $this->create_single_vendor_order( $this->seller_id1 );
+
+        $refund = wc_create_refund(
+            [
+                'amount'   => 5,
+                'reason'   => 'refund type regression',
+                'order_id' => $this->order_id,
+            ]
+        );
+
+        $this->assertNotWPError( $refund, 'Failed to seed the refund the test depends on.' );
+
+        $this->refund_id = $refund->get_id();
+    }
+
+    /**
+     * The unscoped listing — the admin path — must not leak refund objects.
+     */
+    public function test_all_excludes_refund_objects() {
+        $orders = dokan()->order->all( [ 'limit' => 20 ] );
+
+        $this->assertNotEmpty( $orders, 'The seeded order should be listed.' );
+
+        foreach ( $orders as $order ) {
+            $this->assertNotInstanceOf( WC_Order_Refund::class, $order, 'Order\Manager::all() returned a refund object.' );
+            $this->assertSame( 'shop_order', $order->get_type() );
+        }
+    }
+
+    /**
+     * The count query counts orders, not orders plus their refunds.
+     */
+    public function test_all_does_not_count_refunds() {
+        $ids   = dokan()->order->all(
+            [
+                'limit'  => 20,
+                'return' => 'ids',
+            ]
+        );
+        $count = dokan()->order->all(
+            [
+                'limit'  => 20,
+                'return' => 'count',
+            ]
+        );
+
+        $this->assertNotContains( $this->refund_id, $ids, 'The refund id must not appear in the id listing.' );
+        $this->assertSame( count( $ids ), (int) $count, 'The count must match the number of orders returned.' );
+    }
+
+    /**
+     * A caller asking for refunds still gets them — the default is a default, not a lock.
+     */
+    public function test_an_explicit_type_argument_is_still_honoured() {
+        $ids = dokan()->order->all(
+            [
+                'limit'  => 20,
+                'type'   => [ 'shop_order', 'shop_order_refund' ],
+                'return' => 'ids',
+            ]
+        );
+
+        $this->assertContains( $this->refund_id, $ids, 'An explicit type argument must override the shop_order default.' );
+    }
+
+    /**
+     * The unscoped admin listing used to fatal on `WC_Order_Refund::get_refunds()`.
+     */
+    public function test_admin_order_listing_survives_a_refunded_order() {
+        wp_set_current_user( $this->admin_id );
+
+        $response = $this->get_request( 'orders', [ 'per_page' => 20 ] );
+
+        $this->assertSame( 200, $response->get_status() );
+
+        foreach ( $response->get_data() as $order ) {
+            $this->assertNotSame( $this->refund_id, $order['id'], 'A refund must not be rendered as an order.' );
+        }
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+
+        parent::tear_down();
+    }
+}

--- a/tests/php/src/REST/StoreProductsScopeTest.php
+++ b/tests/php/src/REST/StoreProductsScopeTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Author scoping tests for the public store products route.
+ *
+ * `stores/<id>/products` is registered with `__return_true`, so it is normally
+ * served to an anonymous caller. These tests lock down both sides of that:
+ * the route must return exactly the requested store's published products, and
+ * widening it must not hand a vendor a way to read another vendor's objects.
+ *
+ * @group dokan-store-controller
+ * @group dokan-authorization
+ *
+ * @covers \WeDevs\Dokan\REST\StoreController::get_store_products
+ * @covers \WeDevs\Dokan\Abstracts\DokanRESTController::get_items
+ * @covers \WeDevs\Dokan\Abstracts\DokanRESTController::prepare_objects_query
+ * @covers \WeDevs\Dokan\Abstracts\DokanRESTController::format_collection_response
+ */
+class StoreProductsScopeTest extends DokanTestCase {
+
+    /**
+     * Vendor without a single product.
+     *
+     * @var int
+     */
+    protected int $empty_seller_id;
+
+    /**
+     * Published product owned by seller_id1.
+     *
+     * @var int
+     */
+    protected int $seller1_product_id;
+
+    /**
+     * Published product owned by seller_id2.
+     *
+     * @var int
+     */
+    protected int $seller2_product_id;
+
+    /**
+     * Draft product owned by seller_id2.
+     *
+     * @var int
+     */
+    protected int $seller2_draft_id;
+
+    /**
+     * Setup test fixtures.
+     *
+     * @return void
+     */
+    public function set_up() {
+        parent::set_up();
+
+        $this->empty_seller_id = $this->factory()->seller->create();
+
+        $this->seller1_product_id = $this->create_product( $this->seller_id1, 'Vendor One Published', 'publish' );
+        $this->seller2_product_id = $this->create_product( $this->seller_id2, 'Vendor Two Published', 'publish' );
+        $this->seller2_draft_id   = $this->create_product( $this->seller_id2, 'Vendor Two Draft', 'draft' );
+    }
+
+    /**
+     * Create a product owned by the given vendor.
+     *
+     * @param int    $seller_id Vendor the product belongs to.
+     * @param string $name      Product name.
+     * @param string $status    Post status.
+     *
+     * @return int Product id.
+     */
+    protected function create_product( int $seller_id, string $name, string $status ): int {
+        return $this->factory()->product
+            ->set_seller_id( $seller_id )
+            ->create(
+                [
+                    'name'          => $name,
+                    'sku'           => 'scope-' . sanitize_title( $name ),
+                    'status'        => $status,
+                    'regular_price' => '10',
+                ]
+            );
+    }
+
+    /**
+     * Collect the post authors of a collection response.
+     *
+     * @param array $data Response data.
+     *
+     * @return array<int> Unique author ids.
+     */
+    protected function get_authors( array $data ): array {
+        $authors = [];
+
+        foreach ( $data as $product ) {
+            $authors[] = (int) get_post_field( 'post_author', $product['id'] );
+        }
+
+        return array_values( array_unique( $authors ) );
+    }
+
+    /**
+     * A store with no products must report an empty collection, not the whole catalogue.
+     *
+     * @return void
+     */
+    public function test_anonymous_request_for_an_empty_store_returns_nothing(): void {
+        wp_set_current_user( 0 );
+
+        $response = $this->get_request( "stores/{$this->empty_seller_id}/products" );
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertSame( [], $response->get_data(), 'A store with no products must return an empty collection' );
+    }
+
+    /**
+     * An empty collection still has to advertise its totals.
+     *
+     * @return void
+     */
+    public function test_empty_store_response_carries_zero_total_headers(): void {
+        wp_set_current_user( 0 );
+
+        $response = $this->get_request( "stores/{$this->empty_seller_id}/products" );
+        $headers  = $response->get_headers();
+
+        $this->assertArrayHasKey( 'X-WP-Total', $headers, 'X-WP-Total must be sent even when the collection is empty' );
+        $this->assertEquals( 0, $headers['X-WP-Total'] );
+        $this->assertArrayHasKey( 'X-WP-TotalPages', $headers );
+        $this->assertEquals( 0, $headers['X-WP-TotalPages'] );
+    }
+
+    /**
+     * The route must return only the requested store's published products.
+     *
+     * @return void
+     */
+    public function test_anonymous_request_is_scoped_to_the_requested_store(): void {
+        wp_set_current_user( 0 );
+
+        $response = $this->get_request( "stores/{$this->seller_id2}/products" );
+        $data     = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertNotEmpty( $data );
+        $this->assertSame( [ $this->seller_id2 ], $this->get_authors( $data ) );
+
+        $product_ids = wp_list_pluck( $data, 'id' );
+        $this->assertContains( $this->seller2_product_id, $product_ids );
+        $this->assertNotContains( $this->seller1_product_id, $product_ids, 'Another vendor\'s products must not leak' );
+        $this->assertNotContains( $this->seller2_draft_id, $product_ids, 'Draft products are not public' );
+    }
+
+    /**
+     * A logged in vendor gets the same store scoped answer, not their own products.
+     *
+     * @return void
+     */
+    public function test_vendor_browsing_another_store_gets_that_store_products(): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( "stores/{$this->seller_id2}/products" );
+        $data     = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertNotEmpty( $data );
+        $this->assertSame( [ $this->seller_id2 ], $this->get_authors( $data ) );
+        $this->assertNotContains( $this->seller2_draft_id, wp_list_pluck( $data, 'id' ) );
+    }
+
+    /**
+     * A store id of `0` cannot be resolved, so it must not fall through to an unscoped query.
+     *
+     * @return void
+     */
+    public function test_zero_store_id_is_rejected(): void {
+        wp_set_current_user( 0 );
+
+        $response = $this->get_request( 'stores/0/products' );
+
+        $this->assertEquals( 404, $response->get_status() );
+        $this->assertEquals( 'no_store_found', $response->get_data()['code'] );
+    }
+
+    /**
+     * Regression guard for #3274: the `id` param must not scope a vendor's product listing
+     * to another vendor, whichever status param is used to try to unlock it.
+     *
+     * @dataProvider status_param_provider
+     *
+     * @param array $status_params Status parameters sent along with the `id` param.
+     *
+     * @return void
+     */
+    public function test_vendor_cannot_target_another_vendor_via_id_param( array $status_params ): void {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->get_request( 'products', array_merge( [ 'id' => $this->seller_id2 ], $status_params ) );
+        $data     = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertNotEmpty( $data, 'The vendor should still see their own products' );
+        $this->assertSame( [ $this->seller_id1 ], $this->get_authors( $data ) );
+        $this->assertNotContains( $this->seller2_draft_id, wp_list_pluck( $data, 'id' ) );
+    }
+
+    /**
+     * Status parameter combinations a vendor could use to try to widen the author gate.
+     *
+     * @return array<string, array<array<string, mixed>>>
+     */
+    public function status_param_provider(): array {
+        return [
+            'no status param'      => [ [] ],
+            'status=publish'       => [ [ 'status' => 'publish' ] ],
+            'post_status=publish'  => [ [ 'post_status' => 'publish' ] ],
+            'post_status[]=publish' => [ [ 'post_status' => [ 'publish' ] ] ],
+        ];
+    }
+
+    /**
+     * A store admin keeps the ability to list another vendor's products, drafts included.
+     *
+     * @return void
+     */
+    public function test_store_admin_can_still_target_another_vendor(): void {
+        wp_set_current_user( $this->admin_id );
+
+        $response = $this->get_request( 'products', [ 'id' => $this->seller_id2 ] );
+        $data     = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertSame( [ $this->seller_id2 ], $this->get_authors( $data ) );
+        $this->assertContains( $this->seller2_draft_id, wp_list_pluck( $data, 'id' ) );
+    }
+}

--- a/tests/pw/tests/api/stores.spec.ts
+++ b/tests/pw/tests/api/stores.spec.ts
@@ -106,6 +106,47 @@ test.describe('stores api test', () => {
         expect(responseBody).toMatchSchema(schemas.storesSchema.storeProductsSchema);
     });
 
+    // The route is public, so these run without an Authorization header on purpose.
+    test('get store products is scoped to the requested store', { tag: ['@lite'] }, async () => {
+        const [, vendorId] = await apiUtils.getCurrentUser(payloads.vendorAuth);
+        await apiUtils.createProduct(payloads.createProduct(), payloads.vendorAuth);
+
+        const [response, responseBody] = await apiUtils.get(endPoints.getStoreProducts(vendorId));
+        expect(response.ok()).toBeTruthy();
+        expect(responseBody.length).toBeGreaterThan(0);
+        for (const product of responseBody) {
+            expect(String(product.post_author)).toBe(vendorId);
+            expect(product.status).toBe('publish');
+        }
+    });
+
+    test('get store products of an empty store returns nothing', { tag: ['@lite'] }, async () => {
+        const [, emptyStoreId] = await apiUtils.createStore(payloads.createStore());
+
+        const [response, responseBody] = await apiUtils.get(endPoints.getStoreProducts(emptyStoreId));
+        expect(response.ok()).toBeTruthy();
+        expect(responseBody).toEqual([]);
+        expect(response.headers()['x-wp-total']).toBe('0');
+    });
+
+    test('vendor can not list another vendor products via the id param', { tag: ['@lite'] }, async () => {
+        const [, vendorId] = await apiUtils.getCurrentUser(payloads.vendorAuth);
+        const [, vendor2Id] = await apiUtils.getCurrentUser(payloads.vendor2Auth);
+        await apiUtils.createProduct(payloads.createProduct(), payloads.vendorAuth);
+        await apiUtils.createProduct(payloads.createProduct(), payloads.vendor2Auth);
+
+        const bypassAttempts: Record<string, string>[] = [{ id: vendor2Id }, { id: vendor2Id, status: 'publish' }, { id: vendor2Id, post_status: 'publish' }];
+
+        for (const params of bypassAttempts) {
+            const [response, responseBody] = await apiUtils.get(endPoints.getAllProducts, { params, headers: payloads.vendorAuth });
+            expect(response.ok()).toBeTruthy();
+            expect(responseBody.length).toBeGreaterThan(0);
+            for (const product of responseBody) {
+                expect(String(product.post_author)).toBe(vendorId);
+            }
+        }
+    });
+
     test('update a store status', { tag: ['@lite'] }, async () => {
         const [response, responseBody] = await apiUtils.put(endPoints.updateStoreStatus(sellerId), { data: payloads.updateStoreStatus });
         expect(response.ok()).toBeTruthy();


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

`GET /wp-json/dokan/v1/stores/<id>/products` is registered with `'permission_callback' => '__return_true'`, so it is served in a non-admin (usually unauthenticated) context. Since #3274, the shared `DokanRESTController::prepare_objects_query()` honoured the `id` param **only** for store admins. For every other caller, `author` fell back to `dokan_get_current_user_id()`, which is `0` for an anonymous request. `WP_Query` silently discards `author = 0`, so no `post_author` clause was emitted and the endpoint returned **the entire catalogue for every store id** — a store with zero products returned a full page.

**The scope is now decided by the route, not by a caller-supplied param.** The #3274 gate in the shared abstract is restored verbatim.

* `DokanRESTController::set_forced_author()` pins a listing to a single vendor. It is applied in `get_items()`, immediately before `WP_Query` runs, so the pin also survives subclass `prepare_objects_query()` overrides (e.g. `ProductControllerV2` unsets `author`) and any `dokan_rest_{post_type}_object_query` callback.
* `StoreController::get_store_products()` pins the requested store id, and rejects a `0` id with a 404 so it can never fall through to an unscoped query.
* `format_collection_response()` emits `X-WP-Total` / `X-WP-TotalPages` before returning an empty collection, so an empty store reports `0` instead of omitting the header.

An earlier revision of this PR instead widened the shared author gate to honour `id` for "published only" listings. That was withdrawn — it reopened #3274, because the gate read `status` while `ProductController` builds the query from `post_status`, and because `publish` is an internal default rather than a public status for several of the ~15 Lite + Pro controllers that inherit the abstract. See @MdAsifHossainNadim's review for the full reproduction.

### Related Pull Request(s)

* #3274 (introduced the admin-only author gate, which this PR now leaves untouched)

### Closes

* Closes getdokan/plugin-internal-tasks#2209

### How to test the changes in this Pull Request:

1. Create two vendors: one with published products (plus a draft), one with none.
2. Log out (or hit the REST endpoint without a nonce → unauthenticated).
3. `GET /wp-json/dokan/v1/stores/<empty-vendor-id>/products` → expect `[]` and `X-WP-Total: 0`.
4. `GET /wp-json/dokan/v1/stores/<vendor-with-products-id>/products` → expect only that vendor's **published** products.
5. `GET /wp-json/dokan/v1/stores/0/products` → expect a 404 `no_store_found`.
6. Regression: as vendor A, `GET /wp-json/dokan/v1/products?id=<vendorB>` — with and without `status=publish`, `post_status=publish`, `post_status[]=publish` — must stay scoped to vendor A every time.
7. Regression: as vendor A, `GET /wp-json/dokan/v1/coupons?id=<vendorB>&status=publish` → must stay scoped to vendor A.

### Tests

* `tests/php/src/REST/StoreProductsScopeTest.php` — 10 tests / 37 assertions dispatching real REST requests. Five of them fail on the previous head (`cc958108d`) and pass on this one.
* `tests/pw/tests/api/stores.spec.ts` — the same store-scoping checks over real HTTP with **no** `Authorization` header. The pre-existing `get store products` case fetched the admin's own store as admin, which is why it stayed green while the endpoint was returning the whole catalogue.

### Changelog entry

*Fix: public store products endpoint leaked the entire catalogue*

**Before:** `GET /stores/<id>/products` returned the whole site catalogue for every store id when the request was not made by an admin (i.e. all public/app traffic), because the store id was resolved to `author = 0` and `WP_Query` dropped the constraint.

**After:** the endpoint returns only the published products authored by the requested store, for any caller, and an empty store reports `X-WP-Total: 0`. The vendor/admin authorization gate for `dokan/v1/products` and every other controller sharing the abstract is unchanged.
