### PR TITLE
fix(product-editor): enforce the required "Downloadable Files" field

### DIFF
--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -124,6 +124,53 @@ class FormSchema {
     }
 
     /**
+     * Resolve a field's label for a product type, falling back to its shared label.
+     *
+     * Fields can vary by product type through the `labels`, `requireds` and `visibilities` maps, which
+     * Dokan Pro's Product Form Manager writes into. These three resolvers are the PHP counterpart of
+     * `resolveLabel`, `resolveRequired` and `resolveVisibility` in
+     * `src/dashboard/product-editor/utils.tsx`, so both sides read the schema the same way.
+     *
+     * @since 5.0.13
+     *
+     * @param array  $field        Schema field.
+     * @param string $product_type Product type the field is resolved for.
+     *
+     * @return string
+     */
+    public static function get_label( array $field, string $product_type = Elements::PRODUCT_TYPE_SIMPLE ): string {
+        return (string) ( $field['labels'][ $product_type ] ?? $field['label'] ?? '' );
+    }
+
+    /**
+     * Whether a field must be filled in for a product type.
+     *
+     * @since 5.0.13
+     *
+     * @param array  $field        Schema field.
+     * @param string $product_type Product type the field is resolved for.
+     *
+     * @return bool
+     */
+    public static function is_required( array $field, string $product_type = Elements::PRODUCT_TYPE_SIMPLE ): bool {
+        return (bool) ( $field['requireds'][ $product_type ] ?? $field['required'] ?? false );
+    }
+
+    /**
+     * Whether a field is rendered for a product type.
+     *
+     * @since 5.0.13
+     *
+     * @param array  $field        Schema field.
+     * @param string $product_type Product type the field is resolved for.
+     *
+     * @return bool
+     */
+    public static function is_visible( array $field, string $product_type = Elements::PRODUCT_TYPE_SIMPLE ): bool {
+        return (bool) ( $field['visibilities'][ $product_type ] ?? $field['visibility'] ?? true );
+    }
+
+    /**
      * Get available product types as label/value pairs.
      *
      * @since 5.0.0

--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -131,7 +131,7 @@ class FormSchema {
      * `resolveLabel`, `resolveRequired` and `resolveVisibility` in
      * `src/dashboard/product-editor/utils.tsx`, so both sides read the schema the same way.
      *
-     * @since 5.0.13
+     * @since DOKAN_SINCE
      *
      * @param array  $field        Schema field.
      * @param string $product_type Product type the field is resolved for.
@@ -145,7 +145,7 @@ class FormSchema {
     /**
      * Whether a field must be filled in for a product type.
      *
-     * @since 5.0.13
+     * @since DOKAN_SINCE
      *
      * @param array  $field        Schema field.
      * @param string $product_type Product type the field is resolved for.
@@ -159,7 +159,7 @@ class FormSchema {
     /**
      * Whether a field is rendered for a product type.
      *
-     * @since 5.0.13
+     * @since DOKAN_SINCE
      *
      * @param array  $field        Schema field.
      * @param string $product_type Product type the field is resolved for.

--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -124,6 +124,32 @@ class FormSchema {
     }
 
     /**
+     * Find a field in a flat schema by id.
+     *
+     * Sections and fields share one id namespace, so the type is part of the match: a section - or an item an
+     * extension adds through `dokan_product_editor_prepared_schema` - carrying the same id must not answer for
+     * the field, since it has no `requireds` map and would silently switch a rule off.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array  $schema Flat schema items.
+     * @param string $id     Field id to find.
+     *
+     * @return array|null
+     */
+    public static function get_field( array $schema, string $id ): ?array {
+        $matches = wp_list_filter(
+            $schema,
+            [
+				'id'   => $id,
+				'type' => 'field',
+			]
+        );
+
+        return $matches ? reset( $matches ) : null;
+    }
+
+    /**
      * Resolve a field's label for a product type, falling back to its shared label.
      *
      * Fields can vary by product type through the `labels`, `requireds` and `visibilities` maps, which
@@ -852,6 +878,7 @@ class FormSchema {
                 'visibility'   => true,
             ],
         ];
+        // Track the Downloadable checkbox per product type: where a vendor cannot tick it, they must not be asked to fill the section it reveals.
         $downloadable_fields = [
             [
                 'id'           => Elements::SECTION_DOWNLOADABLE,
@@ -860,6 +887,7 @@ class FormSchema {
                 'label'        => __( 'Downloadable Options', 'dokan-lite' ),
                 'description'  => __( 'Configure your downloadable product settings', 'dokan-lite' ),
                 'visibility'   => true,
+                'visibilities' => $digital_field_visibilities,
                 'dependencies' => $dep_downloadable,
             ],
             [
@@ -873,6 +901,7 @@ class FormSchema {
                 'description'  => __( 'Upload files that customers can download after purchase.', 'dokan-lite' ),
                 'dependencies' => $dep_downloadable,
                 'visibility'   => true,
+                'visibilities' => $digital_field_visibilities,
             ],
             [
                 'id'           => Elements::DOWNLOAD_LIMIT,
@@ -884,6 +913,7 @@ class FormSchema {
                 'description'  => __( 'Leave blank for unlimited re-downloads.', 'dokan-lite' ),
                 'dependencies' => $dep_downloadable,
                 'visibility'   => true,
+                'visibilities' => $digital_field_visibilities,
             ],
             [
                 'id'           => Elements::DOWNLOAD_EXPIRY,
@@ -895,6 +925,7 @@ class FormSchema {
                 'description'  => __( 'Enter the number of days before a download link expires, or leave blank.', 'dokan-lite' ),
                 'dependencies' => $dep_downloadable,
                 'visibility'   => true,
+                'visibilities' => $digital_field_visibilities,
             ],
         ];
         $others_fields = [

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -359,9 +359,9 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
          *
          * @since DOKAN_SINCE
          *
-         * @param WC_Data|WP_Error $product  Product assembled from the request, not yet saved.
-         * @param WP_REST_Request  $request  Full details about the request.
-         * @param bool             $creating Whether a new product is being created.
+         * @param WC_Data         $product  Product assembled from the request, not yet saved.
+         * @param WP_REST_Request $request  Full details about the request.
+         * @param bool            $creating Whether a new product is being created.
          */
         return apply_filters( "dokan_rest_pre_insert_{$this->post_type}_object", $product, $request, $creating );
     }
@@ -383,6 +383,9 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * enforcing every required field here would reject those saves outright. Extensions that need their own
      * rules can hook `dokan_rest_pre_insert_product_object`.
      *
+     * Product variations are out of reach here: WooCommerce saves them through WC_REST_Product_Variations_Controller,
+     * which never enters this controller, so a downloadable variation is guarded in the browser only.
+     *
      * @since DOKAN_SINCE
      *
      * @param WP_REST_Request $request Full details about the request.
@@ -398,15 +401,20 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             return null;
         }
 
-        if ( ! $product->is_downloadable() || $product->get_downloads() ) {
+        if ( ! $product->is_downloadable() ) {
             return null;
         }
 
-        // Only a save with nothing attached needs the schema, which is expensive to build.
+        // WooCommerce drops rows on empty() alone, so a whitespace-only file still arrives here - and still saves when the field is optional.
+        foreach ( $product->get_downloads() as $download ) {
+            if ( '' !== trim( (string) $download->get_file() ) ) {
+                return null;
+            }
+        }
+
+        // Only a save with nothing attached needs the schema, which is expensive to build - and never its resolved values.
         $product_type = $product->get_type();
-        $schema       = dokan()->product_editor->get_schema( $product->get_id() );
-        $matches      = wp_list_filter( $schema, [ 'id' => Elements::DOWNLOADS ] );
-        $field        = reset( $matches );
+        $field        = FormSchema::get_field( dokan()->product_editor->get_schema(), Elements::DOWNLOADS );
 
         if ( ! $field || ! FormSchema::is_required( $field, $product_type ) || ! FormSchema::is_visible( $field, $product_type ) ) {
             return null;

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -324,9 +324,11 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * Prepare a single product for create or update.
      *
      * Every save funnels through here - WooCommerce routes create, update and batch alike through
-     * save_object() - so form-level validation is hooked once here instead of per endpoint.
+     * save_object() - so form-level validation runs once here instead of per endpoint, and it judges
+     * the product WooCommerce assembled rather than the raw payload. Nothing is persisted until
+     * save_object() calls save() on what this returns.
      *
-     * @since 5.0.13
+     * @since DOKAN_SINCE
      *
      * @param WP_REST_Request $request  Full details about the request.
      * @param bool            $creating Whether a new product is being created.
@@ -334,7 +336,34 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * @return WC_Data|WP_Error
      */
     protected function prepare_object_for_database( $request, $creating = false ) {
-        return $this->validate_required_downloads( $request ) ?? parent::prepare_object_for_database( $request, $creating );
+        $product = parent::prepare_object_for_database( $request, $creating );
+
+        if ( is_wp_error( $product ) ) {
+            return $product;
+        }
+
+        /**
+         * Filters form-level validation of a vendor product save.
+         *
+         * Return a WP_Error to reject the save. Extensions that add required fields to the product
+         * form can enforce them here instead of patching the controller.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param WP_Error|null   $error    Error to reject the save with, null to allow it.
+         * @param WC_Data         $product  Product assembled from the request, not yet saved.
+         * @param WP_REST_Request $request  Full details about the request.
+         * @param bool            $creating Whether a new product is being created.
+         */
+        $error = apply_filters(
+            'dokan_rest_product_validate_save',
+            $this->validate_required_downloads( $request, $product ),
+            $product,
+            $request,
+            $creating
+        );
+
+        return is_wp_error( $error ) ? $error : $product;
     }
 
     /**
@@ -344,36 +373,40 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * read back from the schema rather than hard-coded. Browser-side validation alone can be bypassed, which
      * is how incomplete downloadable products reach the review queue.
      *
+     * Judged on the assembled product rather than on the payload, because the payload can be shaped to dodge
+     * the rule: WooCommerce turns a product downloadable from `downloadable` alone and only reads `downloads`
+     * when that key is sent, and it drops file-less rows in save_downloadable_files(). A save that leaves
+     * both fields alone, such as quick edit, stays out of scope.
+     *
      * Deliberately scoped to this one field: the schema marks several fields required that a partial form
      * never renders yet still submits empty - the quick-create modal omits the required Description - so
-     * enforcing every required field here would reject those saves outright.
+     * enforcing every required field here would reject those saves outright. Extensions that need their own
+     * rules can hook `dokan_rest_product_validate_save`.
      *
-     * @since 5.0.13
+     * @since DOKAN_SINCE
      *
      * @param WP_REST_Request $request Full details about the request.
+     * @param WC_Data         $product Product assembled from the request, not yet saved.
      *
      * @return WP_Error|null Error when the required file is missing, null otherwise.
      */
-    protected function validate_required_downloads( $request ) {
-        $downloads = $request->get_param( Elements::DOWNLOADS );
+    protected function validate_required_downloads( $request, $product ) {
+        $touches_downloads = null !== $request->get_param( Elements::DOWNLOADS )
+            || null !== $request->get_param( Elements::DOWNLOADABLE );
 
-        // A save that leaves the downloadable fields alone, such as quick edit, is none of our business.
-        if ( ! is_array( $downloads ) || ! dokan_string_to_bool( $request->get_param( Elements::DOWNLOADABLE ) ) ) {
+        if ( ! $touches_downloads || ! $product instanceof WC_Product ) {
             return null;
         }
 
-        foreach ( $downloads as $download ) {
-            if ( ! empty( $download['file'] ) ) {
-                return null;
-            }
+        if ( ! $product->is_downloadable() || $product->get_downloads() ) {
+            return null;
         }
 
         // Only a save with nothing attached needs the schema, which is expensive to build.
-        $product_type = $request->get_param( Elements::TYPE );
-        $product_type = is_string( $product_type ) && '' !== $product_type ? $product_type : Elements::PRODUCT_TYPE_SIMPLE;
-
-        $schema = dokan()->product_editor->get_schema( (int) $request->get_param( 'id' ) );
-        $field  = current( wp_list_filter( $schema, [ 'id' => Elements::DOWNLOADS ] ) );
+        $product_type = $product->get_type();
+        $schema       = dokan()->product_editor->get_schema( $product->get_id() );
+        $matches      = wp_list_filter( $schema, [ 'id' => Elements::DOWNLOADS ] );
+        $field        = reset( $matches );
 
         if ( ! $field || ! FormSchema::is_required( $field, $product_type ) || ! FormSchema::is_visible( $field, $product_type ) ) {
             return null;

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -325,8 +325,10 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      *
      * Every save funnels through here - WooCommerce routes create, update and batch alike through
      * save_object() - so form-level validation runs once here instead of per endpoint, and it judges
-     * the product WooCommerce assembled rather than the raw payload. Nothing is persisted until
-     * save_object() calls save() on what this returns.
+     * the product WooCommerce assembled rather than the raw payload. The product itself is not written
+     * until save_object() calls save() on what this returns, though the parent call can already have
+     * created attachment records when a payload sends images by URL; the vendor form only ever sends
+     * attachment ids.
      *
      * @since DOKAN_SINCE
      *
@@ -342,28 +344,26 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             return $product;
         }
 
+        $invalid = $this->validate_required_downloads( $request, $product );
+
+        if ( is_wp_error( $invalid ) ) {
+            return $invalid;
+        }
+
         /**
-         * Filters form-level validation of a vendor product save.
+         * Filters a vendor product prepared for the database, before it is saved.
          *
-         * Return a WP_Error to reject the save. Extensions that add required fields to the product
-         * form can enforce them here instead of patching the controller.
+         * Scoped to vendor dashboard saves, unlike WooCommerce's own
+         * `woocommerce_rest_pre_insert_product_object`. Return a WP_Error to reject the save, which
+         * is how extensions enforce required fields they add to the product form.
          *
          * @since DOKAN_SINCE
          *
-         * @param WP_Error|null   $error    Error to reject the save with, null to allow it.
-         * @param WC_Data         $product  Product assembled from the request, not yet saved.
-         * @param WP_REST_Request $request  Full details about the request.
-         * @param bool            $creating Whether a new product is being created.
+         * @param WC_Data|WP_Error $product  Product assembled from the request, not yet saved.
+         * @param WP_REST_Request  $request  Full details about the request.
+         * @param bool             $creating Whether a new product is being created.
          */
-        $error = apply_filters(
-            'dokan_rest_product_validate_save',
-            $this->validate_required_downloads( $request, $product ),
-            $product,
-            $request,
-            $creating
-        );
-
-        return is_wp_error( $error ) ? $error : $product;
+        return apply_filters( "dokan_rest_pre_insert_{$this->post_type}_object", $product, $request, $creating );
     }
 
     /**
@@ -381,7 +381,7 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * Deliberately scoped to this one field: the schema marks several fields required that a partial form
      * never renders yet still submits empty - the quick-create modal omits the required Description - so
      * enforcing every required field here would reject those saves outright. Extensions that need their own
-     * rules can hook `dokan_rest_product_validate_save`.
+     * rules can hook `dokan_rest_pre_insert_product_object`.
      *
      * @since DOKAN_SINCE
      *

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -280,12 +280,6 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function create_item( $request ) {
-        $missing_download = $this->validate_required_downloads( $request );
-
-        if ( is_wp_error( $missing_download ) ) {
-            return $missing_download;
-        }
-
         $product = parent::create_item( $request );
 
         if ( is_wp_error( $product ) ) {
@@ -311,12 +305,6 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function update_item( $request ) {
-        $missing_download = $this->validate_required_downloads( $request, (int) $request->get_param( 'id' ) );
-
-        if ( is_wp_error( $missing_download ) ) {
-            return $missing_download;
-        }
-
         $product = parent::update_item( $request );
 
         if ( is_wp_error( $product ) ) {
@@ -333,54 +321,46 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
     }
 
     /**
-     * Reject a downloadable product saved without a file while the form marks "Downloadable Files" as required.
+     * Prepare a single product for create or update.
      *
-     * The required flag lives in the form schema (Dokan Pro's Product Form Manager writes it there), so it is
-     * resolved from the schema rather than hard-coded. Browser-side validation alone can be bypassed, which is
-     * how incomplete downloadable products reach the review queue. Only requests that carry the downloadable
-     * fields are checked, so partial saves such as quick edit stay untouched.
+     * Every save funnels through here - WooCommerce routes create, update and batch alike through
+     * save_object() - so form-level validation is hooked once here instead of per endpoint.
      *
      * @since 5.0.13
      *
-     * @param WP_REST_Request $request    Full details about the request.
-     * @param int             $product_id Product being saved, 0 while creating.
+     * @param WP_REST_Request $request  Full details about the request.
+     * @param bool            $creating Whether a new product is being created.
+     *
+     * @return WC_Data|WP_Error
+     */
+    protected function prepare_object_for_database( $request, $creating = false ) {
+        return $this->validate_required_downloads( $request ) ?? parent::prepare_object_for_database( $request, $creating );
+    }
+
+    /**
+     * Reject a downloadable product saved without a file while the form marks "Downloadable Files" as required.
+     *
+     * The required flag lives in the form schema, where Dokan Pro's Product Form Manager writes it, so it is
+     * read back from the schema rather than hard-coded. Browser-side validation alone can be bypassed, which
+     * is how incomplete downloadable products reach the review queue.
+     *
+     * Deliberately scoped to this one field: the schema marks several fields required that a partial form
+     * never renders yet still submits empty - the quick-create modal omits the required Description - so
+     * enforcing every required field here would reject those saves outright.
+     *
+     * @since 5.0.13
+     *
+     * @param WP_REST_Request $request Full details about the request.
      *
      * @return WP_Error|null Error when the required file is missing, null otherwise.
      */
-    protected function validate_required_downloads( $request, int $product_id = 0 ) {
-        if ( ! $request->has_param( Elements::DOWNLOADS ) ) {
-            return null;
-        }
-
-        if ( ! filter_var( $request->get_param( Elements::DOWNLOADABLE ), FILTER_VALIDATE_BOOLEAN ) ) {
-            return null;
-        }
-
-        $field = null;
-
-        foreach ( dokan()->product_editor->get_schema( $product_id ) as $item ) {
-            if ( Elements::DOWNLOADS === ( $item['id'] ?? '' ) ) {
-                $field = $item;
-                break;
-            }
-        }
-
-        if ( null === $field ) {
-            return null;
-        }
-
-        $product_type = $request->get_param( Elements::TYPE );
-        $product_type = is_string( $product_type ) && '' !== $product_type ? $product_type : Elements::PRODUCT_TYPE_SIMPLE;
-
-        $is_required = $field['requireds'][ $product_type ] ?? $field['required'] ?? false;
-        $is_visible  = $field['visibilities'][ $product_type ] ?? $field['visibility'] ?? true;
-
-        if ( ! $is_required || ! $is_visible ) {
-            return null;
-        }
-
+    protected function validate_required_downloads( $request ) {
         $downloads = $request->get_param( Elements::DOWNLOADS );
-        $downloads = is_array( $downloads ) ? $downloads : [];
+
+        // A save that leaves the downloadable fields alone, such as quick edit, is none of our business.
+        if ( ! is_array( $downloads ) || ! dokan_string_to_bool( $request->get_param( Elements::DOWNLOADABLE ) ) ) {
+            return null;
+        }
 
         foreach ( $downloads as $download ) {
             if ( ! empty( $download['file'] ) ) {
@@ -388,12 +368,26 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             }
         }
 
+        // Only a save with nothing attached needs the schema, which is expensive to build.
+        $product_type = $request->get_param( Elements::TYPE );
+        $product_type = is_string( $product_type ) && '' !== $product_type ? $product_type : Elements::PRODUCT_TYPE_SIMPLE;
+
+        $schema = dokan()->product_editor->get_schema( (int) $request->get_param( 'id' ) );
+        $field  = current( wp_list_filter( $schema, [ 'id' => Elements::DOWNLOADS ] ) );
+
+        if ( ! $field || ! FormSchema::is_required( $field, $product_type ) || ! FormSchema::is_visible( $field, $product_type ) ) {
+            return null;
+        }
+
+        $label = FormSchema::get_label( $field, $product_type );
+        $label = '' !== $label ? $label : __( 'Downloadable Files', 'dokan-lite' );
+
         return new WP_Error(
             'dokan_rest_product_download_required',
             sprintf(
                 /* translators: %s: label of the downloadable files field. */
                 __( '%s is required. Please attach at least one downloadable file.', 'dokan-lite' ),
-                $field['labels'][ $product_type ] ?? $field['label'] ?? __( 'Downloadable Files', 'dokan-lite' )
+                $label
             ),
             [ 'status' => 400 ]
         );

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -280,6 +280,12 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function create_item( $request ) {
+        $missing_download = $this->validate_required_downloads( $request );
+
+        if ( is_wp_error( $missing_download ) ) {
+            return $missing_download;
+        }
+
         $product = parent::create_item( $request );
 
         if ( is_wp_error( $product ) ) {
@@ -305,6 +311,12 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function update_item( $request ) {
+        $missing_download = $this->validate_required_downloads( $request, (int) $request->get_param( 'id' ) );
+
+        if ( is_wp_error( $missing_download ) ) {
+            return $missing_download;
+        }
+
         $product = parent::update_item( $request );
 
         if ( is_wp_error( $product ) ) {
@@ -318,6 +330,73 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
         do_action( 'dokan_product_updated', $product_id, $params );
 
         return $product;
+    }
+
+    /**
+     * Reject a downloadable product saved without a file while the form marks "Downloadable Files" as required.
+     *
+     * The required flag lives in the form schema (Dokan Pro's Product Form Manager writes it there), so it is
+     * resolved from the schema rather than hard-coded. Browser-side validation alone can be bypassed, which is
+     * how incomplete downloadable products reach the review queue. Only requests that carry the downloadable
+     * fields are checked, so partial saves such as quick edit stay untouched.
+     *
+     * @since 5.0.13
+     *
+     * @param WP_REST_Request $request    Full details about the request.
+     * @param int             $product_id Product being saved, 0 while creating.
+     *
+     * @return WP_Error|null Error when the required file is missing, null otherwise.
+     */
+    protected function validate_required_downloads( $request, int $product_id = 0 ) {
+        if ( ! $request->has_param( Elements::DOWNLOADS ) ) {
+            return null;
+        }
+
+        if ( ! filter_var( $request->get_param( Elements::DOWNLOADABLE ), FILTER_VALIDATE_BOOLEAN ) ) {
+            return null;
+        }
+
+        $field = null;
+
+        foreach ( dokan()->product_editor->get_schema( $product_id ) as $item ) {
+            if ( Elements::DOWNLOADS === ( $item['id'] ?? '' ) ) {
+                $field = $item;
+                break;
+            }
+        }
+
+        if ( null === $field ) {
+            return null;
+        }
+
+        $product_type = $request->get_param( Elements::TYPE );
+        $product_type = is_string( $product_type ) && '' !== $product_type ? $product_type : Elements::PRODUCT_TYPE_SIMPLE;
+
+        $is_required = $field['requireds'][ $product_type ] ?? $field['required'] ?? false;
+        $is_visible  = $field['visibilities'][ $product_type ] ?? $field['visibility'] ?? true;
+
+        if ( ! $is_required || ! $is_visible ) {
+            return null;
+        }
+
+        $downloads = $request->get_param( Elements::DOWNLOADS );
+        $downloads = is_array( $downloads ) ? $downloads : [];
+
+        foreach ( $downloads as $download ) {
+            if ( ! empty( $download['file'] ) ) {
+                return null;
+            }
+        }
+
+        return new WP_Error(
+            'dokan_rest_product_download_required',
+            sprintf(
+                /* translators: %s: label of the downloadable files field. */
+                __( '%s is required. Please attach at least one downloadable file.', 'dokan-lite' ),
+                $field['labels'][ $product_type ] ?? $field['label'] ?? __( 'Downloadable Files', 'dokan-lite' )
+            ),
+            [ 'status' => 400 ]
+        );
     }
 
     /**

--- a/src/dashboard/product-editor/components/FileUploadEdit.tsx
+++ b/src/dashboard/product-editor/components/FileUploadEdit.tsx
@@ -1,7 +1,7 @@
 import { DokanButton } from '@dokan/components';
 import { SimpleInput } from '@getdokan/dokan-ui';
 import { MediaUploader } from '@src/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { Plus, Upload, X } from 'lucide-react';
@@ -9,21 +9,26 @@ import CustomField, { getValidationError } from './CustomField';
 
 const DOWNLOADABLE_UPLOADER_PARAMS = { type: 'downloadable_product' };
 
-const FileUploadEdit = ( { field, onChange, validity }: any ) => {
-    const [ files, setFiles ] = useState(
-        field.value?.length > 0
-            ? field.value
-            : [
-                  {
-                      id: '',
-                      name: '',
-                      file: '',
-                  },
-              ]
-    );
+const blankRow = () => ( { id: '', name: '', file: '' } );
+
+const FileUploadEdit = ( { data, field, onChange, validity }: any ) => {
+    // Seed from what the form holds now, not the schema snapshot: unticking Downloadable unmounts these rows
+    // while the form keeps them, so showing the field again must not read as "no files".
+    const [ files, setFiles ] = useState( () => {
+        const current = data?.[ field.id ] ?? field.value;
+
+        return current?.length > 0 ? current : [ blankRow() ];
+    } );
 
     // Re-sync rows when field.value loads/changes after mount (e.g. the create → edit SPA transition); the initial useState alone misses the late-arriving value.
+    const synced = useRef( field.value );
     useEffect( () => {
+        // Only a genuinely new schema value wins; replaying the one already seeded would drop unsaved edits.
+        if ( field.value === synced.current ) {
+            return;
+        }
+        synced.current = field.value;
+
         if ( field.value?.length > 0 ) {
             setFiles( field.value );
         }
@@ -57,19 +62,14 @@ const FileUploadEdit = ( { field, onChange, validity }: any ) => {
     const publish = ( newFiles: any[] ) => {
         setFiles( newFiles );
         onChange( {
-            [ field.id ]: newFiles.filter( ( file: any ) => file.file ),
+            [ field.id ]: newFiles.filter(
+                ( file: any ) => String( file.file ?? '' ).trim() !== ''
+            ),
         } );
     };
 
     const onAddRow = () => {
-        publish( [
-            ...files,
-            {
-                id: '',
-                name: '',
-                file: '',
-            },
-        ] );
+        publish( [ ...files, blankRow() ] );
     };
 
     const onRemoveRow = ( index: number ) => {

--- a/src/dashboard/product-editor/components/FileUploadEdit.tsx
+++ b/src/dashboard/product-editor/components/FileUploadEdit.tsx
@@ -45,37 +45,43 @@ const FileUploadEdit = ( { field, onChange, validity }: any ) => {
         field
     ) as Record< string, string > | undefined;
 
+    /**
+     * Keep every row on screen, but hand the form only the rows that carry a file.
+     *
+     * A row the vendor has started but not attached a file to is scaffolding, not a value —
+     * naming it must not satisfy a "required" rule, and WooCommerce discards it on save anyway
+     * (`save_downloadable_files()`), so the form data now matches what actually gets stored.
+     *
+     * @param newFiles Rows to render.
+     */
+    const publish = ( newFiles: any[] ) => {
+        setFiles( newFiles );
+        onChange( {
+            [ field.id ]: newFiles.filter( ( file: any ) => file.file ),
+        } );
+    };
+
     const onAddRow = () => {
-        const newFiles = [
+        publish( [
             ...files,
             {
                 id: '',
                 name: '',
                 file: '',
             },
-        ];
-        setFiles( newFiles );
-        onChange( {
-            [ field.id ]: newFiles,
-        } );
+        ] );
     };
 
     const onRemoveRow = ( index: number ) => {
-        const newFiles = files.filter( ( _: any, i: number ) => i !== index );
-        setFiles( newFiles );
-        onChange( {
-            [ field.id ]: newFiles,
-        } );
+        publish( files.filter( ( _: any, i: number ) => i !== index ) );
     };
 
     const updateRow = ( index: number, key: string, value: any ) => {
-        const newFiles = files.map( ( file: any, i: number ) =>
-            i === index ? { ...file, [ key ]: value } : file
+        publish(
+            files.map( ( file: any, i: number ) =>
+                i === index ? { ...file, [ key ]: value } : file
+            )
         );
-        setFiles( newFiles );
-        onChange( {
-            [ field.id ]: newFiles,
-        } );
     };
 
     const onSelectFile = ( value: any, index: number ) => {
@@ -89,10 +95,7 @@ const FileUploadEdit = ( { field, onChange, validity }: any ) => {
             name: selectedValue.title || selectedValue.name,
         };
 
-        setFiles( newFiles );
-        onChange( {
-            [ field.id ]: newFiles,
-        } );
+        publish( newFiles );
     };
 
     return (

--- a/src/dashboard/product-editor/exports.ts
+++ b/src/dashboard/product-editor/exports.ts
@@ -26,6 +26,7 @@ export { default as CustomField, getValidationError } from './components/CustomF
 // Utils
 export {
     getField,
+    isEmpty,
     resolveLabel,
     resolveRequired,
     resolveVisibility,

--- a/src/dashboard/product-editor/field-config/getFieldConfig.tsx
+++ b/src/dashboard/product-editor/field-config/getFieldConfig.tsx
@@ -4,8 +4,8 @@ import { __experimentalInputControlPrefixWrapper as InputControlPrefixWrapper } 
 import { Info } from 'lucide-react';
 import { getFieldConfigFrom } from './index';
 import { FormItem } from '../types';
-import { resolveDependency } from '../utils';
-import { isEmpty, runSchemaValidations } from './validations';
+import { isEmpty, resolveDependency } from '../utils';
+import { runSchemaValidations } from './validations';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { RawHTML } from '@wordpress/element';

--- a/src/dashboard/product-editor/field-config/validations/index.ts
+++ b/src/dashboard/product-editor/field-config/validations/index.ts
@@ -2,6 +2,20 @@ import { __ } from '@wordpress/i18n';
 import { FieldValidator, FormItem, ValidationRule, DependencyCondition } from '../../types';
 import { resolveDependency } from '../../utils';
 
+// A repeater row is blank when every value inside it is empty, e.g. a downloadable-file row the vendor added but never filled in.
+const isBlankRow = ( row: any ): boolean => {
+    if ( row === null || row === undefined ) {
+        return true;
+    }
+    if ( typeof row === 'string' ) {
+        return row.trim().length === 0;
+    }
+    if ( typeof row === 'object' && ! Array.isArray( row ) ) {
+        return Object.values( row ).every( isBlankRow );
+    }
+    return false;
+};
+
 export const isEmpty = ( v: any ) => {
     if ( v === null || v === undefined ) {
         return true;
@@ -10,7 +24,8 @@ export const isEmpty = ( v: any ) => {
         return v.trim().length === 0;
     }
     if ( Array.isArray( v ) ) {
-        return v.length === 0;
+        // Blank rows carry no value, so an array made only of them counts as empty.
+        return v.every( isBlankRow );
     }
     return false;
 };

--- a/src/dashboard/product-editor/field-config/validations/index.ts
+++ b/src/dashboard/product-editor/field-config/validations/index.ts
@@ -1,34 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { FieldValidator, FormItem, ValidationRule, DependencyCondition } from '../../types';
-import { resolveDependency } from '../../utils';
-
-// A repeater row is blank when every value inside it is empty, e.g. a downloadable-file row the vendor added but never filled in.
-const isBlankRow = ( row: any ): boolean => {
-    if ( row === null || row === undefined ) {
-        return true;
-    }
-    if ( typeof row === 'string' ) {
-        return row.trim().length === 0;
-    }
-    if ( typeof row === 'object' && ! Array.isArray( row ) ) {
-        return Object.values( row ).every( isBlankRow );
-    }
-    return false;
-};
-
-export const isEmpty = ( v: any ) => {
-    if ( v === null || v === undefined ) {
-        return true;
-    }
-    if ( typeof v === 'string' ) {
-        return v.trim().length === 0;
-    }
-    if ( Array.isArray( v ) ) {
-        // Blank rows carry no value, so an array made only of them counts as empty.
-        return v.every( isBlankRow );
-    }
-    return false;
-};
+import { isEmpty, resolveDependency } from '../../utils';
 
 // ---------------------------------------------------------------------------
 // Schema-driven validation engine

--- a/src/dashboard/product-editor/utils.tsx
+++ b/src/dashboard/product-editor/utils.tsx
@@ -85,6 +85,11 @@ const isPlainObject = ( val: any ): boolean =>
  * those rows is no more a value than an empty list is. Scalars keep their usual
  * meaning, so `0` and `false` are values.
  *
+ * Backs both the `required` validation and the `empty`/`not_empty` dependency
+ * comparisons, so the form only ever holds one definition of "no value".
+ *
+ * @since DOKAN_SINCE
+ *
  * @param val Value to test.
  */
 export function isEmpty( val: any ): boolean {

--- a/src/dashboard/product-editor/utils.tsx
+++ b/src/dashboard/product-editor/utils.tsx
@@ -69,8 +69,25 @@ export function fieldValueForProduct( item: FormItem ): any {
     return v ?? '';
 }
 
-/** True if value is considered empty (null, undefined, '', whitespace-only, or empty array). */
-function isEmptyValue( val: any ): boolean {
+/** True for a plain `{}` object — class instances such as Date own no enumerable values and must not read as empty. */
+const isPlainObject = ( val: any ): boolean =>
+    typeof val === 'object' &&
+    val !== null &&
+    ! Array.isArray( val ) &&
+    [ Object.prototype, null ].includes( Object.getPrototypeOf( val ) );
+
+/**
+ * True if a value carries nothing: null, undefined, whitespace-only text, or a
+ * collection whose entries are all themselves empty.
+ *
+ * Recursing matters for repeater fields — a downloadable-file row the vendor
+ * added but never filled in is `{ id: '', name: '', file: '' }`, and a list of
+ * those rows is no more a value than an empty list is. Scalars keep their usual
+ * meaning, so `0` and `false` are values.
+ *
+ * @param val Value to test.
+ */
+export function isEmpty( val: any ): boolean {
     if ( val === undefined || val === null ) {
         return true;
     }
@@ -78,7 +95,10 @@ function isEmptyValue( val: any ): boolean {
         return val.trim() === '';
     }
     if ( Array.isArray( val ) ) {
-        return val.length === 0;
+        return val.every( isEmpty );
+    }
+    if ( isPlainObject( val ) ) {
+        return Object.values( val ).every( isEmpty );
     }
     return false;
 }
@@ -108,9 +128,9 @@ function resolveCondition(
 
     switch ( comparison ) {
         case 'empty':
-            return isEmptyValue( depValue );
+            return isEmpty( depValue );
         case 'not_empty':
-            return ! isEmptyValue( depValue );
+            return ! isEmpty( depValue );
         case '==':
         case 'equal':
             return (

--- a/src/dashboard/product-editor/utils.tsx
+++ b/src/dashboard/product-editor/utils.tsx
@@ -77,6 +77,36 @@ const isPlainObject = ( val: any ): boolean =>
     [ Object.prototype, null ].includes( Object.getPrototypeOf( val ) );
 
 /**
+ * Walk a value for emptiness, remembering collections already visited.
+ *
+ * @param val  Value to test.
+ * @param seen Collections visited on this walk, allocated only once one is reached.
+ */
+function isEmptyDeep( val: any, seen?: WeakSet< object > ): boolean {
+    if ( val === undefined || val === null ) {
+        return true;
+    }
+    if ( typeof val === 'string' ) {
+        return val.trim() === '';
+    }
+    if ( ! Array.isArray( val ) && ! isPlainObject( val ) ) {
+        return false;
+    }
+
+    // A branch that loops back on itself adds no value, and this backs a public helper an extension can hand any object.
+    const visited = seen ?? new WeakSet();
+
+    if ( visited.has( val ) ) {
+        return true;
+    }
+    visited.add( val );
+
+    return Object.values( val ).every( ( entry ) =>
+        isEmptyDeep( entry, visited )
+    );
+}
+
+/**
  * True if a value carries nothing: null, undefined, whitespace-only text, or a
  * collection whose entries are all themselves empty.
  *
@@ -84,6 +114,8 @@ const isPlainObject = ( val: any ): boolean =>
  * added but never filled in is `{ id: '', name: '', file: '' }`, and a list of
  * those rows is no more a value than an empty list is. Scalars keep their usual
  * meaning, so `0` and `false` are values.
+ *
+ * An extension whose blank value is meaningful should send a scalar — `{}` and `[ '' ]` read as empty.
  *
  * Backs both the `required` validation and the `empty`/`not_empty` dependency
  * comparisons, so the form only ever holds one definition of "no value".
@@ -93,19 +125,7 @@ const isPlainObject = ( val: any ): boolean =>
  * @param val Value to test.
  */
 export function isEmpty( val: any ): boolean {
-    if ( val === undefined || val === null ) {
-        return true;
-    }
-    if ( typeof val === 'string' ) {
-        return val.trim() === '';
-    }
-    if ( Array.isArray( val ) ) {
-        return val.every( isEmpty );
-    }
-    if ( isPlainObject( val ) ) {
-        return Object.values( val ).every( isEmpty );
-    }
-    return false;
+    return isEmptyDeep( val );
 }
 
 /** Normalize checkbox-like values to boolean for comparison. */

--- a/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
+++ b/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\REST\ProductControllerV3;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Server-side enforcement of the required "Downloadable Files" form field.
+ *
+ * Covers getdokan/dokan-pro#5963: a downloadable product could be saved with no
+ * attached file even though the form schema (Dokan Pro's Product Form Manager)
+ * marked the field as required.
+ *
+ * @group dokan-product-controller-v3
+ * @group dokan-product-editor
+ *
+ * @covers \WeDevs\Dokan\REST\ProductControllerV3::validate_required_downloads
+ */
+class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
+
+    /**
+     * Product owned by the acting vendor.
+     *
+     * @var int
+     */
+    protected int $product_id;
+
+    /**
+     * Setup test environment.
+     *
+     * @return void
+     */
+    public function set_up() {
+        parent::set_up();
+
+        $controller = new ProductControllerV3();
+        $controller->register_routes();
+
+        $this->product_id = $this->factory()->product
+            ->set_seller_id( $this->seller_id1 )
+            ->create(
+                [
+					'name'          => 'Downloadable Product',
+					'regular_price' => '10',
+				]
+            );
+
+        wp_set_current_user( $this->seller_id1 );
+    }
+
+    /**
+     * Mark the "Downloadable Files" field required, the way the Product Form Manager does.
+     *
+     * @return void
+     */
+    protected function require_downloads_field(): void {
+        add_filter(
+            'dokan_product_editor_prepared_schema',
+            function ( $items ) {
+                foreach ( $items as &$item ) {
+                    if ( 'downloads' === ( $item['id'] ?? '' ) ) {
+                        $item['required'] = true;
+                    }
+                }
+                unset( $item );
+
+                return $items;
+            },
+            99
+        );
+    }
+
+    /**
+     * Dispatch a product update, mirroring a real REST client.
+     *
+     * @param array $body Product payload.
+     *
+     * @return WP_REST_Response
+     */
+    protected function update_request( array $body ): WP_REST_Response {
+        $request = new WP_REST_Request( 'PUT', '/dokan/v3/products/' . $this->product_id );
+        $request->add_header( 'Content-Type', 'application/json' );
+        $request->set_body( wp_json_encode( $body + [ 'id' => $this->product_id ] ) );
+
+        return $this->server->dispatch( $request );
+    }
+
+    /**
+     * A downloadable product with no download rows is rejected.
+     *
+     * @return void
+     */
+    public function test_downloadable_product_without_files_is_rejected(): void {
+        $this->require_downloads_field();
+
+        $response = $this->update_request(
+            [
+				'type'         => 'simple',
+				'downloadable' => true,
+				'downloads'    => [],
+			]
+        );
+
+        $this->assertSame( 400, $response->get_status(), 'A required download must block the save.' );
+        $this->assertSame( 'dokan_rest_product_download_required', $response->as_error()->get_error_code() );
+        $this->assertFalse( wc_get_product( $this->product_id )->is_downloadable(), 'The product must not be saved as downloadable.' );
+    }
+
+    /**
+     * Blank rows carry no file, so they do not satisfy the requirement.
+     *
+     * @return void
+     */
+    public function test_blank_download_rows_do_not_satisfy_the_requirement(): void {
+        $this->require_downloads_field();
+
+        $response = $this->update_request(
+            [
+				'type'         => 'simple',
+				'downloadable' => true,
+				'downloads'    => [
+					[
+						'id'   => '',
+						'name' => 'Untitled',
+						'file' => '',
+					],
+				],
+			]
+        );
+
+        $this->assertSame( 400, $response->get_status(), 'A row without a file must block the save.' );
+        $this->assertSame( 'dokan_rest_product_download_required', $response->as_error()->get_error_code() );
+    }
+
+    /**
+     * A partial save that never touches the downloadable fields stays untouched.
+     *
+     * @return void
+     */
+    public function test_partial_update_without_downloads_is_allowed(): void {
+        $this->require_downloads_field();
+
+        $response = $this->update_request( [ 'regular_price' => '12.50' ] );
+
+        $this->assertSame( 200, $response->get_status(), 'Quick-edit style saves must not hit the download rule.' );
+        $this->assertSame( '12.50', wc_get_product( $this->product_id )->get_regular_price() );
+    }
+
+    /**
+     * Nothing is enforced while the field is left optional in the form schema.
+     *
+     * @return void
+     */
+    public function test_optional_downloads_field_is_not_enforced(): void {
+        $response = $this->update_request(
+            [
+				'type'         => 'simple',
+				'downloadable' => true,
+				'downloads'    => [],
+			]
+        );
+
+        $this->assertSame( 200, $response->get_status(), 'An optional field must not block the save.' );
+        $this->assertTrue( wc_get_product( $this->product_id )->is_downloadable() );
+    }
+}

--- a/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
+++ b/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
@@ -398,13 +398,13 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
-     * Extensions can reject a save through the shared validation filter.
+     * Extensions can reject a save through the prepared-object filter.
      *
      * @return void
      */
     public function test_extensions_can_reject_a_save(): void {
         add_filter(
-            'dokan_rest_product_validate_save',
+            'dokan_rest_pre_insert_product_object',
             static function () {
                 return new \WP_Error( 'dokan_test_rejected', 'Nope.', [ 'status' => 400 ] );
             }
@@ -412,7 +412,33 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
 
         $response = $this->update_request( [ 'regular_price' => '12.50' ] );
 
-        $this->assertSame( 400, $response->get_status(), 'The validation filter must be able to reject a save.' );
+        $this->assertSame( 400, $response->get_status(), 'The filter must be able to reject a save.' );
         $this->assertSame( 'dokan_test_rejected', $response->as_error()->get_error_code() );
+    }
+
+    /**
+     * The prepared-object filter receives the assembled product on an allowed save.
+     *
+     * @return void
+     */
+    public function test_extensions_receive_the_prepared_product(): void {
+        $seen = null;
+
+        add_filter(
+            'dokan_rest_pre_insert_product_object',
+            static function ( $product, $request, $creating ) use ( &$seen ) {
+                $seen = [ $product, $creating ];
+
+                return $product;
+            },
+            10,
+            3
+        );
+
+        $response = $this->update_request( [ 'regular_price' => '12.50' ] );
+
+        $this->assertSame( 200, $response->get_status(), 'Returning the product must let the save through.' );
+        $this->assertInstanceOf( \WC_Product::class, $seen[0] ?? null, 'The filter should receive the assembled product.' );
+        $this->assertFalse( $seen[1] ?? true, 'An update is not a create.' );
     }
 }

--- a/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
+++ b/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
@@ -18,8 +18,16 @@ use WP_REST_Response;
  * @group dokan-product-editor
  *
  * @covers \WeDevs\Dokan\REST\ProductControllerV3::validate_required_downloads
+ * @covers \WeDevs\Dokan\REST\ProductControllerV3::prepare_object_for_database
  */
 class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v3';
 
     /**
      * Product owned by the acting vendor.
@@ -56,7 +64,7 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      *
      * @return void
      */
-    protected function require_downloads_field(): void {
+    protected function mark_downloads_required(): void {
         add_filter(
             'dokan_product_editor_prepared_schema',
             function ( $items ) {
@@ -74,16 +82,34 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
-     * Dispatch a product update, mirroring a real REST client.
+     * A downloadable product payload carrying the given file rows.
+     *
+     * @param array $downloads Download rows.
+     *
+     * @return array
+     */
+    protected function downloadable_payload( array $downloads = [] ): array {
+        return [
+            'type'         => 'simple',
+            'downloadable' => true,
+            'downloads'    => $downloads,
+        ];
+    }
+
+    /**
+     * Dispatch a product update as a JSON request, the way the product form does.
+     *
+     * The JSON content type is load bearing: the controller re-encodes the resolved payload onto the
+     * request body during `rest_pre_dispatch`, which WordPress only parses back for JSON requests.
      *
      * @param array $body Product payload.
      *
      * @return WP_REST_Response
      */
     protected function update_request( array $body ): WP_REST_Response {
-        $request = new WP_REST_Request( 'PUT', '/dokan/v3/products/' . $this->product_id );
+        $request = new WP_REST_Request( 'PUT', $this->get_route( '/products/' . $this->product_id ) );
         $request->add_header( 'Content-Type', 'application/json' );
-        $request->set_body( wp_json_encode( $body + [ 'id' => $this->product_id ] ) );
+        $request->set_body( wp_json_encode( $body ) );
 
         return $this->server->dispatch( $request );
     }
@@ -94,15 +120,9 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      * @return void
      */
     public function test_downloadable_product_without_files_is_rejected(): void {
-        $this->require_downloads_field();
+        $this->mark_downloads_required();
 
-        $response = $this->update_request(
-            [
-				'type'         => 'simple',
-				'downloadable' => true,
-				'downloads'    => [],
-			]
-        );
+        $response = $this->update_request( $this->downloadable_payload() );
 
         $this->assertSame( 400, $response->get_status(), 'A required download must block the save.' );
         $this->assertSame( 'dokan_rest_product_download_required', $response->as_error()->get_error_code() );
@@ -115,20 +135,18 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      * @return void
      */
     public function test_blank_download_rows_do_not_satisfy_the_requirement(): void {
-        $this->require_downloads_field();
+        $this->mark_downloads_required();
 
         $response = $this->update_request(
-            [
-				'type'         => 'simple',
-				'downloadable' => true,
-				'downloads'    => [
+            $this->downloadable_payload(
+                [
 					[
 						'id'   => '',
 						'name' => 'Untitled',
 						'file' => '',
 					],
-				],
-			]
+				]
+            )
         );
 
         $this->assertSame( 400, $response->get_status(), 'A row without a file must block the save.' );
@@ -141,7 +159,7 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      * @return void
      */
     public function test_partial_update_without_downloads_is_allowed(): void {
-        $this->require_downloads_field();
+        $this->mark_downloads_required();
 
         $response = $this->update_request( [ 'regular_price' => '12.50' ] );
 
@@ -155,13 +173,7 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      * @return void
      */
     public function test_optional_downloads_field_is_not_enforced(): void {
-        $response = $this->update_request(
-            [
-				'type'         => 'simple',
-				'downloadable' => true,
-				'downloads'    => [],
-			]
-        );
+        $response = $this->update_request( $this->downloadable_payload() );
 
         $this->assertSame( 200, $response->get_status(), 'An optional field must not block the save.' );
         $this->assertTrue( wc_get_product( $this->product_id )->is_downloadable() );

--- a/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
+++ b/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
@@ -23,6 +23,11 @@ use WP_REST_Response;
 class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
 
     /**
+     * Error code the guard rejects with.
+     */
+    const ERROR_CODE = 'dokan_rest_product_download_required';
+
+    /**
      * REST namespace for this controller.
      *
      * @var string
@@ -47,6 +52,9 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
         $controller = new ProductControllerV3();
         $controller->register_routes();
 
+        // Keep WooCommerce's approved download directories out of the way; this suite is about the form rule.
+        update_option( 'wc_downloads_approved_directories_mode', 'disabled' );
+
         $this->product_id = $this->factory()->product
             ->set_seller_id( $this->seller_id1 )
             ->create(
@@ -60,17 +68,19 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
-     * Mark the "Downloadable Files" field required, the way the Product Form Manager does.
+     * Override the "Downloadable Files" schema field, the way the Product Form Manager does.
+     *
+     * @param array $overrides Schema keys to merge onto the field.
      *
      * @return void
      */
-    protected function mark_downloads_required(): void {
+    protected function override_downloads_field( array $overrides ): void {
         add_filter(
             'dokan_product_editor_prepared_schema',
-            function ( $items ) {
+            function ( $items ) use ( $overrides ) {
                 foreach ( $items as &$item ) {
                     if ( 'downloads' === ( $item['id'] ?? '' ) ) {
-                        $item['required'] = true;
+                        $item = array_merge( $item, $overrides );
                     }
                 }
                 unset( $item );
@@ -79,6 +89,15 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
             },
             99
         );
+    }
+
+    /**
+     * Mark the "Downloadable Files" field required for every product type.
+     *
+     * @return void
+     */
+    protected function mark_downloads_required(): void {
+        $this->override_downloads_field( [ 'required' => true ] );
     }
 
     /**
@@ -97,21 +116,60 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
-     * Dispatch a product update as a JSON request, the way the product form does.
+     * A download row pointing at a real file.
+     *
+     * @return array
+     */
+    protected function file_row(): array {
+        return [
+            'id'   => '',
+            'name' => 'Guide',
+            'file' => content_url( 'uploads/dokan-required-downloads-test.pdf' ),
+        ];
+    }
+
+    /**
+     * Dispatch a JSON request, the way the product form does.
      *
      * The JSON content type is load bearing: the controller re-encodes the resolved payload onto the
      * request body during `rest_pre_dispatch`, which WordPress only parses back for JSON requests.
+     *
+     * @param string $method HTTP method.
+     * @param string $route  Route below the namespace.
+     * @param array  $body   Request payload.
+     *
+     * @return WP_REST_Response
+     */
+    protected function json_request( string $method, string $route, array $body ): WP_REST_Response {
+        $request = new WP_REST_Request( $method, $this->get_route( $route ) );
+        $request->add_header( 'Content-Type', 'application/json' );
+        $request->set_body( wp_json_encode( $body ) );
+
+        return $this->server->dispatch( $request );
+    }
+
+    /**
+     * Dispatch a product update.
      *
      * @param array $body Product payload.
      *
      * @return WP_REST_Response
      */
     protected function update_request( array $body ): WP_REST_Response {
-        $request = new WP_REST_Request( 'PUT', $this->get_route( '/products/' . $this->product_id ) );
-        $request->add_header( 'Content-Type', 'application/json' );
-        $request->set_body( wp_json_encode( $body ) );
+        return $this->json_request( 'PUT', '/products/' . $this->product_id, $body );
+    }
 
-        return $this->server->dispatch( $request );
+    /**
+     * Assert a response was rejected by the download rule.
+     *
+     * @param WP_REST_Response $response Response under test.
+     * @param string           $message  Failure message.
+     *
+     * @return void
+     */
+    protected function assertRejectedForMissingDownload( WP_REST_Response $response, string $message ): void {
+        $this->assertSame( 400, $response->get_status(), $message );
+        $this->assertSame( self::ERROR_CODE, $response->as_error()->get_error_code(), $message );
     }
 
     /**
@@ -122,10 +180,11 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     public function test_downloadable_product_without_files_is_rejected(): void {
         $this->mark_downloads_required();
 
-        $response = $this->update_request( $this->downloadable_payload() );
+        $this->assertRejectedForMissingDownload(
+            $this->update_request( $this->downloadable_payload() ),
+            'A required download must block the save.'
+        );
 
-        $this->assertSame( 400, $response->get_status(), 'A required download must block the save.' );
-        $this->assertSame( 'dokan_rest_product_download_required', $response->as_error()->get_error_code() );
         $this->assertFalse( wc_get_product( $this->product_id )->is_downloadable(), 'The product must not be saved as downloadable.' );
     }
 
@@ -137,20 +196,106 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     public function test_blank_download_rows_do_not_satisfy_the_requirement(): void {
         $this->mark_downloads_required();
 
-        $response = $this->update_request(
-            $this->downloadable_payload(
+        $this->assertRejectedForMissingDownload(
+            $this->update_request(
+                $this->downloadable_payload(
+                    [
+						[
+							'id' => '',
+							'name' => 'Untitled',
+							'file' => '',
+						],
+					]
+                )
+            ),
+            'A row without a file must block the save.'
+        );
+    }
+
+    /**
+     * Omitting the downloads key does not dodge the rule.
+     *
+     * WooCommerce turns a product downloadable from `downloadable` alone and only reads `downloads`
+     * when that key is present, so a payload-shaped guard would let this through.
+     *
+     * @return void
+     */
+    public function test_update_without_a_downloads_key_is_rejected(): void {
+        $this->mark_downloads_required();
+
+        $this->assertRejectedForMissingDownload(
+            $this->update_request(
                 [
-					[
-						'id'   => '',
-						'name' => 'Untitled',
-						'file' => '',
-					],
+					'type' => 'simple',
+					'downloadable' => true,
 				]
-            )
+            ),
+            'Turning a product downloadable without sending downloads must block the save.'
+        );
+    }
+
+    /**
+     * The rule applies to product creation as well as updates.
+     *
+     * @return void
+     */
+    public function test_create_without_a_downloads_key_is_rejected(): void {
+        $this->mark_downloads_required();
+
+        $this->assertRejectedForMissingDownload(
+            $this->json_request(
+                'POST',
+                '/products',
+                [
+					'name'         => 'Created downloadable',
+					'type'         => 'simple',
+					'downloadable' => true,
+				]
+            ),
+            'Creating a downloadable product with no file must block the save.'
+        );
+    }
+
+    /**
+     * Batch updates run through the same hook.
+     *
+     * @return void
+     */
+    public function test_batch_update_is_rejected(): void {
+        $this->mark_downloads_required();
+
+        $response = $this->json_request(
+            'POST',
+            '/products/batch',
+            [
+                'update' => [
+                    array_merge( [ 'id' => $this->product_id ], $this->downloadable_payload() ),
+                ],
+            ]
         );
 
-        $this->assertSame( 400, $response->get_status(), 'A row without a file must block the save.' );
-        $this->assertSame( 'dokan_rest_product_download_required', $response->as_error()->get_error_code() );
+        $data = $response->get_data();
+
+        $this->assertArrayHasKey( 'update', $data, 'Batch response should contain an update section.' );
+        $this->assertSame( self::ERROR_CODE, $data['update'][0]['error']['code'] ?? '', 'Batch items must be validated too.' );
+    }
+
+    /**
+     * A row with a real file passes the rule.
+     *
+     * @return void
+     */
+    public function test_attached_file_is_accepted(): void {
+        $this->mark_downloads_required();
+
+        $response = $this->update_request( $this->downloadable_payload( [ $this->file_row() ] ) );
+
+        $this->assertSame( 200, $response->get_status(), 'An attached file must satisfy the rule.' );
+
+        $product = wc_get_product( $this->product_id );
+
+        $this->assertTrue( $product->is_downloadable() );
+        $this->assertCount( 1, $product->get_downloads(), 'The attached file should be stored.' );
     }
 
     /**
@@ -168,6 +313,23 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
+     * A product that is already downloadable with no file stays editable through partial saves.
+     *
+     * @return void
+     */
+    public function test_existing_zero_file_product_stays_editable(): void {
+        $product = wc_get_product( $this->product_id );
+        $product->set_downloadable( true );
+        $product->save();
+
+        $this->mark_downloads_required();
+
+        $response = $this->update_request( [ 'regular_price' => '12.50' ] );
+
+        $this->assertSame( 200, $response->get_status(), 'Products predating the rule must remain editable.' );
+    }
+
+    /**
      * Nothing is enforced while the field is left optional in the form schema.
      *
      * @return void
@@ -177,5 +339,80 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
 
         $this->assertSame( 200, $response->get_status(), 'An optional field must not block the save.' );
         $this->assertTrue( wc_get_product( $this->product_id )->is_downloadable() );
+    }
+
+    /**
+     * A required field that the form hides for this product type is not enforced.
+     *
+     * @return void
+     */
+    public function test_hidden_downloads_field_is_not_enforced(): void {
+        $this->override_downloads_field(
+            [
+				'required'   => true,
+				'visibility' => false,
+			]
+        );
+
+        $response = $this->update_request( $this->downloadable_payload() );
+
+        $this->assertSame( 200, $response->get_status(), 'A hidden field must not block the save.' );
+    }
+
+    /**
+     * Per-product-type `requireds` win over the shared `required` flag.
+     *
+     * @return void
+     */
+    public function test_per_type_required_map_is_honoured(): void {
+        $this->override_downloads_field(
+            [
+				'required'  => true,
+				'requireds' => [ 'simple' => false ],
+			]
+        );
+
+        $response = $this->update_request( $this->downloadable_payload() );
+
+        $this->assertSame( 200, $response->get_status(), 'The simple-product override must win over the shared flag.' );
+    }
+
+    /**
+     * Per-product-type `visibilities` win over the shared `visibility` flag.
+     *
+     * @return void
+     */
+    public function test_per_type_visibility_map_is_honoured(): void {
+        $this->override_downloads_field(
+            [
+				'required'     => true,
+				'visibility'   => false,
+				'visibilities' => [ 'simple' => true ],
+			]
+        );
+
+        $this->assertRejectedForMissingDownload(
+            $this->update_request( $this->downloadable_payload() ),
+            'The simple-product override must win over the shared visibility flag.'
+        );
+    }
+
+    /**
+     * Extensions can reject a save through the shared validation filter.
+     *
+     * @return void
+     */
+    public function test_extensions_can_reject_a_save(): void {
+        add_filter(
+            'dokan_rest_product_validate_save',
+            static function () {
+                return new \WP_Error( 'dokan_test_rejected', 'Nope.', [ 'status' => 400 ] );
+            }
+        );
+
+        $response = $this->update_request( [ 'regular_price' => '12.50' ] );
+
+        $this->assertSame( 400, $response->get_status(), 'The validation filter must be able to reject a save.' );
+        $this->assertSame( 'dokan_test_rejected', $response->as_error()->get_error_code() );
     }
 }

--- a/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
+++ b/tests/php/src/REST/ProductControllerV3RequiredDownloadsTest.php
@@ -2,6 +2,8 @@
 
 namespace WeDevs\Dokan\Test\REST;
 
+use WeDevs\Dokan\ProductEditor\Elements;
+use WeDevs\Dokan\ProductEditor\FormSchema;
 use WeDevs\Dokan\REST\ProductControllerV3;
 use WeDevs\Dokan\Test\DokanTestCase;
 use WP_REST_Request;
@@ -107,9 +109,9 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      *
      * @return array
      */
-    protected function downloadable_payload( array $downloads = [] ): array {
+    protected function downloadable_payload( array $downloads = [], string $type = 'simple' ): array {
         return [
-            'type'         => 'simple',
+            'type'         => $type,
             'downloadable' => true,
             'downloads'    => $downloads,
         ];
@@ -189,11 +191,16 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
     }
 
     /**
-     * Blank rows carry no file, so they do not satisfy the requirement.
+     * A row carries no file, so it does not satisfy the requirement.
+     *
+     * @dataProvider unusable_file_values
+     *
+     * @param string $file      File value the row carries.
+     * @param string $describes What that value makes the row.
      *
      * @return void
      */
-    public function test_blank_download_rows_do_not_satisfy_the_requirement(): void {
+    public function test_rows_without_a_usable_file_do_not_satisfy_the_requirement( string $file, string $describes ): void {
         $this->mark_downloads_required();
 
         $this->assertRejectedForMissingDownload(
@@ -201,15 +208,27 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
                 $this->downloadable_payload(
                     [
 						[
-							'id' => '',
+							'id'   => '',
 							'name' => 'Untitled',
-							'file' => '',
+							'file' => $file,
 						],
 					]
                 )
             ),
-            'A row without a file must block the save.'
+            sprintf( 'A row %s must block the save.', $describes )
         );
+    }
+
+    /**
+     * File values that leave a row carrying no attachment.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public function unusable_file_values(): array {
+        return [
+            'missing'         => [ '', 'without a file' ],
+            'whitespace only' => [ '   ', 'whose file is only whitespace' ],
+        ];
     }
 
     /**
@@ -347,10 +366,12 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
      * @return void
      */
     public function test_hidden_downloads_field_is_not_enforced(): void {
+        // Hiding a field for every product type clears the per-type map, which is what the Product Form Manager writes.
         $this->override_downloads_field(
             [
-				'required'   => true,
-				'visibility' => false,
+				'required'     => true,
+				'visibility'   => false,
+				'visibilities' => [],
 			]
         );
 
@@ -395,6 +416,50 @@ class ProductControllerV3RequiredDownloadsTest extends DokanTestCase {
             $this->update_request( $this->downloadable_payload() ),
             'The simple-product override must win over the shared visibility flag.'
         );
+    }
+
+    /**
+     * A product type that offers no Downloadable checkbox is not held to the rule.
+     *
+     * Ticking Downloadable on a simple product and then switching type leaves the flag set while the
+     * checkbox that clears it is gone, so enforcing the file here would strand the vendor on a form
+     * they cannot satisfy or undo.
+     *
+     * @return void
+     */
+    public function test_type_without_a_downloadable_option_is_not_enforced(): void {
+        $this->mark_downloads_required();
+
+        $response = $this->update_request( $this->downloadable_payload( [], Elements::PRODUCT_TYPE_GROUPED ) );
+
+        $this->assertSame( 200, $response->get_status(), 'A type that cannot offer downloads must stay saveable.' );
+    }
+
+    /**
+     * The file field is offered exactly where the checkbox that reveals it is offered.
+     *
+     * @return void
+     */
+    public function test_downloads_field_tracks_the_downloadable_checkbox_visibility(): void {
+        $schema = dokan()->product_editor->get_schema();
+
+        $downloads = FormSchema::get_field( $schema, Elements::DOWNLOADS );
+        $checkbox  = FormSchema::get_field( $schema, Elements::DOWNLOADABLE );
+
+        $types = [
+            Elements::PRODUCT_TYPE_SIMPLE,
+            Elements::PRODUCT_TYPE_VARIABLE,
+            Elements::PRODUCT_TYPE_VARIATION,
+            Elements::PRODUCT_TYPE_GROUPED,
+        ];
+
+        foreach ( $types as $type ) {
+            $this->assertSame(
+                FormSchema::is_visible( $checkbox, $type ),
+                FormSchema::is_visible( $downloads, $type ),
+                sprintf( 'The %s form must offer the file field only where it offers the Downloadable checkbox.', $type )
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

A vendor can submit a Virtual + Downloadable product with **no downloadable file attached**, even when *Dokan → Product Form Manager → Downloadable Options → Downloadable Files* is toggled **Required**. The product saves and lands in the review queue with `downloadable = yes` and 0 files.

Two separate gaps let it through:

**1. Blank repeater rows counted as a value (client side)**

`FileUploadEdit` renders one empty row up front and pushes every row it holds — blank ones included — into the form data. The required check in `isEmpty()` only asked whether the array had entries:

```ts
if ( Array.isArray( v ) ) {
    return v.length === 0;
}
```

So the field starts correctly invalid (`downloads: []`), but the moment the vendor clicks **Add New** or types into a row, `downloads` becomes `[ { id: '', name: '', file: '' } ]` — length 1 — the rule passes and **Save Changes** unlocks.

Two changes close it:

- `isEmpty()` now recurses, so a collection whose entries are all themselves empty is empty. There were three copies of this predicate in the module — `isEmpty` in `field-config/validations`, and `isEmptyValue` in `utils.tsx` backing the `empty`/`not_empty` **dependency** comparisons — so they collapse into one exported `isEmpty()` in `utils.tsx`; otherwise a blank download row would be "empty" to validation and "not empty" to dependency resolution at the same time. Recursion is limited to plain objects, because `Object.values( new Date() )` is `[]` and a `Date` must not read as no value.
- `FileUploadEdit` now hands the form only the rows that carry a file, while still rendering every row. It is the one place that knows `file` is the meaningful key, so a row the vendor has named but not attached a file to no longer satisfies the rule — previously that passed the browser check and died at the server with a 400. Form data now also matches what WooCommerce persists, since `save_downloadable_files()` discards file-less rows anyway.

**2. Nothing enforced the required flags server side**

`ProductControllerV3` handed the payload straight to WooCommerce, which silently drops file rows with no `file` — so the product saved as downloadable with zero downloads.

`validate_required_downloads()` now rejects such a save before the product is written. It hangs off a single `prepare_object_for_database()` override rather than a guard in each endpoint — WooCommerce routes create, update and batch alike through `save_object()`, so one override covers all three.

**It judges the assembled product, not the payload.** WooCommerce turns a product downloadable from `downloadable` alone and only reads `downloads` when that key is present, so a payload-shaped check is trivially dodged — `POST /dokan/v3/products {"downloadable":true}` with no `downloads` key returned `201` with `downloadable = yes` and zero files. Checking `$product->is_downloadable() && ! $product->get_downloads()` after `parent::prepare_object_for_database()` closes that, and because WooCommerce has already dropped file-less rows by then, the same single check covers blank rows and name-only rows too. Nothing is persisted until `save_object()` calls `save()` on what the method returns.

Scope still keys off the request — a save touching neither `downloads` nor `downloadable` (quick edit, batch status changes) is out of scope, so products that predate the rule stay editable.

The rule is read from the form schema, so it follows whatever the Product Form Manager is set to — including per-product-type `requireds`/`visibilities` and a renamed field label — and stays inert while the field is optional. Per-type resolution lives on `FormSchema::get_label()` / `::is_required()` / `::is_visible()`, the PHP counterparts of `resolveLabel` / `resolveRequired` / `resolveVisibility` in `utils.tsx`.

**Extension point:** `prepare_object_for_database()` now ends with `dokan_rest_pre_insert_product_object`, following the convention already used by `OrderController`, `CustomersController` and Pro's Coupon / Variation / ManualOrders controllers. Returning a `WP_Error` rejects the save, so extensions that inject required fields into the product form can enforce them without patching this controller. It mirrors WooCommerce's `woocommerce_rest_pre_insert_product_object` — which Pro's simple-auction and subscription modules already use for this job — but is scoped to vendor dashboard saves.

**Why this enforces one field and not every required field:** the schema marks several fields required that a partial form never renders yet still submits empty — `description` is required by default and the quick-create modal omits it while `initForm` still seeds and POSTs it as `''` — so a blanket "all required fields" check would reject every quick create. That constraint is recorded in the method's docblock so the next reader doesn't "fix the altitude" and break product creation.

### Closes

* Closes getdokan/dokan-pro#5963
* Closes https://github.com/getdokan/plugin-internal-tasks/issues/2223
* Client report: getdokan/client-issue#509

### How to test the changes in this Pull Request:

1. As admin, go to **Dokan → Product Form Manager → Downloadable Options** and turn **Required** on for **Downloadable Files**.
2. Log in as a vendor and open **Products → Add new product** (new React editor).
3. Fill in title, description, price and category, then tick **Downloadable** and **Virtual**.
4. Leave **Downloadable Files** empty and click **Add New** once or twice to add blank rows.
   * **Save Changes stays disabled**, the section shows *1 field needs attention* and the field shows *Please fill out this field.*
5. Type a **name** into a row but no file → the name stays put and **Save Changes is still disabled**.
6. Type or choose a file URL in that row → the error clears, **Save Changes** enables, and the product saves with the download attached.
7. Server side, `PUT dokan/v3/products/<id>` with `downloadable: true` and `downloads: []`, rows whose `file` is empty, or **no `downloads` key at all**, returns `400 dokan_rest_product_download_required`.
8. Regression checks: turn **Required** back off — a downloadable product saves with no file again; quick create and a partial `PUT` that omits `downloads` keep working.

Verified against a live install (Lite 5.0.12 / Pro Business 5.0.11, WC 10.x):

| case | result |
|---|---|
| no rows / one blank row / name-only row | `400 dokan_rest_product_download_required` |
| `downloadable: true` with **no `downloads` key** — create and update | `400` (was `201` / `200` before this) |
| same via `POST /products/batch` | rejected per item |
| file attached | 200, saved with 1 download |
| not downloadable · partial `PUT` without `downloads` · quick-create draft | 200 / 201 |
| field left optional, or hidden for this product type | 200 |
| product that predates the rule: price-only or status-only save | 200 |
| product that predates the rule: turning `downloadable` off | 200 |

Client side: `[]`, blank rows and a **row carrying only a name** all keep **Save Changes** disabled; typing that name stays visible in the row while the form data stays empty, and adding the file enables Save and persists one download.

Blast radius of the shared `isEmpty()` change was measured rather than assumed: old vs new implementation diffed over every array/object-valued schema field across 40 real products (14 fields, 28 distinct values) — **0 behaviour changes**. The only differences are `[ { …all blank } ]`, `[ '' ]` and `{}`, none of which any Lite or Pro field produces.

### Changelog entry

*Fixed: required "Downloadable Files" field was not enforced*

Vendors could submit a downloadable product without attaching any file even though the Product Form Manager marked Downloadable Files as required, so incomplete downloadable products reached the review queue. Empty file rows no longer count as a filled-in value, and the requirement is now enforced on the server as well as in the browser.

### Before Changes

With **Downloadable Files** required and left empty, clicking **Add New** cleared the validation error and enabled **Save Changes**. The product saved with `downloadable = yes` and `downloads = 0`.

### After Changes

Blank rows no longer satisfy the requirement — **Save Changes** stays disabled and the field keeps showing *Please fill out this field.* until a file is attached. A crafted REST save is rejected with `400 dokan_rest_product_download_required`.

### PR Self Review Checklist:

* [x] Code is following code style guidelines
* [x] Have not left commented out code
* [x] Have not left any debug/console statements
