### PR TITLE
fix(product-editor): honor configured placeholder for Attributes field

### DIFF
--- a/src/dashboard/product-editor/components/AttributesEdit.tsx
+++ b/src/dashboard/product-editor/components/AttributesEdit.tsx
@@ -174,6 +174,10 @@ const AttributesEdit = ( { data, field, onChange, validity }: any ) => {
         } ) );
     }, [] );
 
+    const placeholder =
+        field.placeholder ||
+        __( 'Add existing attribute or custom', 'dokan-lite' );
+
     return (
         <CustomField field={ field } error={ getValidationError( validity ) }>
             <div className="flex flex-col gap-4">
@@ -215,10 +219,7 @@ const AttributesEdit = ( { data, field, onChange, validity }: any ) => {
                             onChange={ ( val: any ) =>
                                 setSelectedAttrAdd( val )
                             }
-                            placeholder={ __(
-                                'Add existing attribute or custom',
-                                'dokan-lite'
-                            ) }
+                            placeholder={ placeholder }
                             isClearable={ false }
                         />
                     </div>


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the WordPress' coding standards
* [x] My code satisfies feature requirements
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

The Attributes edit component (`AttributesEdit.tsx`) hardcoded the placeholder
of its "add attribute" `AsyncSelect`, ignoring the placeholder text configured
in the Product Form Manager. Every other field edit component
(`SelectEdit`, `PriceEdit`, `AsyncSelectEdit`, `RichTextEdit`, `TextAreaEdit`,
`DateTimePickerEdit`, `FileUploadEdit`) reads `field.placeholder` — Attributes
was the only exception, so admin-configured placeholder text was silently
dropped for that section only.

Now reads `field.placeholder` with the previous string as fallback, matching
the pattern used by all other sections.

### Closes

* Closes getdokan/dokan-pro#6028
* Closes https://github.com/getdokan/plugin-internal-tasks/issues/2221

### How to test the changes in this Pull Request:

1. Open the **Product Form Manager** settings.
2. Add placeholder text to a field in the **Attributes** section. Save.
3. Open the product create/edit form on the storefront.
4. The Attributes "add" field now shows the configured placeholder.
   (Previously it always showed "Add existing attribute or custom".)

### Changelog entry

*Fix: Attributes field placeholder from Product Form Manager not displayed*

Previously the Attributes section ignored the placeholder configured in the
Product Form Manager and always showed a hardcoded string. Now the configured
placeholder is displayed, consistent with every other section. When no
placeholder is configured, the original default text is used.

### Before Changes

Attributes field always displays "Add existing attribute or custom" regardless
of configured placeholder. See https://imgur.com/a/2phslS4

### After Changes

Attributes field displays the placeholder configured in the Product Form Manager.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute editing fields by honoring custom placeholder text when provided.
  * Preserved localized placeholder text as a fallback when no custom value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->