### PR TITLE
fix(vendor-dashboard): decode entities in React vendor dashboard menu labels

### DIFF
--- a/src/vendor-dashboard/layout/components/Header.tsx
+++ b/src/vendor-dashboard/layout/components/Header.tsx
@@ -114,7 +114,11 @@ const Header = ( { onToggleSidebar }: { onToggleSidebar: () => void } ) => {
                                                             item?.icon
                                                         )
                                                     ) }
-                                                    <span>{ item?.label }</span>
+                                                    <span>
+                                                        { decodeEntities(
+                                                            item?.label
+                                                        ) }
+                                                    </span>
                                                 </a>
                                             </li>
                                         )

--- a/src/vendor-dashboard/layout/components/Sidebar.tsx
+++ b/src/vendor-dashboard/layout/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
     useState,
 } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import * as LucideIcons from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
@@ -37,6 +38,16 @@ export const getActiveSubmenuKey = (
     } );
     return activeKey;
 };
+
+// Labels arrive HTML-escaped from esc_html__, so decode for display (&amp; -> &) while JSX still escapes markup.
+const getMenuTitle = ( hookName: string, menuItem: any ): string =>
+    decodeEntities(
+        applyFilters(
+            hookName,
+            menuItem?.menu_manager_title || menuItem?.title,
+            menuItem
+        ) as string
+    );
 
 const Sidebar = ( {
     collapsed,
@@ -313,11 +324,10 @@ const Sidebar = ( {
                                     );
 
                                     const menuItemRef = getMenuItemRef( key );
-                                    const menuTitle = applyFilters(
+                                    const menuTitle = getMenuTitle(
                                         'dokan_sidebar_menu_title',
-                                        item?.menu_manager_title || item?.title,
                                         item
-                                    ) as string;
+                                    );
                                     const isMenuItemActive =  isParentActive || isParentActiveCollapsed ;
 
                                     return (
@@ -460,12 +470,10 @@ const Sidebar = ( {
                                                                     activeSubkey;
 
                                                                 const subMenuTitle =
-                                                                    applyFilters(
+                                                                    getMenuTitle(
                                                                         'dokan_sidebar_submenu_title',
-                                                                        subitem?.menu_manager_title ||
-                                                                            subitem?.title,
                                                                         subitem
-                                                                    ) as string;
+                                                                    );
 
                                                                 return (
                                                                     <li

--- a/src/vendor-dashboard/layout/components/SubmenuPopover.tsx
+++ b/src/vendor-dashboard/layout/components/SubmenuPopover.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@wordpress/components';
 import { twMerge } from 'tailwind-merge';
 // eslint-disable-next-line import/named
 import { RefObject, useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { isRTL } from '@wordpress/i18n';
 import { getActiveSubmenuKey } from './Sidebar';
 
@@ -65,7 +66,7 @@ const SubmenuPopover = ( {
                                         ) }
                                     >
                                         <span className="ms-1">
-                                            { subitem.title }
+                                            { decodeEntities( subitem.title ) }
                                         </span>
                                         { subitem.counts > 0 && (
                                             <span className="ms-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 py-0.5 text-[10px] font-semibold leading-none rounded-md text-white sidebar-submenu-bubble">


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the ESLint tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

A vendor dashboard menu label translated to text containing an ampersand rendered as `Leverans &amp; upphämtning` instead of `Leverans & upphämtning`.

The cause is a mismatch between how the labels are produced and how the React dashboard consumes them. Around a dozen menu registrations across Lite and Pro build their title with `esc_html__()` rather than `__()`, so the translated string is already HTML-escaped by the time it reaches `vendorDashboardLayoutConfig`. The legacy PHP menu prints that string into markup, where `&amp;` renders as `&` and nothing looks wrong. The React sidebar renders it as text, so the entity shows up literally.

This decodes entities at the four places that print those labels: the sidebar menu title, the expanded submenu title, the collapsed-sidebar popover, and the header account dropdown. JSX still escapes any markup, so this only restores display text — it does not introduce an HTML sink. `decodeEntities` is already the established convention for this in Lite (`Header.tsx` uses it on `item?.url`, and there are ~20 more call sites across the dashboard and product editor).

**Why here rather than at the registrations.** `dokan_get_dashboard_nav` and `dokan_get_dashboard_settings_nav` are public filters, so the set of registrations is unbounded — third-party modules will keep shipping `esc_html__()`. Fixing the ~13 in-repo sites (8 in Pro's `Reports.php`, plus `Review.php`, `ManualOrders/Menus.php`, `Announcement`, `delivery-time`, `booking`, `export-import`, `subscription`, `vendor-staff`, `store-support`, `simple-auction`, `vendor-analytics`, and Lite's `ReverseWithdrawal/Hooks.php`) would leave every third-party menu broken and would need a matching change in Pro. Decoding at render is the one place that covers all of them, including labels set through the Menu Manager.

While in there, the duplicated `menu_manager_title || title` + `applyFilters` resolution is extracted into a small `getMenuTitle()` helper shared by the two sidebar call sites. The popover keeps its own one-liner — it deliberately reads `subitem.title` raw with no filter and no `menu_manager_title` fallback, and unifying that would change behaviour.

### Closes

* Closes getdokan/dokan-pro#6038
* Closes getdokan/plugin-internal-tasks#2230

### How to test the changes in this Pull Request:

1. Translate a vendor dashboard menu label to text containing an ampersand — the issue's case is the Pro **Delivery Time** menu translated to `Leverans & upphämtning`. A quick stand-in without a locale file:

   ```php
   add_filter( 'gettext_dokan', function ( $t, $text ) {
       return 'Delivery Time' === $text ? 'Leverans & upphämtning' : $t;
   }, 10, 2 );
   ```

2. Open the vendor dashboard. The sidebar label reads `Leverans & upphämtning`, not `Leverans &amp; upphämtning`.
3. Expand a menu with a submenu whose label is also registered with `esc_html__()` (translate `Statement` under **Reports** to something containing `&`) and confirm the expanded submenu is correct.
4. Collapse the sidebar and hover the same menu — the popover label is correct too.
5. Translate `My Account` (the `dokan-lite` text domain) to something containing `&` and open the header account dropdown at the top right — that label is correct as well.
6. Confirm every other menu label still renders normally, and that the legacy (non-React) vendor dashboard menu is unaffected.

### Changelog entry

*Fix - Ampersands in translated vendor dashboard menu labels displayed as `&amp;`*

A vendor dashboard menu label translated to text containing an ampersand rendered the raw `&amp;` entity in the React dashboard, while the same string displayed correctly everywhere else. Menu labels are now decoded before display in the sidebar, submenus, the collapsed-sidebar popover and the header account dropdown, so translated labels appear exactly as entered.

### Before Changes

Sidebar showed `Leverans &amp; upphämtning`; the header account dropdown showed `Konto &amp; profil`.

### After Changes

Both read `Leverans & upphämtning` and `Konto & profil`. The raw config values are unchanged (`vendorDashboardLayoutConfig` still carries the escaped strings) — only the display is fixed.

### Note for reviewers

The underlying `esc_html__()` in the menu registrations is left alone on purpose, per the reasoning above. If the team would rather correct those at source as well, the Pro side is a separate PR and this one should stay regardless, to cover third-party menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
