### PR TITLE
fix: hold vendor downloadable file changes until admin approval

### DIFF
--- a/includes/Admin/Hooks.php
+++ b/includes/Admin/Hooks.php
@@ -39,6 +39,10 @@ class Hooks {
 
         add_action( 'woocommerce_product_bulk_edit_end', [ $this, 'add_product_commission_bulk_edit_field' ] );
         add_action( 'woocommerce_product_bulk_edit_save', [ $this, 'save_custom_bulk_edit_field' ], 10, 1 );
+
+        // Downloadable files a vendor submitted for approval
+        add_action( 'woocommerce_product_options_downloads', [ $this, 'render_pending_downloadable_files' ] );
+        add_action( 'admin_notices', [ $this, 'pending_downloadable_files_notice' ] );
     }
 
     /**
@@ -268,5 +272,78 @@ class Hooks {
         }
 
         ProductHooks::save_per_product_commission_options( $product->get_id(), $_REQUEST ); // phpcs:ignore
+    }
+    /**
+     * Show the downloadable files a vendor submitted for approval below the live files.
+     *
+     * The WooCommerce product data panel lists the approved files that customers
+     * currently hold; the pending replacement is rendered read-only underneath so the
+     * admin can review what publishing will deliver.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function render_pending_downloadable_files() {
+        $post = get_post();
+
+        if ( ! $post instanceof WP_Post || 'product' !== $post->post_type ) {
+            return;
+        }
+
+        $staged = dokan_get_staged_downloadable_files( $post->ID );
+
+        if ( null === $staged ) {
+            return;
+        }
+        ?>
+        <div class="options_group dokan-pending-downloadable-files">
+            <p class="form-field">
+                <strong><?php esc_html_e( 'Replacement files awaiting your approval', 'dokan-lite' ); ?></strong><br>
+                <?php esc_html_e( 'The vendor submitted these files with the pending update. Customers who already purchased keep the files listed above until you publish this product; publishing delivers the files below to them.', 'dokan-lite' ); ?>
+            </p>
+            <?php if ( empty( $staged ) ) : ?>
+                <p class="form-field"><?php esc_html_e( 'The vendor removed all downloadable files. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?></p>
+            <?php else : ?>
+                <ul class="form-field">
+                    <?php foreach ( $staged as $file ) : ?>
+                        <?php
+                        $file_url  = isset( $file['file'] ) ? $file['file'] : '';
+                        $file_name = ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file_url );
+                        ?>
+                        <li>
+                            <strong><?php echo esc_html( $file_name ); ?></strong>
+                            &mdash; <a href="<?php echo esc_url( $file_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $file_url ); ?></a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * Warn the admin on the product edit screen when replacement files await approval.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function pending_downloadable_files_notice() {
+        $screen = get_current_screen();
+        $post   = get_post();
+
+        if ( ! $screen || 'product' !== $screen->id || ! $post instanceof WP_Post || 'product' !== $post->post_type ) {
+            return;
+        }
+
+        if ( null === dokan_get_staged_downloadable_files( $post->ID ) ) {
+            return;
+        }
+        ?>
+        <div class="notice notice-warning">
+            <p><?php esc_html_e( 'This product has replacement downloadable files awaiting your approval. Existing customers keep the currently approved files until you publish; review the pending files under General → Downloadable files before publishing.', 'dokan-lite' ); ?></p>
+        </div>
+        <?php
     }
 }

--- a/includes/Admin/Hooks.php
+++ b/includes/Admin/Hooks.php
@@ -301,29 +301,70 @@ class Hooks {
             <p class="form-field">
                 <label><?php esc_html_e( 'Awaiting approval', 'dokan-lite' ); ?></label>
                 <span class="description">
-                    <strong><?php esc_html_e( 'The vendor submitted replacement files with this pending update.', 'dokan-lite' ); ?></strong><br>
-                    <?php esc_html_e( 'Customers who already purchased keep the files listed above until you publish this product; publishing delivers the files below to them.', 'dokan-lite' ); ?>
+                    <strong><?php esc_html_e( 'This pending update carries downloadable changes that have not been delivered yet.', 'dokan-lite' ); ?></strong><br>
+                    <?php esc_html_e( 'Customers who already purchased keep the files listed above until you publish this product; publishing delivers the changes below to them.', 'dokan-lite' ); ?>
                 </span>
             </p>
             <?php foreach ( $staged as $entry ) : ?>
                 <p class="form-field">
                     <label><?php echo esc_html( $entry['label'] ); ?></label>
                     <span class="description">
-                        <?php if ( empty( $entry['files'] ) ) : ?>
-                            <?php esc_html_e( 'The vendor removed all downloadable files. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?>
-                        <?php else : ?>
+                        <?php if ( $entry['submitted_by'] ) : ?>
+                            <em>
+                                <?php
+                                printf(
+                                    /* translators: %s: display name of the user who submitted the pending files. */
+                                    esc_html__( 'Submitted by %s', 'dokan-lite' ),
+                                    esc_html( $entry['submitted_by'] )
+                                );
+                                ?>
+                            </em><br>
+                        <?php endif; ?>
+                        <?php if ( 'no' === $entry['flag'] ) : ?>
+                            <?php esc_html_e( 'Downloads are being switched off for this product. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?><br>
+                        <?php elseif ( 'yes' === $entry['flag'] ) : ?>
+                            <?php esc_html_e( 'Downloads are being switched back on for this product.', 'dokan-lite' ); ?><br>
+                        <?php endif; ?>
+                        <?php if ( is_array( $entry['files'] ) && empty( $entry['files'] ) ) : ?>
+                            <?php esc_html_e( 'All downloadable files were removed. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?>
+                        <?php elseif ( is_array( $entry['files'] ) ) : ?>
                             <?php foreach ( $entry['files'] as $file ) : ?>
                                 <?php
-                                $file_url  = isset( $file['file'] ) ? $file['file'] : '';
-                                $file_name = ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file_url );
+                                $file_url = isset( $file['file'] ) ? $file['file'] : '';
+                                // The real filename leads, not the vendor's label. The label is a
+                                // free-text field the media picker never rewrites (WooCommerce
+                                // behaves the same way), so after a file swap it still reads as the
+                                // previous file - and an administrator would be reviewing a name
+                                // that does not belong to the file they are about to approve.
+                                $real_name  = wc_get_filename_from_url( $file_url );
+                                $shown_name = isset( $file['name'] ) ? $file['name'] : '';
                                 ?>
-                                <strong><?php echo esc_html( $file_name ); ?></strong> &mdash;
+                                <strong><?php echo esc_html( $real_name ? $real_name : $file_url ); ?></strong>
+                                <?php if ( '' !== $shown_name && $shown_name !== $real_name ) : ?>
+                                    <?php
+                                    printf(
+                                        /* translators: %s: the label shown to customers for this download. */
+                                        esc_html__( '(shown to customers as "%s")', 'dokan-lite' ),
+                                        esc_html( $shown_name )
+                                    );
+                                    ?>
+                                <?php endif; ?>
+                                <br>
                                 <a href="<?php echo esc_url( $file_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $file_url ); ?></a><br>
                             <?php endforeach; ?>
                         <?php endif; ?>
                     </span>
                 </p>
             <?php endforeach; ?>
+            <p class="form-field">
+                <label>&nbsp;</label>
+                <span class="description">
+                    <button type="submit" name="dokan_discard_pending_downloads" value="1" class="button">
+                        <?php esc_html_e( 'Discard pending files', 'dokan-lite' ); ?>
+                    </button><br>
+                    <?php esc_html_e( 'Rejects the changes above and keeps the currently approved files. The product itself is saved as usual.', 'dokan-lite' ); ?>
+                </span>
+            </p>
         </div>
         <?php
     }
@@ -360,7 +401,7 @@ class Hooks {
      *
      * @param int $product_id Product ID.
      *
-     * @return array<int, array{id:int, label:string, files:array}>
+     * @return array<int, array{id:int, label:string, files:array|null, flag:string|null, submitted_by:string}>
      */
     protected function collect_staged_downloadable_files( $product_id ) {
         $product = wc_get_product( $product_id );
@@ -379,15 +420,21 @@ class Hooks {
 
         foreach ( $ids as $id ) {
             $files = dokan_get_staged_downloadable_files( $id );
+            $flag  = dokan_get_staged_downloadable_flag( $id );
 
-            if ( null === $files ) {
+            if ( null === $files && null === $flag ) {
                 continue;
             }
 
+            $author = (int) get_post_meta( $id, '_dokan_pending_downloadable_files_author', true );
+            $user   = $author ? get_userdata( $author ) : false;
+
             $entries[] = [
-                'id'    => $id,
-                'files' => $files,
-                'label' => $id === $product_id
+                'id'           => $id,
+                'files'        => $files,
+                'flag'         => $flag,
+                'submitted_by' => $user ? $user->display_name : '',
+                'label'        => $id === $product_id
                     ? __( 'Pending files', 'dokan-lite' )
                     /* translators: %s: variation name. */
                     : sprintf( __( 'Pending files — %s', 'dokan-lite' ), wc_get_product( $id ) ? wc_get_product( $id )->get_name() : $id ),

--- a/includes/Admin/Hooks.php
+++ b/includes/Admin/Hooks.php
@@ -41,7 +41,7 @@ class Hooks {
         add_action( 'woocommerce_product_bulk_edit_save', [ $this, 'save_custom_bulk_edit_field' ], 10, 1 );
 
         // Downloadable files a vendor submitted for approval
-        add_action( 'woocommerce_product_options_downloads', [ $this, 'render_pending_downloadable_files' ] );
+        add_action( 'woocommerce_product_options_general_product_data', [ $this, 'render_pending_downloadable_files' ], 99 );
         add_action( 'admin_notices', [ $this, 'pending_downloadable_files_notice' ] );
     }
 
@@ -291,33 +291,39 @@ class Hooks {
             return;
         }
 
-        $staged = dokan_get_staged_downloadable_files( $post->ID );
+        $staged = $this->collect_staged_downloadable_files( $post->ID );
 
-        if ( null === $staged ) {
+        if ( ! $staged ) {
             return;
         }
         ?>
         <div class="options_group dokan-pending-downloadable-files">
             <p class="form-field">
-                <strong><?php esc_html_e( 'Replacement files awaiting your approval', 'dokan-lite' ); ?></strong><br>
-                <?php esc_html_e( 'The vendor submitted these files with the pending update. Customers who already purchased keep the files listed above until you publish this product; publishing delivers the files below to them.', 'dokan-lite' ); ?>
+                <label><?php esc_html_e( 'Awaiting approval', 'dokan-lite' ); ?></label>
+                <span class="description">
+                    <strong><?php esc_html_e( 'The vendor submitted replacement files with this pending update.', 'dokan-lite' ); ?></strong><br>
+                    <?php esc_html_e( 'Customers who already purchased keep the files listed above until you publish this product; publishing delivers the files below to them.', 'dokan-lite' ); ?>
+                </span>
             </p>
-            <?php if ( empty( $staged ) ) : ?>
-                <p class="form-field"><?php esc_html_e( 'The vendor removed all downloadable files. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?></p>
-            <?php else : ?>
-                <ul class="form-field">
-                    <?php foreach ( $staged as $file ) : ?>
-                        <?php
-                        $file_url  = isset( $file['file'] ) ? $file['file'] : '';
-                        $file_name = ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file_url );
-                        ?>
-                        <li>
-                            <strong><?php echo esc_html( $file_name ); ?></strong>
-                            &mdash; <a href="<?php echo esc_url( $file_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $file_url ); ?></a>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            <?php endif; ?>
+            <?php foreach ( $staged as $entry ) : ?>
+                <p class="form-field">
+                    <label><?php echo esc_html( $entry['label'] ); ?></label>
+                    <span class="description">
+                        <?php if ( empty( $entry['files'] ) ) : ?>
+                            <?php esc_html_e( 'The vendor removed all downloadable files. Publishing will revoke the downloads of existing customers.', 'dokan-lite' ); ?>
+                        <?php else : ?>
+                            <?php foreach ( $entry['files'] as $file ) : ?>
+                                <?php
+                                $file_url  = isset( $file['file'] ) ? $file['file'] : '';
+                                $file_name = ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file_url );
+                                ?>
+                                <strong><?php echo esc_html( $file_name ); ?></strong> &mdash;
+                                <a href="<?php echo esc_url( $file_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $file_url ); ?></a><br>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </span>
+                </p>
+            <?php endforeach; ?>
         </div>
         <?php
     }
@@ -337,7 +343,7 @@ class Hooks {
             return;
         }
 
-        if ( null === dokan_get_staged_downloadable_files( $post->ID ) ) {
+        if ( ! $this->collect_staged_downloadable_files( $post->ID ) ) {
             return;
         }
         ?>
@@ -345,5 +351,49 @@ class Hooks {
             <p><?php esc_html_e( 'This product has replacement downloadable files awaiting your approval. Existing customers keep the currently approved files until you publish; review the pending files under General → Downloadable files before publishing.', 'dokan-lite' ); ?></p>
         </div>
         <?php
+    }
+
+    /**
+     * Collect the staged downloadable file sets of a product and its variations.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int $product_id Product ID.
+     *
+     * @return array<int, array{id:int, label:string, files:array}>
+     */
+    protected function collect_staged_downloadable_files( $product_id ) {
+        $product = wc_get_product( $product_id );
+
+        if ( ! $product ) {
+            return [];
+        }
+
+        $ids = [ $product_id ];
+
+        if ( $product->is_type( 'variable' ) ) {
+            $ids = array_merge( $ids, array_map( 'absint', $product->get_children() ) );
+        }
+
+        $entries = [];
+
+        foreach ( $ids as $id ) {
+            $files = dokan_get_staged_downloadable_files( $id );
+
+            if ( null === $files ) {
+                continue;
+            }
+
+            $entries[] = [
+                'id'    => $id,
+                'files' => $files,
+                'label' => $id === $product_id
+                    ? __( 'Pending files', 'dokan-lite' )
+                    /* translators: %s: variation name. */
+                    : sprintf( __( 'Pending files — %s', 'dokan-lite' ), wc_get_product( $id ) ? wc_get_product( $id )->get_name() : $id ),
+            ];
+        }
+
+        return $entries;
     }
 }

--- a/includes/Admin/Hooks.php
+++ b/includes/Admin/Hooks.php
@@ -273,6 +273,7 @@ class Hooks {
 
         ProductHooks::save_per_product_commission_options( $product->get_id(), $_REQUEST ); // phpcs:ignore
     }
+
     /**
      * Show the downloadable files a vendor submitted for approval below the live files.
      *

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -87,6 +87,14 @@ class Products {
     public static function load_download_virtual_template( $post, $post_id ) {
         $_downloadable   = get_post_meta( $post_id, '_downloadable', true );
         $_virtual        = get_post_meta( $post_id, '_virtual', true );
+        $staged_flag     = dokan_get_staged_downloadable_flag( $post_id );
+
+        // while the change awaits approval, show the vendor what they submitted rather than
+        // the still-live value, the same way the file list does
+        if ( null !== $staged_flag ) {
+            $_downloadable = $staged_flag;
+        }
+
         $is_downloadable = 'yes' === $_downloadable;
         $is_virtual      = 'yes' === $_virtual;
         $digital_mode    = dokan_get_option( 'global_digital_mode', 'dokan_general', 'sell_both' );
@@ -491,6 +499,16 @@ class Products {
 
         if ( empty( $post_status ) ) {
             $post_status = $current_post_status;
+        }
+
+        // A vendor may only move a product between the statuses the dashboard actually
+        // offers them. Without this a crafted POST sets any status at all — including one
+        // that releases a downloadable file change being held for admin review, letting the
+        // vendor approve their own submission.
+        if ( ! array_key_exists( $post_status, (array) dokan_get_available_post_status( $post_id ) ) ) {
+            $post_status = $is_new_product
+                ? dokan_get_default_product_status( get_current_user_id() )
+                : $current_post_status;
         }
 
         if ( ! dokan_is_product_author( $post_id ) ) {

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -350,12 +350,21 @@ function dokan_process_product_meta( int $post_id, array $data = [] ) {
                 }
             }
 
-            // grant permission to any newly added files on any existing orders for this product prior to saving
-            do_action( 'dokan_process_file_download', $post_id, 0, $files );
+            if ( dokan_downloadable_files_require_approval( $post_id, $files ) ) {
+                // existing customers keep the approved files until an admin publishes the product
+                update_post_meta( $post_id, '_dokan_pending_downloadable_files', $files );
+            } else {
+                // grant permission to any newly added files on any existing orders for this product prior to saving
+                do_action( 'dokan_process_file_download', $post_id, 0, $files );
 
-            update_post_meta( $post_id, '_downloadable_files', $files );
+                update_post_meta( $post_id, '_downloadable_files', $files );
+                delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
+            }
+        } elseif ( dokan_downloadable_files_require_approval( $post_id, [] ) ) {
+            update_post_meta( $post_id, '_dokan_pending_downloadable_files', [] );
         } else {
             update_post_meta( $post_id, '_downloadable_files', '' );
+            delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
         }
 
         update_post_meta( $post_id, '_download_limit', $_download_limit );
@@ -1085,3 +1094,90 @@ function dokan_vendor_product_review_restriction( array $data ): array {
     return $data;
 }
 add_filter( 'woocommerce_product_review_comment_form_args', 'dokan_vendor_product_review_restriction' );
+
+/**
+ * Check whether a changed set of downloadable files must be held back for admin approval.
+ *
+ * While a product edit sits in pending review, customers who already purchased must
+ * keep the last approved files. A changed file set is therefore staged in the
+ * `_dokan_pending_downloadable_files` meta instead of being written to
+ * `_downloadable_files`, and applied when an admin publishes the product.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int   $product_id Product ID.
+ * @param array $new_files  Submitted downloadable files, keyed by download id.
+ *
+ * @return bool
+ */
+function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
+    global $wpdb;
+
+    if ( 'pending' !== get_post_status( $product_id ) ) {
+        return false;
+    }
+
+    $live_files = get_post_meta( $product_id, '_downloadable_files', true );
+    $live_ids   = is_array( $live_files ) ? array_keys( $live_files ) : [];
+    $new_ids    = array_keys( (array) $new_files );
+
+    sort( $live_ids );
+    sort( $new_ids );
+
+    if ( $live_ids === $new_ids ) {
+        return false;
+    }
+
+    // staging only matters when somebody already holds a download permission for this product
+    $has_permissions = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->prepare(
+            "SELECT permission_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d LIMIT 1",
+            $product_id
+        )
+    );
+
+    /**
+     * Filter whether a changed downloadable file set is staged until admin approval.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param bool  $require_approval Whether the new file set should be staged.
+     * @param int   $product_id       Product ID.
+     * @param array $new_files        Submitted downloadable files, keyed by download id.
+     */
+    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', ! empty( $has_permissions ), $product_id, $new_files );
+}
+
+/**
+ * Apply staged downloadable files once a product gets published.
+ *
+ * Runs late on `save_post` so it also wins when an admin approves a pending product
+ * from the WooCommerce product edit screen, whose own meta box save (priority 1)
+ * re-saves the previously approved files.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ *
+ * @return void
+ */
+function dokan_apply_staged_downloadable_files( $post_id, $post ) {
+    if ( 'product' !== $post->post_type || 'publish' !== $post->post_status ) {
+        return;
+    }
+
+    $staged = get_post_meta( $post_id, '_dokan_pending_downloadable_files', true );
+
+    if ( ! is_array( $staged ) ) {
+        return;
+    }
+
+    delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
+
+    // move existing customers over to the newly approved files
+    do_action( 'dokan_process_file_download', $post_id, 0, $staged );
+
+    update_post_meta( $post_id, '_downloadable_files', empty( $staged ) ? '' : $staged );
+}
+add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -350,21 +350,12 @@ function dokan_process_product_meta( int $post_id, array $data = [] ) {
                 }
             }
 
-            if ( dokan_downloadable_files_require_approval( $post_id, $files ) ) {
-                // existing customers keep the approved files until an admin publishes the product
-                update_post_meta( $post_id, '_dokan_pending_downloadable_files', $files );
-            } else {
-                // grant permission to any newly added files on any existing orders for this product prior to saving
-                do_action( 'dokan_process_file_download', $post_id, 0, $files );
+            // grant permission to any newly added files on any existing orders for this product prior to saving
+            do_action( 'dokan_process_file_download', $post_id, 0, $files );
 
-                update_post_meta( $post_id, '_downloadable_files', $files );
-                delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
-            }
-        } elseif ( dokan_downloadable_files_require_approval( $post_id, [] ) ) {
-            update_post_meta( $post_id, '_dokan_pending_downloadable_files', [] );
+            update_post_meta( $post_id, '_downloadable_files', $files );
         } else {
             update_post_meta( $post_id, '_downloadable_files', '' );
-            delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
         }
 
         update_post_meta( $post_id, '_download_limit', $_download_limit );
@@ -381,7 +372,7 @@ function dokan_process_product_meta( int $post_id, array $data = [] ) {
             update_post_meta( $post_id, '_download_type', wc_clean( $data['_download_type'] ) );
         }
     } else {
-        // the product is no longer downloadable; a staged file set must not apply on approval
+        // the product is no longer downloadable; a staged replacement must not apply on approval
         delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
     }
 
@@ -1105,7 +1096,8 @@ add_filter( 'woocommerce_product_review_comment_form_args', 'dokan_vendor_produc
  *
  * @param int $product_id Product or variation ID.
  *
- * @return array|null Staged files keyed by download id (may be empty when the vendor removed all files), null when nothing is staged.
+ * @return array|null Staged files keyed by download id (may be empty when the vendor
+ *                    removed every file), null when nothing is staged.
  */
 function dokan_get_staged_downloadable_files( $product_id ) {
     $staged = get_post_meta( $product_id, '_dokan_pending_downloadable_files', true );
@@ -1131,10 +1123,10 @@ function dokan_get_downloadable_files_released_statuses( $product_id = 0 ) {
      *
      * @since DOKAN_SINCE
      *
-     * @param string[] $released_statuses Post statuses that release staged files. Default `publish`.
+     * @param string[] $released_statuses Post statuses that release staged files.
      * @param int      $product_id        Product ID.
      */
-    return (array) apply_filters( 'dokan_downloadable_files_released_statuses', [ 'publish' ], $product_id );
+    return (array) apply_filters( 'dokan_downloadable_files_released_statuses', [ 'publish', 'private' ], $product_id );
 }
 
 /**
@@ -1171,32 +1163,34 @@ function dokan_downloadable_file_sets_differ( $files_a, $files_b ) {
 }
 
 /**
- * Check whether a changed set of downloadable files must be held back for admin approval.
+ * Check whether downloadable file changes on this product are held for admin approval.
  *
- * While a product edit awaits review, customers who already purchased must keep the
- * last approved files. A changed file set is therefore staged in the
- * `_dokan_pending_downloadable_files` meta instead of being written to
- * `_downloadable_files`, and applied when the product is published.
+ * Three things must hold: the product is not in a released status, the save is genuinely
+ * subject to review (a vendor whose products need approval — not a trusted vendor, a
+ * marketplace with approval switched off, or a shop manager's own product), and at least
+ * one customer already holds a download permission, since the hold exists to protect them.
  *
  * @since DOKAN_SINCE
  *
- * @param int         $product_id Product or variation ID (the ID download permissions are stored under).
- * @param array       $new_files  Submitted downloadable files, keyed by download id.
- * @param string|null $status     Status the product is being saved with. Defaults to the stored status.
+ * @param int $product_id Product or variation ID (the ID permissions are stored under).
  *
  * @return bool
  */
-function dokan_downloadable_files_require_approval( $product_id, $new_files, $status = null ) {
+function dokan_downloadable_hold_applies( $product_id ) {
     global $wpdb;
 
-    $status           = null === $status ? get_post_status( $product_id ) : $status;
-    $require_approval = false;
+    $product  = wc_get_product( $product_id );
+    $owner_id = $product && $product->is_type( 'variation' ) ? $product->get_parent_id() : $product_id;
+    $applies  = false;
 
-    if ( $product_id && ! in_array( $status, dokan_get_downloadable_files_released_statuses( $product_id ), true ) ) {
-        $live_files = get_post_meta( $product_id, '_downloadable_files', true );
+    if ( $owner_id && ! in_array( get_post_status( $owner_id ), dokan_get_downloadable_files_released_statuses( $owner_id ), true ) ) {
+        $author = (int) get_post_field( 'post_author', $owner_id );
 
-        if ( dokan_downloadable_file_sets_differ( is_array( $live_files ) ? $live_files : [], $new_files ) ) {
-            // staging only matters when somebody already holds a download permission for this product
+        // only a vendor whose saves actually pass through review is held: someone who
+        // can manage WooCommerce is the reviewer, not the reviewed, and a trusted vendor
+        // or a marketplace with approval switched off has no review step at all
+        if ( $author && ! user_can( $author, 'manage_woocommerce' ) && 'publish' !== dokan_get_default_product_status( $author ) ) {
+            // the hold only matters when somebody already holds a download permission
             $has_permissions = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
                 $wpdb->prepare(
                     "SELECT permission_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d LIMIT 1",
@@ -1204,308 +1198,242 @@ function dokan_downloadable_files_require_approval( $product_id, $new_files, $st
                 )
             );
 
-            $require_approval = ! empty( $has_permissions );
+            $applies = ! empty( $has_permissions );
         }
     }
 
     /**
-     * Filter whether a changed downloadable file set is staged until admin approval.
+     * Filter whether downloadable file changes on a product are held until admin approval.
      *
      * @since DOKAN_SINCE
      *
-     * @param bool   $require_approval Whether the new file set should be staged.
-     * @param int    $product_id       Product or variation ID.
-     * @param array  $new_files        Submitted downloadable files, keyed by download id.
-     * @param string $status           Status the product is being saved with.
+     * @param bool $applies    Whether the hold applies.
+     * @param int  $product_id Product or variation ID.
      */
-    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', $require_approval, $product_id, $new_files, $status );
+    return (bool) apply_filters( 'dokan_downloadable_hold_applies', $applies, $product_id );
 }
 
 /**
- * Convert WC_Product_Download objects to the array format stored in `_downloadable_files`.
+ * Track products whose staged files were released during this request.
+ *
+ * WooCommerce writes `_downloadable_files` *after* the `save_post` that triggers the
+ * release, so a save that both approves the product and sets the files lands its own set
+ * last. Remembering the release lets that later write re-point existing permissions at
+ * what actually ended up live, instead of leaving them on the released set.
  *
  * @since DOKAN_SINCE
  *
- * @param WC_Product_Download[]|array $downloads Download objects.
- *
- * @return array Files keyed by download id.
- */
-function dokan_downloads_to_files_array( $downloads ) {
-    $files = [];
-
-    foreach ( (array) $downloads as $key => $download ) {
-        if ( $download instanceof WC_Product_Download ) {
-            $files[ $download->get_id() ] = [
-                'name' => $download->get_name(),
-                'file' => $download->get_file(),
-            ];
-        } elseif ( is_array( $download ) && ! empty( $download['file'] ) ) {
-            $files[ $key ] = [
-                'name' => isset( $download['name'] ) ? $download['name'] : '',
-                'file' => $download['file'],
-            ];
-        }
-    }
-
-    return $files;
-}
-
-/**
- * Convert a `_downloadable_files` style array to WC_Product_Download objects.
- *
- * @since DOKAN_SINCE
- *
- * @param array $files Files keyed by download id.
- *
- * @return WC_Product_Download[]
- */
-function dokan_files_array_to_downloads( $files ) {
-    $downloads = [];
-
-    foreach ( (array) $files as $key => $file ) {
-        if ( ! is_array( $file ) || empty( $file['file'] ) ) {
-            continue;
-        }
-
-        $download = new WC_Product_Download();
-        $download->set_id( (string) $key );
-        $download->set_name( ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
-        $download->set_file( $file['file'] );
-        $download->set_enabled( isset( $file['enabled'] ) ? (bool) $file['enabled'] : true );
-
-        $downloads[] = $download;
-    }
-
-    return $downloads;
-}
-
-/**
- * Track products whose download permissions must be re-synced with their live files.
- *
- * When a save both publishes and changes the files, the pre-save hook drops any staged
- * replacement and flags the product here. Syncing is idempotent (it reconciles
- * permissions to the current live files), so the post-save hook may run it on every
- * save of the request without clearing the flag; a `shutdown` pass runs it once more
- * against the final files and clears the flags. This survives WooCommerce nesting a
- * second save inside the first, whose early `after` fires before the new files are written.
- *
- * @since DOKAN_SINCE
- *
- * @param int|null $product_id Product or variation ID, or null for the `flush` action.
- * @param string   $action     'flag', 'peek' (default) or 'flush'.
+ * @param int  $product_id Product or variation ID.
+ * @param bool $set        True to record a release, null to read.
  *
  * @return bool
  */
-function dokan_downloadable_files_permission_sync( $product_id = null, $action = 'peek' ) {
-    static $flags      = [];
-    static $registered = false;
+function dokan_downloadable_files_released_this_request( $product_id, $set = null ) {
+    static $released = [];
 
-    if ( 'flag' === $action ) {
-        $flags[ $product_id ] = true;
+    if ( is_array( $set ) ) {
+        $released[ $product_id ] = [
+            'files' => $set,
+            'token' => did_action( 'save_post' ),
+        ];
 
-        if ( ! $registered ) {
-            $registered = true;
-            add_action( 'shutdown', 'dokan_flush_downloadable_permission_syncs', 20 );
-        }
-
-        return true;
+        return $set;
     }
 
-    if ( 'flush' === $action ) {
-        foreach ( array_keys( $flags ) as $pid ) {
-            dokan_sync_download_permissions_with_product_files( $pid );
-        }
-
-        $flags = [];
-
-        return true;
+    if ( ! isset( $released[ $product_id ] ) ) {
+        return null;
     }
 
-    return ! empty( $flags[ $product_id ] );
+    // only the save that performed the release may claim it: WooCommerce writes the meta
+    // straight after that save's `save_post`, so the counter has not moved on yet
+    if ( $released[ $product_id ]['token'] !== did_action( 'save_post' ) ) {
+        unset( $released[ $product_id ] );
+
+        return null;
+    }
+
+    return $released[ $product_id ]['files'];
 }
 
 /**
- * Flush pending download-permission syncs at the end of the request.
+ * Hold a changed downloadable file set until an admin approves it.
+ *
+ * Every save path writes `_downloadable_files` through `update_post_meta()` — the classic
+ * vendor form writes it directly, and WooCommerce CRUD (the REST endpoints, the product
+ * editor, the wp-admin screen and WP-CLI) writes it from `update_downloads()`. Filtering
+ * the meta write itself therefore covers all of them from one place: while the product
+ * awaits review the submitted set is stored in `_dokan_pending_downloadable_files` and the
+ * live value is left untouched, so existing customers keep the files they already have.
  *
  * @since DOKAN_SINCE
  *
- * @return void
+ * @param mixed  $check      Short-circuit value; null lets the write continue.
+ * @param int    $object_id  Product or variation ID.
+ * @param string $meta_key   Meta key being written.
+ * @param mixed  $meta_value Value being written.
+ *
+ * @return mixed True to swallow the write, otherwise the unchanged short-circuit value.
  */
-function dokan_flush_downloadable_permission_syncs() {
-    dokan_downloadable_files_permission_sync( null, 'flush' );
+function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key, $meta_value = null ) {
+    if ( null !== $check || '_downloadable_files' !== $meta_key ) {
+        return $check;
+    }
+
+    if ( ! in_array( get_post_type( $object_id ), [ 'product', 'product_variation' ], true ) ) {
+        return $check;
+    }
+
+    if ( dokan_releasing_staged_downloadable_files() ) {
+        // the release step is writing the approved files; never intercept that
+        return $check;
+    }
+
+    // WooCommerce slashes its own writes and `update_post_meta()` unslashes once, so the
+    // real value is the unslashed one; it is re-slashed when stored so it round-trips
+    $new_files = is_array( $meta_value ) ? wp_unslash( $meta_value ) : [];
+
+    if ( ! dokan_downloadable_hold_applies( $object_id ) ) {
+        $staged_here  = dokan_get_staged_downloadable_files( $object_id );
+        $pre_release  = dokan_downloadable_files_released_this_request( $object_id );
+
+        if ( null === $staged_here && null === $pre_release ) {
+            return $check;
+        }
+
+        // Work out whether this save is really setting the files or just echoing back
+        // what it was given. A REST client that reads a product, flips its status and
+        // PUTs it back sends the files it was handed — that is an approval, not an edit.
+        $baseline = null !== $pre_release ? $pre_release : (array) get_post_meta( $object_id, '_downloadable_files', true );
+
+        if ( ! dokan_downloadable_file_sets_differ( $baseline, $new_files ) ) {
+            // an echo: leave the released files in place
+            return null !== $pre_release ? true : $check;
+        }
+
+        // a genuine edit by the approver: their set wins over the staged submission, and
+        // `_downloadable_files` still holds the previous value so the permission handler
+        // can move existing customers onto the incoming one
+        delete_post_meta( $object_id, '_dokan_pending_downloadable_files' );
+
+        $variation_id = 'product_variation' === get_post_type( $object_id ) ? $object_id : 0;
+        $owner_id     = $variation_id ? wp_get_post_parent_id( $object_id ) : $object_id;
+
+        dokan_releasing_staged_downloadable_files( true );
+        do_action( 'dokan_process_file_download', $owner_id, $variation_id, $new_files );
+        dokan_releasing_staged_downloadable_files( false );
+
+        return $check;
+    }
+
+    $live_files = get_post_meta( $object_id, '_downloadable_files', true );
+
+    if ( ! dokan_downloadable_file_sets_differ( is_array( $live_files ) ? $live_files : [], $new_files ) ) {
+        // The submitted set matches what is already live. Only the vendor putting their
+        // own files back counts as withdrawing the submission: anyone else saving the
+        // product — an admin opening it to review the pending files, for instance — is
+        // re-submitting the rendered approved set and must not discard it.
+        $owner_id = 'product_variation' === get_post_type( $object_id ) ? wp_get_post_parent_id( $object_id ) : $object_id;
+
+        if ( dokan_is_product_author( $owner_id ) ) {
+            delete_post_meta( $object_id, '_dokan_pending_downloadable_files' );
+        }
+
+        return $check;
+    }
+
+    update_post_meta( $object_id, '_dokan_pending_downloadable_files', wp_slash( $new_files ) );
+
+    // swallow the write: the approved files stay live for existing customers
+    return true;
 }
+add_filter( 'update_post_metadata', 'dokan_hold_downloadable_files_meta_write', 10, 5 );
 
 /**
- * Hold changed downloadable files on WooCommerce CRUD saves while the product awaits approval.
+ * Hold the removal of every downloadable file until an admin approves it.
  *
- * Covers every path that saves through `WC_Product::save()`: the Dokan REST product
- * endpoints, the new product editor, `Product\Manager::update()`, the wp-admin product
- * screen and WP-CLI. For a held (unpublished) status the submitted files are staged and
- * the approved files are kept on the object, so WooCommerce persists those unchanged.
- * The actual release happens later, on `save_post`, once every write in the request is done.
+ * WooCommerce deletes `_downloadable_files` rather than writing an empty value when a
+ * product ends up with no files, so the deletion needs the same hold as a replacement.
  *
  * @since DOKAN_SINCE
  *
- * @param WC_Product $product Product being saved.
+ * @param mixed  $check     Short-circuit value; null lets the delete continue.
+ * @param int    $object_id Product or variation ID.
+ * @param string $meta_key  Meta key being deleted.
  *
- * @return void
+ * @return mixed True to swallow the delete, otherwise the unchanged short-circuit value.
  */
-function dokan_hold_downloadable_files_before_product_save( $product ) {
-    if ( ! $product instanceof WC_Product || ! $product->get_id() ) {
-        return;
-    }
-
-    $product_id   = $product->get_id();
-    $is_variation = $product->is_type( 'variation' );
-    $status       = $is_variation ? get_post_status( $product->get_parent_id() ) : $product->get_status();
-
-    if ( ! $product->get_downloadable() ) {
-        // no longer downloadable: a pending replacement must not apply on approval
-        delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
-
-        return;
-    }
-
-    if ( ! array_key_exists( 'downloads', $product->get_changes() ) ) {
-        return;
-    }
-
-    $live_files       = get_post_meta( $product_id, '_downloadable_files', true );
-    $approved         = is_array( $live_files ) ? $live_files : [];
-    $new_files        = dokan_downloads_to_files_array( $product->get_downloads() );
-    $changed          = dokan_downloadable_file_sets_differ( $approved, $new_files );
-    $owner_product_id = $is_variation ? $product->get_parent_id() : $product_id;
-    $released         = in_array( $status, dokan_get_downloadable_files_released_statuses( $product_id ), true );
-
-    if ( $released ) {
-        // publishing while also changing the files: the submitted files win. Drop any
-        // staged replacement and re-sync permissions once the new files are written.
-        if ( $changed && null !== dokan_get_staged_downloadable_files( $product_id ) ) {
-            delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
-            dokan_downloadable_files_permission_sync( $product_id, 'flag' );
-        }
-
-        return;
-    }
-
-    if ( ! $changed ) {
-        // the vendor resubmitting the approved files cancels their pending replacement
-        if ( dokan_is_product_author( $owner_product_id ) ) {
-            delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
-        }
-
-        return;
-    }
-
-    if ( ! dokan_downloadable_files_require_approval( $product_id, $new_files, $status ) ) {
-        return;
-    }
-
-    update_post_meta( $product_id, '_dokan_pending_downloadable_files', $new_files );
-
-    try {
-        // keep the approved files on the object so WooCommerce persists them unchanged
-        $product->set_downloads( dokan_files_array_to_downloads( $approved ) );
-    } catch ( Exception $e ) {
-        // the approved files can no longer be re-set; fall back to the regular save
-        delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
-    }
+function dokan_hold_downloadable_files_meta_delete( $check, $object_id, $meta_key ) {
+    return dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key, [] );
 }
-add_action( 'woocommerce_before_product_object_save', 'dokan_hold_downloadable_files_before_product_save' );
+add_filter( 'delete_post_metadata', 'dokan_hold_downloadable_files_meta_delete', 10, 3 );
 
 /**
- * Re-sync download permissions after a publish-time file change on a CRUD save.
- *
- * When a save both publishes and changes the files, `before` drops the staged
- * replacement and flags the product; this runs after WooCommerce writes the new
- * files so existing customers are moved onto them (WooCommerce core no longer
- * syncs permissions on file changes).
+ * Track whether the release step is currently writing a product's approved files.
  *
  * @since DOKAN_SINCE
  *
- * @param WC_Product $product Saved product.
+ * @param bool|null $set True to enter the release, false to leave it, null to read.
  *
- * @return void
+ * @return bool
  */
-function dokan_sync_downloadable_permissions_after_product_save( $product ) {
-    if ( ! $product instanceof WC_Product || ! $product->get_id() ) {
-        return;
+function dokan_releasing_staged_downloadable_files( $set = null ) {
+    static $releasing = false;
+
+    if ( null !== $set ) {
+        $releasing = (bool) $set;
     }
 
-    $product_id = $product->get_id();
-
-    if ( ! dokan_downloadable_files_permission_sync( $product_id, 'peek' ) ) {
-        return;
-    }
-
-    dokan_sync_download_permissions_with_product_files( $product_id );
+    return $releasing;
 }
-add_action( 'woocommerce_after_product_object_save', 'dokan_sync_downloadable_permissions_after_product_save', PHP_INT_MAX );
 
 /**
- * Sync existing download permissions with the files currently live on a product.
+ * Block download permission changes while a product's files are held.
  *
- * Permissions pointing at files no longer on the product are revoked and files not yet
- * granted are granted on every order that holds a permission for the product.
+ * The permission handler runs before the file meta is written, so the hold has to stop it
+ * separately: without this the vendor's save would move existing customers onto files that
+ * are not live yet.
  *
  * @since DOKAN_SINCE
  *
- * @param int $product_id Product or variation ID.
+ * @param bool   $allowed     Whether the permission change may go ahead.
+ * @param string $download_id Download id.
+ * @param int    $product_id  Product or variation ID.
  *
- * @return void
+ * @return bool
  */
-function dokan_sync_download_permissions_with_product_files( $product_id ) {
-    global $wpdb;
+function dokan_block_held_download_permission_change( $allowed, $download_id, $product_id ) {
+    static $held = [];
 
-    $product = wc_get_product( $product_id );
+    if ( dokan_releasing_staged_downloadable_files() ) {
+        // a release re-evaluates from scratch, and it is the only thing that changes the
+        // answer mid-request, so the cache below cannot go stale behind it
+        $held = [];
 
-    if ( ! $product ) {
-        return;
+        return $allowed;
     }
 
-    $live_ids = array_map( 'strval', array_keys( (array) $product->get_downloads() ) );
-    $table    = "{$wpdb->prefix}woocommerce_downloadable_product_permissions";
-    $rows     = $wpdb->get_results( $wpdb->prepare( "SELECT permission_id, order_id, download_id FROM {$table} WHERE product_id = %d", $product_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    // The permission handler asks once per download id per order; without this the hold
+    // check would repeat a product load, a capability check and a query for each one.
+    // Keyed by status as well as id, since the status is what the answer turns on.
+    $key = $product_id . '|' . get_post_status( $product_id );
 
-    if ( empty( $rows ) ) {
-        return;
+    if ( ! isset( $held[ $key ] ) ) {
+        $held[ $key ] = dokan_downloadable_hold_applies( $product_id );
     }
 
-    $granted = [];
-
-    foreach ( $rows as $row ) {
-        if ( ! in_array( (string) $row->download_id, $live_ids, true ) ) {
-            $wpdb->delete( $table, [ 'permission_id' => $row->permission_id ], [ '%d' ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-            continue;
-        }
-
-        $granted[ $row->order_id ][] = (string) $row->download_id;
-    }
-
-    foreach ( array_unique( wp_list_pluck( $rows, 'order_id' ) ) as $order_id ) {
-        $order = wc_get_order( $order_id );
-
-        if ( ! $order ) {
-            continue;
-        }
-
-        $missing = array_diff( $live_ids, isset( $granted[ $order_id ] ) ? $granted[ $order_id ] : [] );
-
-        foreach ( $missing as $download_id ) {
-            wc_downloadable_file_permission( $download_id, $product_id, $order );
-        }
-    }
+    return $held[ $key ] ? false : $allowed;
 }
+add_filter( 'woocommerce_process_product_file_download_paths_remove_access_to_old_file', 'dokan_block_held_download_permission_change', 10, 3 );
+add_filter( 'woocommerce_process_product_file_download_paths_grant_access_to_new_file', 'dokan_block_held_download_permission_change', 10, 3 );
 
 /**
- * Release staged downloadable files once a product is published.
+ * Release staged downloadable files once a product is approved.
  *
- * Runs late on `save_post` (priority 999) so it is the final word on every publish
- * route — the Dokan admin dashboard, WP quick edit, the WooCommerce product edit
- * screen, REST and WP-CLI. WooCommerce's own meta box save (priority 1) re-writes the
- * previously approved files from the submitted form; this runs afterwards. If the live
- * files were changed directly this request (an admin editing the rows while publishing),
- * those win and permissions are synced to them; otherwise the staged files are applied.
+ * Runs late on `save_post` (priority 999) so it is the final word on every approval route
+ * — the Dokan admin dashboard, WP quick edit, the WooCommerce product edit screen, REST
+ * and WP-CLI. WooCommerce's own meta box save (priority 1) re-writes the previously
+ * approved files from the submitted form; this runs afterwards. If the approving save set
+ * the files itself, that set wins and the staged submission is discarded.
  *
  * @since DOKAN_SINCE
  *
@@ -1533,7 +1461,6 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
         [
             'product_id'   => $post_id,
             'variation_id' => 0,
-            'meta_id'      => $post_id,
         ],
     ];
 
@@ -1542,26 +1469,172 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
             $targets[] = [
                 'product_id'   => $post_id,
                 'variation_id' => (int) $child,
-                'meta_id'      => (int) $child,
             ];
         }
     }
 
     foreach ( $targets as $target ) {
-        $staged = dokan_get_staged_downloadable_files( $target['meta_id'] );
+        $meta_id = $target['variation_id'] ? $target['variation_id'] : $target['product_id'];
+        $staged  = dokan_get_staged_downloadable_files( $meta_id );
 
         if ( null === $staged ) {
             continue;
         }
 
+        if ( 'yes' !== get_post_meta( $meta_id, '_downloadable', true ) ) {
+            // the product no longer serves downloads; the submission is moot
+            delete_post_meta( $meta_id, '_dokan_pending_downloadable_files' );
+
+            continue;
+        }
+
+        $pre_release = get_post_meta( $meta_id, '_downloadable_files', true );
+        dokan_downloadable_files_released_this_request( $meta_id, is_array( $pre_release ) ? $pre_release : [] );
+        dokan_releasing_staged_downloadable_files( true );
+
         // move existing customers over to the newly approved files; the permission
         // handler diffs against the still-live approved files, so it must run first
         do_action( 'dokan_process_file_download', $target['product_id'], $target['variation_id'], $staged );
 
-        update_post_meta( $target['meta_id'], '_downloadable_files', empty( $staged ) ? '' : $staged );
+        if ( empty( $staged ) ) {
+            delete_post_meta( $meta_id, '_downloadable_files' );
+        } else {
+            // slashed to match how WooCommerce writes this meta, since it is unslashed once on the way in
+            update_post_meta( $meta_id, '_downloadable_files', wp_slash( $staged ) );
+        }
+
+        dokan_releasing_staged_downloadable_files( false );
 
         // cleared last so a fatal in a permission hook does not drop the vendor's submission
-        delete_post_meta( $target['meta_id'], '_dokan_pending_downloadable_files' );
+        delete_post_meta( $meta_id, '_dokan_pending_downloadable_files' );
     }
 }
 add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );
+
+/**
+ * Discard staged downloadable files when a product is trashed.
+ *
+ * Trashing a pending product is a plausible "reject" gesture, so an untrashed and later
+ * published product must not silently deliver a replacement submitted before the trash.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $post_id Post ID.
+ *
+ * @return void
+ */
+function dokan_discard_staged_downloadable_files_on_trash( $post_id ) {
+    if ( 'product' !== get_post_type( $post_id ) ) {
+        return;
+    }
+
+    $ids     = [ $post_id ];
+    $product = wc_get_product( $post_id );
+
+    if ( $product && $product->is_type( 'variable' ) ) {
+        $ids = array_merge( $ids, array_map( 'absint', $product->get_children() ) );
+    }
+
+    foreach ( $ids as $id ) {
+        delete_post_meta( $id, '_dokan_pending_downloadable_files' );
+    }
+}
+add_action( 'trashed_post', 'dokan_discard_staged_downloadable_files_on_trash' );
+
+/**
+ * Build the REST `downloads` shape from a staged file set.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array $staged Staged files keyed by download id.
+ *
+ * @return array
+ */
+function dokan_staged_downloads_for_rest( $staged, $as_attachment_ids = false ) {
+    $downloads = [];
+
+    foreach ( (array) $staged as $key => $file ) {
+        $url = isset( $file['file'] ) ? $file['file'] : '';
+
+        $downloads[] = [
+            // the product editor keys rows by attachment id, the REST product schema by download id
+            'id'   => $as_attachment_ids ? (string) attachment_url_to_postid( $url ) : (string) $key,
+            'name' => isset( $file['name'] ) ? $file['name'] : '',
+            'file' => $url,
+        ];
+    }
+
+    return $downloads;
+}
+
+/**
+ * Show a vendor their own pending downloadable files in REST product responses.
+ *
+ * While an update awaits approval the live files are deliberately the approved ones, so
+ * without this the vendor would be handed back files they did not submit and would have
+ * no way to tell that their upload is being held.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param WP_REST_Response $response Response object.
+ * @param WC_Product       $product  Product object.
+ *
+ * @return WP_REST_Response
+ */
+function dokan_rest_show_staged_downloadable_files( $response, $product ) {
+    if ( ! $response instanceof WP_REST_Response || ! $product instanceof WC_Product ) {
+        return $response;
+    }
+
+    $product_id = $product->get_id();
+    $staged     = dokan_get_staged_downloadable_files( $product_id );
+    $data       = $response->get_data();
+
+    $data['dokan_downloads_awaiting_approval'] = null !== $staged;
+
+    if ( null !== $staged && dokan_is_product_author( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product_id ) ) {
+        $data['downloads'] = dokan_staged_downloads_for_rest( $staged );
+    }
+
+    $response->set_data( $data );
+
+    return $response;
+}
+add_filter( 'woocommerce_rest_prepare_product_object', 'dokan_rest_show_staged_downloadable_files', 20, 2 );
+add_filter( 'woocommerce_rest_prepare_product_variation_object', 'dokan_rest_show_staged_downloadable_files', 20, 2 );
+
+/**
+ * Show a vendor their own pending downloadable files in the product editor schema.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array $data       Editor payload.
+ * @param int   $product_id  Product ID.
+ *
+ * @return array
+ */
+function dokan_editor_show_staged_downloadable_files( $data, $product_id = 0 ) {
+    if ( empty( $data['form_items'] ) || ! is_array( $data['form_items'] ) ) {
+        return $data;
+    }
+
+    $product_id = $product_id ? (int) $product_id : (int) ( $data['product_id'] ?? 0 );
+    $staged     = $product_id ? dokan_get_staged_downloadable_files( $product_id ) : null;
+
+    if ( null === $staged || ! dokan_is_product_author( $product_id ) ) {
+        return $data;
+    }
+
+    foreach ( $data['form_items'] as &$item ) {
+        if ( isset( $item['id'] ) && 'downloads' === $item['id'] ) {
+            $item['value'] = dokan_staged_downloads_for_rest( $staged, true );
+        }
+    }
+
+    unset( $item );
+
+    $data['dokan_downloads_awaiting_approval'] = true;
+
+    return $data;
+}
+add_filter( 'dokan_product_editor_args', 'dokan_editor_show_staged_downloadable_files', 10, 2 );

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1309,6 +1309,12 @@ function dokan_downloadable_files_released_this_request( $product_id, $set = nul
  * @return mixed True to swallow the write, otherwise the unchanged short-circuit value.
  */
 function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key, $meta_value = null ) {
+    // `update_post_metadata` is one of the hottest filters in WordPress: this runs on every
+    // post meta write on the site. Both guards below are deliberately the cheapest possible
+    // and ordered accordingly — a string comparison against two keys rejects effectively
+    // every call before anything touches the database. `get_post_type()` returns false for a
+    // non-post id, which fails the second check, so a caller passing something that is not a
+    // post never reaches the logic underneath.
     if ( null !== $check || ! in_array( $meta_key, [ '_downloadable_files', '_downloadable' ], true ) ) {
         return $check;
     }
@@ -1728,90 +1734,6 @@ function dokan_sync_download_permissions_on_crud_save( $product_id, $variation_i
 add_action( 'woocommerce_process_product_file_download_paths', 'dokan_sync_download_permissions_on_crud_save', 10, 3 );
 
 /**
- * Give a vendor's REST product save the same status treatment as the vendor product form.
- *
- * `handle_product_update()` runs the submitted status through `dokan_update_product_post_data`,
- * which is where Dokan Pro downgrades an untrusted vendor's `publish` back to pending review.
- * No REST controller applied that filter, so the same edit made through the new product
- * editor stayed published and skipped review entirely — the approval setting simply did not
- * apply to that editor.
- *
- * Only a vendor saving their own product is affected: somebody who can manage WooCommerce is
- * the reviewer, and their save must not be downgraded.
- *
- * @since DOKAN_SINCE
- *
- * @param WC_Product      $product  Product object about to be saved.
- * @param WP_REST_Request $request  Request object.
- * @param bool            $creating True when the product is being created.
- *
- * @return WC_Product
- */
-function dokan_rest_apply_vendor_product_status( $product, $request, $creating = false ) {
-    if ( ! $product instanceof WC_Product ) {
-        return $product;
-    }
-
-    /**
-     * Filter whether a vendor's REST product save is put through the review status rules.
-     *
-     * @since DOKAN_SINCE
-     *
-     * @param bool       $apply   Whether to apply the vendor status rules.
-     * @param WC_Product $product Product being saved.
-     */
-    if ( ! apply_filters( 'dokan_rest_apply_vendor_product_status', true, $product ) ) {
-        return $product;
-    }
-
-    // Creation is deliberately out of scope here. A new product has no ID yet, and the
-    // `dokan_update_product_post_data` consumers are written against the vendor form, which
-    // only ever fires on a product that already exists — Pro's subscription module calls
-    // `wc_get_product( $data['ID'] )->get_status()` with no guard, so handing it `ID => 0`
-    // is fatal.
-    //
-    // Note that this leaves a separate, pre-existing hole: creating over REST with
-    // `status: publish` publishes immediately without review. That is its own bug and wants
-    // its own fix rather than being folded in here.
-    if ( $creating || ! $product->get_id() ) {
-        return $product;
-    }
-
-    $user_id = dokan_get_current_user_id();
-
-    if ( ! $user_id || user_can( $user_id, 'manage_woocommerce' ) || ! dokan_is_user_seller( $user_id ) ) {
-        return $product;
-    }
-
-    // only the vendor's own product
-    if ( (int) get_post_field( 'post_author', $product->get_id() ) !== $user_id ) {
-        return $product;
-    }
-
-    $status = $product->get_status();
-
-    // `auto-draft` is the quick-create flow, not a submission; leave it alone
-    if ( ! $status || 'auto-draft' === $status ) {
-        return $product;
-    }
-
-    $data = apply_filters(
-        'dokan_update_product_post_data',
-        [
-            'ID'          => $product->get_id(),
-            'post_status' => $status,
-        ]
-    );
-
-    if ( ! empty( $data['post_status'] ) && $data['post_status'] !== $status ) {
-        $product->set_status( $data['post_status'] );
-    }
-
-    return $product;
-}
-add_filter( 'woocommerce_rest_pre_insert_product_object', 'dokan_rest_apply_vendor_product_status', 20, 3 );
-
-/**
  * Discard a product's pending downloadable file submission, variations included.
  *
  * @since DOKAN_SINCE
@@ -1931,10 +1853,19 @@ function dokan_staged_downloads_for_rest( $staged, $as_attachment_ids = false ) 
 
     foreach ( (array) $staged as $key => $file ) {
         $url = isset( $file['file'] ) ? $file['file'] : '';
+        $id  = (string) $key;
+
+        if ( $as_attachment_ids ) {
+            // the product editor keys rows by attachment id, the REST product schema by
+            // download id. `attachment_url_to_postid()` returns 0 for anything that is not a
+            // WP attachment, and downloadable files are often external URLs — every one of
+            // those would collide on id "0", so fall back to the download id, which is unique.
+            $attachment_id = attachment_url_to_postid( $url );
+            $id            = $attachment_id ? (string) $attachment_id : (string) $key;
+        }
 
         $downloads[] = [
-            // the product editor keys rows by attachment id, the REST product schema by download id
-            'id'   => $as_attachment_ids ? (string) attachment_url_to_postid( $url ) : (string) $key,
+            'id'   => $id,
             'name' => isset( $file['name'] ) ? $file['name'] : '',
             'file' => $url,
         ];

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -380,6 +380,9 @@ function dokan_process_product_meta( int $post_id, array $data = [] ) {
         if ( isset( $data['_download_type'] ) ) {
             update_post_meta( $post_id, '_download_type', wc_clean( $data['_download_type'] ) );
         }
+    } else {
+        // the product is no longer downloadable; a staged file set must not apply on approval
+        delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
     }
 
     // Update SKU
@@ -1113,28 +1116,38 @@ add_filter( 'woocommerce_product_review_comment_form_args', 'dokan_vendor_produc
 function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
     global $wpdb;
 
-    if ( 'pending' !== get_post_status( $product_id ) ) {
-        return false;
+    $require_approval = false;
+
+    /**
+     * Filter the product statuses whose downloadable file changes are held back for approval.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string[] $held_statuses Post statuses treated as awaiting review.
+     * @param int      $product_id    Product ID.
+     */
+    $held_statuses = apply_filters( 'dokan_downloadable_files_approval_statuses', [ 'pending' ], $product_id );
+
+    if ( in_array( get_post_status( $product_id ), $held_statuses, true ) ) {
+        $live_files = get_post_meta( $product_id, '_downloadable_files', true );
+        $live_ids   = is_array( $live_files ) ? array_keys( $live_files ) : [];
+        $new_ids    = array_keys( (array) $new_files );
+
+        sort( $live_ids );
+        sort( $new_ids );
+
+        if ( $live_ids !== $new_ids ) {
+            // staging only matters when somebody already holds a download permission for this product
+            $has_permissions = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+                $wpdb->prepare(
+                    "SELECT permission_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d LIMIT 1",
+                    $product_id
+                )
+            );
+
+            $require_approval = ! empty( $has_permissions );
+        }
     }
-
-    $live_files = get_post_meta( $product_id, '_downloadable_files', true );
-    $live_ids   = is_array( $live_files ) ? array_keys( $live_files ) : [];
-    $new_ids    = array_keys( (array) $new_files );
-
-    sort( $live_ids );
-    sort( $new_ids );
-
-    if ( $live_ids === $new_ids ) {
-        return false;
-    }
-
-    // staging only matters when somebody already holds a download permission for this product
-    $has_permissions = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-        $wpdb->prepare(
-            "SELECT permission_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d LIMIT 1",
-            $product_id
-        )
-    );
 
     /**
      * Filter whether a changed downloadable file set is staged until admin approval.
@@ -1145,7 +1158,7 @@ function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
      * @param int   $product_id       Product ID.
      * @param array $new_files        Submitted downloadable files, keyed by download id.
      */
-    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', ! empty( $has_permissions ), $product_id, $new_files );
+    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', $require_approval, $product_id, $new_files );
 }
 
 /**
@@ -1173,11 +1186,13 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
         return;
     }
 
-    delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
-
-    // move existing customers over to the newly approved files
+    // move existing customers over to the newly approved files; the permission
+    // handler diffs against the still-live approved files, so it must run first
     do_action( 'dokan_process_file_download', $post_id, 0, $staged );
 
     update_post_meta( $post_id, '_downloadable_files', empty( $staged ) ? '' : $staged );
+
+    // cleared last so a fatal in a permission hook does not drop the vendor's submission
+    delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
 }
 add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1099,44 +1099,103 @@ function dokan_vendor_product_review_restriction( array $data ): array {
 add_filter( 'woocommerce_product_review_comment_form_args', 'dokan_vendor_product_review_restriction' );
 
 /**
- * Check whether a changed set of downloadable files must be held back for admin approval.
- *
- * While a product edit sits in pending review, customers who already purchased must
- * keep the last approved files. A changed file set is therefore staged in the
- * `_dokan_pending_downloadable_files` meta instead of being written to
- * `_downloadable_files`, and applied when an admin publishes the product.
+ * Get the downloadable files a vendor submitted while the product awaits approval.
  *
  * @since DOKAN_SINCE
  *
- * @param int   $product_id Product ID.
- * @param array $new_files  Submitted downloadable files, keyed by download id.
+ * @param int $product_id Product or variation ID.
  *
- * @return bool
+ * @return array|null Staged files keyed by download id (may be empty when the vendor removed all files), null when nothing is staged.
  */
-function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
-    global $wpdb;
+function dokan_get_staged_downloadable_files( $product_id ) {
+    $staged = get_post_meta( $product_id, '_dokan_pending_downloadable_files', true );
 
-    $require_approval = false;
+    return is_array( $staged ) ? $staged : null;
+}
 
+/**
+ * Get the product statuses in which downloadable file changes reach customers directly.
+ *
+ * Any other status is treated as awaiting review, so a changed file set is staged
+ * until the product reaches one of these statuses.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $product_id Product ID.
+ *
+ * @return string[]
+ */
+function dokan_get_downloadable_files_released_statuses( $product_id = 0 ) {
     /**
-     * Filter the product statuses whose downloadable file changes are held back for approval.
+     * Filter the product statuses in which downloadable file changes are delivered to customers immediately.
      *
      * @since DOKAN_SINCE
      *
-     * @param string[] $held_statuses Post statuses treated as awaiting review.
-     * @param int      $product_id    Product ID.
+     * @param string[] $released_statuses Post statuses that release staged files. Default `publish`.
+     * @param int      $product_id        Product ID.
      */
-    $held_statuses = apply_filters( 'dokan_downloadable_files_approval_statuses', [ 'pending' ], $product_id );
+    return (array) apply_filters( 'dokan_downloadable_files_released_statuses', [ 'publish' ], $product_id );
+}
 
-    if ( in_array( get_post_status( $product_id ), $held_statuses, true ) ) {
+/**
+ * Check whether two downloadable file sets point to different files.
+ *
+ * Compared by file URL rather than download id: the classic vendor form keys files by
+ * `md5( url )` while WooCommerce CRUD saves generate UUID ids, so ids differ between
+ * save paths even when the files are the same.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array $files_a Files keyed by download id, each with a `file` URL.
+ * @param array $files_b Files keyed by download id, each with a `file` URL.
+ *
+ * @return bool
+ */
+function dokan_downloadable_file_sets_differ( $files_a, $files_b ) {
+    $urls = static function ( $files ) {
+        $list = [];
+
+        foreach ( (array) $files as $file ) {
+            if ( is_array( $file ) && ! empty( $file['file'] ) ) {
+                $list[] = trim( (string) $file['file'] );
+            }
+        }
+
+        $list = array_values( array_unique( $list ) );
+        sort( $list );
+
+        return $list;
+    };
+
+    return $urls( $files_a ) !== $urls( $files_b );
+}
+
+/**
+ * Check whether a changed set of downloadable files must be held back for admin approval.
+ *
+ * While a product edit awaits review, customers who already purchased must keep the
+ * last approved files. A changed file set is therefore staged in the
+ * `_dokan_pending_downloadable_files` meta instead of being written to
+ * `_downloadable_files`, and applied when the product is published.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int         $product_id Product or variation ID (the ID download permissions are stored under).
+ * @param array       $new_files  Submitted downloadable files, keyed by download id.
+ * @param string|null $status     Status the product is being saved with. Defaults to the stored status.
+ *
+ * @return bool
+ */
+function dokan_downloadable_files_require_approval( $product_id, $new_files, $status = null ) {
+    global $wpdb;
+
+    $status           = null === $status ? get_post_status( $product_id ) : $status;
+    $require_approval = false;
+
+    if ( $product_id && ! in_array( $status, dokan_get_downloadable_files_released_statuses( $product_id ), true ) ) {
         $live_files = get_post_meta( $product_id, '_downloadable_files', true );
-        $live_ids   = is_array( $live_files ) ? array_keys( $live_files ) : [];
-        $new_ids    = array_keys( (array) $new_files );
 
-        sort( $live_ids );
-        sort( $new_ids );
-
-        if ( $live_ids !== $new_ids ) {
+        if ( dokan_downloadable_file_sets_differ( is_array( $live_files ) ? $live_files : [], $new_files ) ) {
             // staging only matters when somebody already holds a download permission for this product
             $has_permissions = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
                 $wpdb->prepare(
@@ -1154,19 +1213,299 @@ function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
      *
      * @since DOKAN_SINCE
      *
-     * @param bool  $require_approval Whether the new file set should be staged.
-     * @param int   $product_id       Product ID.
-     * @param array $new_files        Submitted downloadable files, keyed by download id.
+     * @param bool   $require_approval Whether the new file set should be staged.
+     * @param int    $product_id       Product or variation ID.
+     * @param array  $new_files        Submitted downloadable files, keyed by download id.
+     * @param string $status           Status the product is being saved with.
      */
-    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', $require_approval, $product_id, $new_files );
+    return (bool) apply_filters( 'dokan_downloadable_files_require_approval', $require_approval, $product_id, $new_files, $status );
 }
 
 /**
- * Apply staged downloadable files once a product gets published.
+ * Convert WC_Product_Download objects to the array format stored in `_downloadable_files`.
  *
- * Runs late on `save_post` so it also wins when an admin approves a pending product
- * from the WooCommerce product edit screen, whose own meta box save (priority 1)
- * re-saves the previously approved files.
+ * @since DOKAN_SINCE
+ *
+ * @param WC_Product_Download[]|array $downloads Download objects.
+ *
+ * @return array Files keyed by download id.
+ */
+function dokan_downloads_to_files_array( $downloads ) {
+    $files = [];
+
+    foreach ( (array) $downloads as $key => $download ) {
+        if ( $download instanceof WC_Product_Download ) {
+            $files[ $download->get_id() ] = [
+                'name' => $download->get_name(),
+                'file' => $download->get_file(),
+            ];
+        } elseif ( is_array( $download ) && ! empty( $download['file'] ) ) {
+            $files[ $key ] = [
+                'name' => isset( $download['name'] ) ? $download['name'] : '',
+                'file' => $download['file'],
+            ];
+        }
+    }
+
+    return $files;
+}
+
+/**
+ * Convert a `_downloadable_files` style array to WC_Product_Download objects.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array $files Files keyed by download id.
+ *
+ * @return WC_Product_Download[]
+ */
+function dokan_files_array_to_downloads( $files ) {
+    $downloads = [];
+
+    foreach ( (array) $files as $key => $file ) {
+        if ( ! is_array( $file ) || empty( $file['file'] ) ) {
+            continue;
+        }
+
+        $download = new WC_Product_Download();
+        $download->set_id( (string) $key );
+        $download->set_name( ! empty( $file['name'] ) ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
+        $download->set_file( $file['file'] );
+        $download->set_enabled( isset( $file['enabled'] ) ? (bool) $file['enabled'] : true );
+
+        $downloads[] = $download;
+    }
+
+    return $downloads;
+}
+
+/**
+ * Track products whose download permissions must be re-synced with their live files.
+ *
+ * When a save both publishes and changes the files, the pre-save hook drops any staged
+ * replacement and flags the product here. Syncing is idempotent (it reconciles
+ * permissions to the current live files), so the post-save hook may run it on every
+ * save of the request without clearing the flag; a `shutdown` pass runs it once more
+ * against the final files and clears the flags. This survives WooCommerce nesting a
+ * second save inside the first, whose early `after` fires before the new files are written.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int|null $product_id Product or variation ID, or null for the `flush` action.
+ * @param string   $action     'flag', 'peek' (default) or 'flush'.
+ *
+ * @return bool
+ */
+function dokan_downloadable_files_permission_sync( $product_id = null, $action = 'peek' ) {
+    static $flags      = [];
+    static $registered = false;
+
+    if ( 'flag' === $action ) {
+        $flags[ $product_id ] = true;
+
+        if ( ! $registered ) {
+            $registered = true;
+            add_action( 'shutdown', 'dokan_flush_downloadable_permission_syncs', 20 );
+        }
+
+        return true;
+    }
+
+    if ( 'flush' === $action ) {
+        foreach ( array_keys( $flags ) as $pid ) {
+            dokan_sync_download_permissions_with_product_files( $pid );
+        }
+
+        $flags = [];
+
+        return true;
+    }
+
+    return ! empty( $flags[ $product_id ] );
+}
+
+/**
+ * Flush pending download-permission syncs at the end of the request.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @return void
+ */
+function dokan_flush_downloadable_permission_syncs() {
+    dokan_downloadable_files_permission_sync( null, 'flush' );
+}
+
+/**
+ * Hold changed downloadable files on WooCommerce CRUD saves while the product awaits approval.
+ *
+ * Covers every path that saves through `WC_Product::save()`: the Dokan REST product
+ * endpoints, the new product editor, `Product\Manager::update()`, the wp-admin product
+ * screen and WP-CLI. For a held (unpublished) status the submitted files are staged and
+ * the approved files are kept on the object, so WooCommerce persists those unchanged.
+ * The actual release happens later, on `save_post`, once every write in the request is done.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param WC_Product $product Product being saved.
+ *
+ * @return void
+ */
+function dokan_hold_downloadable_files_before_product_save( $product ) {
+    if ( ! $product instanceof WC_Product || ! $product->get_id() ) {
+        return;
+    }
+
+    $product_id   = $product->get_id();
+    $is_variation = $product->is_type( 'variation' );
+    $status       = $is_variation ? get_post_status( $product->get_parent_id() ) : $product->get_status();
+
+    if ( ! $product->get_downloadable() ) {
+        // no longer downloadable: a pending replacement must not apply on approval
+        delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
+
+        return;
+    }
+
+    if ( ! array_key_exists( 'downloads', $product->get_changes() ) ) {
+        return;
+    }
+
+    $live_files       = get_post_meta( $product_id, '_downloadable_files', true );
+    $approved         = is_array( $live_files ) ? $live_files : [];
+    $new_files        = dokan_downloads_to_files_array( $product->get_downloads() );
+    $changed          = dokan_downloadable_file_sets_differ( $approved, $new_files );
+    $owner_product_id = $is_variation ? $product->get_parent_id() : $product_id;
+    $released         = in_array( $status, dokan_get_downloadable_files_released_statuses( $product_id ), true );
+
+    if ( $released ) {
+        // publishing while also changing the files: the submitted files win. Drop any
+        // staged replacement and re-sync permissions once the new files are written.
+        if ( $changed && null !== dokan_get_staged_downloadable_files( $product_id ) ) {
+            delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
+            dokan_downloadable_files_permission_sync( $product_id, 'flag' );
+        }
+
+        return;
+    }
+
+    if ( ! $changed ) {
+        // the vendor resubmitting the approved files cancels their pending replacement
+        if ( dokan_is_product_author( $owner_product_id ) ) {
+            delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
+        }
+
+        return;
+    }
+
+    if ( ! dokan_downloadable_files_require_approval( $product_id, $new_files, $status ) ) {
+        return;
+    }
+
+    update_post_meta( $product_id, '_dokan_pending_downloadable_files', $new_files );
+
+    try {
+        // keep the approved files on the object so WooCommerce persists them unchanged
+        $product->set_downloads( dokan_files_array_to_downloads( $approved ) );
+    } catch ( Exception $e ) {
+        // the approved files can no longer be re-set; fall back to the regular save
+        delete_post_meta( $product_id, '_dokan_pending_downloadable_files' );
+    }
+}
+add_action( 'woocommerce_before_product_object_save', 'dokan_hold_downloadable_files_before_product_save' );
+
+/**
+ * Re-sync download permissions after a publish-time file change on a CRUD save.
+ *
+ * When a save both publishes and changes the files, `before` drops the staged
+ * replacement and flags the product; this runs after WooCommerce writes the new
+ * files so existing customers are moved onto them (WooCommerce core no longer
+ * syncs permissions on file changes).
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param WC_Product $product Saved product.
+ *
+ * @return void
+ */
+function dokan_sync_downloadable_permissions_after_product_save( $product ) {
+    if ( ! $product instanceof WC_Product || ! $product->get_id() ) {
+        return;
+    }
+
+    $product_id = $product->get_id();
+
+    if ( ! dokan_downloadable_files_permission_sync( $product_id, 'peek' ) ) {
+        return;
+    }
+
+    dokan_sync_download_permissions_with_product_files( $product_id );
+}
+add_action( 'woocommerce_after_product_object_save', 'dokan_sync_downloadable_permissions_after_product_save', PHP_INT_MAX );
+
+/**
+ * Sync existing download permissions with the files currently live on a product.
+ *
+ * Permissions pointing at files no longer on the product are revoked and files not yet
+ * granted are granted on every order that holds a permission for the product.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $product_id Product or variation ID.
+ *
+ * @return void
+ */
+function dokan_sync_download_permissions_with_product_files( $product_id ) {
+    global $wpdb;
+
+    $product = wc_get_product( $product_id );
+
+    if ( ! $product ) {
+        return;
+    }
+
+    $live_ids = array_map( 'strval', array_keys( (array) $product->get_downloads() ) );
+    $table    = "{$wpdb->prefix}woocommerce_downloadable_product_permissions";
+    $rows     = $wpdb->get_results( $wpdb->prepare( "SELECT permission_id, order_id, download_id FROM {$table} WHERE product_id = %d", $product_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+    if ( empty( $rows ) ) {
+        return;
+    }
+
+    $granted = [];
+
+    foreach ( $rows as $row ) {
+        if ( ! in_array( (string) $row->download_id, $live_ids, true ) ) {
+            $wpdb->delete( $table, [ 'permission_id' => $row->permission_id ], [ '%d' ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+            continue;
+        }
+
+        $granted[ $row->order_id ][] = (string) $row->download_id;
+    }
+
+    foreach ( array_unique( wp_list_pluck( $rows, 'order_id' ) ) as $order_id ) {
+        $order = wc_get_order( $order_id );
+
+        if ( ! $order ) {
+            continue;
+        }
+
+        $missing = array_diff( $live_ids, isset( $granted[ $order_id ] ) ? $granted[ $order_id ] : [] );
+
+        foreach ( $missing as $download_id ) {
+            wc_downloadable_file_permission( $download_id, $product_id, $order );
+        }
+    }
+}
+
+/**
+ * Release staged downloadable files once a product is published.
+ *
+ * Runs late on `save_post` (priority 999) so it is the final word on every publish
+ * route — the Dokan admin dashboard, WP quick edit, the WooCommerce product edit
+ * screen, REST and WP-CLI. WooCommerce's own meta box save (priority 1) re-writes the
+ * previously approved files from the submitted form; this runs afterwards. If the live
+ * files were changed directly this request (an admin editing the rows while publishing),
+ * those win and permissions are synced to them; otherwise the staged files are applied.
  *
  * @since DOKAN_SINCE
  *
@@ -1176,23 +1515,53 @@ function dokan_downloadable_files_require_approval( $product_id, $new_files ) {
  * @return void
  */
 function dokan_apply_staged_downloadable_files( $post_id, $post ) {
-    if ( 'product' !== $post->post_type || 'publish' !== $post->post_status ) {
+    if ( 'product' !== $post->post_type ) {
         return;
     }
 
-    $staged = get_post_meta( $post_id, '_dokan_pending_downloadable_files', true );
-
-    if ( ! is_array( $staged ) ) {
+    if ( ! in_array( $post->post_status, dokan_get_downloadable_files_released_statuses( $post_id ), true ) ) {
         return;
     }
 
-    // move existing customers over to the newly approved files; the permission
-    // handler diffs against the still-live approved files, so it must run first
-    do_action( 'dokan_process_file_download', $post_id, 0, $staged );
+    $product = wc_get_product( $post_id );
 
-    update_post_meta( $post_id, '_downloadable_files', empty( $staged ) ? '' : $staged );
+    if ( ! $product ) {
+        return;
+    }
 
-    // cleared last so a fatal in a permission hook does not drop the vendor's submission
-    delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
+    $targets = [
+        [
+            'product_id'   => $post_id,
+            'variation_id' => 0,
+            'meta_id'      => $post_id,
+        ],
+    ];
+
+    if ( $product->is_type( 'variable' ) ) {
+        foreach ( $product->get_children() as $child ) {
+            $targets[] = [
+                'product_id'   => $post_id,
+                'variation_id' => (int) $child,
+                'meta_id'      => (int) $child,
+            ];
+        }
+    }
+
+    foreach ( $targets as $target ) {
+        $staged = dokan_get_staged_downloadable_files( $target['meta_id'] );
+
+        if ( null === $staged ) {
+            continue;
+        }
+
+        // move existing customers over to the newly approved files; the permission
+        // handler diffs against the still-live approved files, so it must run first
+        do_action( 'dokan_process_file_download', $target['product_id'], $target['variation_id'], $staged );
+
+        update_post_meta( $target['meta_id'], '_downloadable_files', empty( $staged ) ? '' : $staged );
+
+        // cleared last so a fatal in a permission hook does not drop the vendor's submission
+        delete_post_meta( $target['meta_id'], '_dokan_pending_downloadable_files' );
+    }
 }
 add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -371,9 +371,12 @@ function dokan_process_product_meta( int $post_id, array $data = [] ) {
         if ( isset( $data['_download_type'] ) ) {
             update_post_meta( $post_id, '_download_type', wc_clean( $data['_download_type'] ) );
         }
-    } else {
-        // the product is no longer downloadable; a staged replacement must not apply on approval
+    } elseif ( ! dokan_downloadable_hold_applies( $post_id ) ) {
+        // the product is no longer downloadable and the change applies right away, so a
+        // staged replacement must not apply on approval. When the untick is itself held,
+        // the staged files stay put and the release handler resolves both together.
         delete_post_meta( $post_id, '_dokan_pending_downloadable_files' );
+        delete_post_meta( $post_id, '_dokan_pending_downloadable_files_author' );
     }
 
     // Update SKU
@@ -1111,6 +1114,11 @@ function dokan_get_staged_downloadable_files( $product_id ) {
  * Any other status is treated as awaiting review, so a changed file set is staged
  * until the product reaches one of these statuses.
  *
+ * Only `publish` releases. A status a vendor can reach on their own must never be in
+ * this list, or the vendor could release their own submission: `dokan_get_available_post_status()`
+ * withholds `publish` from an untrusted vendor, and Dokan Pro downgrades a submitted
+ * `publish` back to pending, so `publish` is reachable only through a reviewer.
+ *
  * @since DOKAN_SINCE
  *
  * @param int $product_id Product ID.
@@ -1126,7 +1134,32 @@ function dokan_get_downloadable_files_released_statuses( $product_id = 0 ) {
      * @param string[] $released_statuses Post statuses that release staged files.
      * @param int      $product_id        Product ID.
      */
-    return (array) apply_filters( 'dokan_downloadable_files_released_statuses', [ 'publish', 'private' ], $product_id );
+    return (array) apply_filters( 'dokan_downloadable_files_released_statuses', [ 'publish' ], $product_id );
+}
+
+/**
+ * Get the product statuses that discard a pending downloadable file submission.
+ *
+ * Rejecting is the gesture the marketplace actually ships for saying no, so it must drop
+ * the submission: otherwise the next approval would deliver the very file the
+ * administrator turned down.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $product_id Product ID.
+ *
+ * @return string[]
+ */
+function dokan_get_downloadable_files_rejected_statuses( $product_id = 0 ) {
+    /**
+     * Filter the product statuses that discard a pending downloadable file submission.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string[] $rejected_statuses Post statuses that discard staged files.
+     * @param int      $product_id        Product ID.
+     */
+    return (array) apply_filters( 'dokan_downloadable_files_rejected_statuses', [ 'reject', 'trash' ], $product_id );
 }
 
 /**
@@ -1223,10 +1256,11 @@ function dokan_downloadable_hold_applies( $product_id ) {
  *
  * @since DOKAN_SINCE
  *
- * @param int  $product_id Product or variation ID.
- * @param bool $set        True to record a release, null to read.
+ * @param int        $product_id Product or variation ID.
+ * @param array|null $set        The files that were live before the release, to record it;
+ *                               null to read the recorded set back.
  *
- * @return bool
+ * @return array|null The pre-release files when this request performed the release, else null.
  */
 function dokan_downloadable_files_released_this_request( $product_id, $set = null ) {
     static $released = [];
@@ -1275,7 +1309,7 @@ function dokan_downloadable_files_released_this_request( $product_id, $set = nul
  * @return mixed True to swallow the write, otherwise the unchanged short-circuit value.
  */
 function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key, $meta_value = null ) {
-    if ( null !== $check || '_downloadable_files' !== $meta_key ) {
+    if ( null !== $check || ! in_array( $meta_key, [ '_downloadable_files', '_downloadable' ], true ) ) {
         return $check;
     }
 
@@ -1284,13 +1318,17 @@ function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key
     }
 
     if ( dokan_releasing_staged_downloadable_files() ) {
-        // the release step is writing the approved files; never intercept that
+        // the release step is writing the approved values; never intercept that
         return $check;
     }
 
-    // WooCommerce slashes its own writes and `update_post_meta()` unslashes once, so the
-    // real value is the unslashed one; it is re-slashed when stored so it round-trips
-    $new_files = is_array( $meta_value ) ? wp_unslash( $meta_value ) : [];
+    if ( '_downloadable' === $meta_key ) {
+        return dokan_hold_downloadable_flag_meta_write( $check, $object_id, $meta_value );
+    }
+
+    // `update_metadata()` unslashes before firing this filter, so the value here is already
+    // the real one; it is re-slashed on the way into storage so it round-trips unchanged
+    $new_files = is_array( $meta_value ) ? $meta_value : [];
 
     if ( ! dokan_downloadable_hold_applies( $object_id ) ) {
         $staged_here  = dokan_get_staged_downloadable_files( $object_id );
@@ -1314,6 +1352,7 @@ function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key
         // `_downloadable_files` still holds the previous value so the permission handler
         // can move existing customers onto the incoming one
         delete_post_meta( $object_id, '_dokan_pending_downloadable_files' );
+        delete_post_meta( $object_id, '_dokan_pending_downloadable_files_author' );
 
         $variation_id = 'product_variation' === get_post_type( $object_id ) ? $object_id : 0;
         $owner_id     = $variation_id ? wp_get_post_parent_id( $object_id ) : $object_id;
@@ -1336,6 +1375,24 @@ function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key
 
         if ( dokan_is_product_author( $owner_id ) ) {
             delete_post_meta( $object_id, '_dokan_pending_downloadable_files' );
+            delete_post_meta( $object_id, '_dokan_pending_downloadable_files_author' );
+        }
+
+        // The files are the same but their download ids may have been re-keyed: the classic
+        // form keys by `md5( url )` while CRUD saves generate UUIDs or use attachment ids, so
+        // saving the same product through a different path rewrites every id. Download
+        // permissions are keyed by download id, so they have to follow the re-key or the
+        // customer loses access to a file that never actually changed. The hold blocks the
+        // permission handler, and nothing is staged here (the URLs match), so without this
+        // the permission would be orphaned with no later step to repair it.
+        if ( array_keys( (array) $live_files ) !== array_keys( $new_files ) ) {
+            $variation_id = 'product_variation' === get_post_type( $object_id ) ? $object_id : 0;
+
+            // safe while held: the file behind the id is byte-for-byte what the customer
+            // already had, so nothing unreviewed reaches them
+            dokan_releasing_staged_downloadable_files( true );
+            do_action( 'dokan_process_file_download', $owner_id, $variation_id, $new_files );
+            dokan_releasing_staged_downloadable_files( false );
         }
 
         return $check;
@@ -1343,10 +1400,102 @@ function dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key
 
     update_post_meta( $object_id, '_dokan_pending_downloadable_files', wp_slash( $new_files ) );
 
+    // remembered so the admin review panel can say whose files these are: a reviewer
+    // editing the rows on a product that stays pending stages their own set here too
+    update_post_meta( $object_id, '_dokan_pending_downloadable_files_author', dokan_get_current_user_id() );
+
+    dokan_mark_parent_has_staged_downloadables( $object_id );
+
     // swallow the write: the approved files stay live for existing customers
     return true;
 }
 add_filter( 'update_post_metadata', 'dokan_hold_downloadable_files_meta_write', 10, 5 );
+
+/**
+ * Hold the "Downloadable" flag until an admin approves it.
+ *
+ * `WC_Product::has_file()` gates on `is_downloadable()`, so writing `no` drops the product
+ * out of `wc_get_customer_available_downloads()` entirely — a vendor unticking the box on a
+ * pending product would revoke a paying customer's access before any review, which is the
+ * same gap as a file swap and revokes rather than substitutes.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param mixed $check      Short-circuit value; null lets the write continue.
+ * @param int   $object_id  Product or variation ID.
+ * @param mixed $meta_value Value being written.
+ *
+ * @return mixed True to swallow the write, otherwise the unchanged short-circuit value.
+ */
+function dokan_hold_downloadable_flag_meta_write( $check, $object_id, $meta_value ) {
+    if ( ! dokan_downloadable_hold_applies( $object_id ) ) {
+        return $check;
+    }
+
+    $submitted = 'yes' === $meta_value ? 'yes' : 'no';
+    $live      = 'yes' === get_post_meta( $object_id, '_downloadable', true ) ? 'yes' : 'no';
+
+    if ( $submitted === $live ) {
+        // back to what is already live: nothing left awaiting approval
+        delete_post_meta( $object_id, '_dokan_pending_downloadable' );
+
+        return $check;
+    }
+
+    // Note on withdrawing a staged untick: the classic vendor form writes `_downloadable`
+    // on every save, so re-ticking reaches the branch above and cancels the removal. A CRUD
+    // save only writes the meta when the value differs from what is stored — and the stored
+    // value is deliberately still the approved one — so re-ticking there is a no-op that
+    // leaves the removal staged. The vendor still sees the pending state, because the REST
+    // read surfaces the staged flag; the removal simply has to be withdrawn from the
+    // product form, or discarded by the administrator.
+
+    update_post_meta( $object_id, '_dokan_pending_downloadable', $submitted );
+
+    dokan_mark_parent_has_staged_downloadables( $object_id );
+
+    // swallow the write: existing customers keep their downloads until an admin approves
+    return true;
+}
+
+/**
+ * Flag a variable parent so the release handler knows a child has something staged.
+ *
+ * Release runs on the parent's `save_post`; without this marker it would have to load the
+ * product and walk its children on every save just to discover there is nothing to do.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $object_id Product or variation ID.
+ *
+ * @return void
+ */
+function dokan_mark_parent_has_staged_downloadables( $object_id ) {
+    if ( 'product_variation' !== get_post_type( $object_id ) ) {
+        return;
+    }
+
+    $parent_id = wp_get_post_parent_id( $object_id );
+
+    if ( $parent_id ) {
+        update_post_meta( $parent_id, '_dokan_pending_downloadable_children', 'yes' );
+    }
+}
+
+/**
+ * Get the "Downloadable" flag a vendor submitted while the product awaits approval.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $product_id Product or variation ID.
+ *
+ * @return string|null `yes` or `no` when a change is staged, null when nothing is staged.
+ */
+function dokan_get_staged_downloadable_flag( $product_id ) {
+    $staged = get_post_meta( $product_id, '_dokan_pending_downloadable', true );
+
+    return in_array( $staged, [ 'yes', 'no' ], true ) ? $staged : null;
+}
 
 /**
  * Hold the removal of every downloadable file until an admin approves it.
@@ -1363,6 +1512,10 @@ add_filter( 'update_post_metadata', 'dokan_hold_downloadable_files_meta_write', 
  * @return mixed True to swallow the delete, otherwise the unchanged short-circuit value.
  */
 function dokan_hold_downloadable_files_meta_delete( $check, $object_id, $meta_key ) {
+    if ( '_downloadable_files' !== $meta_key ) {
+        return $check;
+    }
+
     return dokan_hold_downloadable_files_meta_write( $check, $object_id, $meta_key, [] );
 }
 add_filter( 'delete_post_metadata', 'dokan_hold_downloadable_files_meta_delete', 10, 3 );
@@ -1451,6 +1604,14 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
         return;
     }
 
+    // cheap early-out before loading the product: almost every product save has nothing
+    // staged, and post meta is already primed with the post
+    $has_own_staging = null !== dokan_get_staged_downloadable_files( $post_id ) || null !== dokan_get_staged_downloadable_flag( $post_id );
+
+    if ( ! $has_own_staging && ! get_post_meta( $post_id, '_dokan_pending_downloadable_children', true ) ) {
+        return;
+    }
+
     $product = wc_get_product( $post_id );
 
     if ( ! $product ) {
@@ -1474,8 +1635,19 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
     }
 
     foreach ( $targets as $target ) {
-        $meta_id = $target['variation_id'] ? $target['variation_id'] : $target['product_id'];
-        $staged  = dokan_get_staged_downloadable_files( $meta_id );
+        $meta_id     = $target['variation_id'] ? $target['variation_id'] : $target['product_id'];
+        $staged      = dokan_get_staged_downloadable_files( $meta_id );
+        $staged_flag = dokan_get_staged_downloadable_flag( $meta_id );
+
+        if ( null !== $staged_flag ) {
+            // applied before the files below, so approving an untick correctly ends with
+            // the product serving no downloads at all
+            dokan_releasing_staged_downloadable_files( true );
+            update_post_meta( $meta_id, '_downloadable', $staged_flag );
+            dokan_releasing_staged_downloadable_files( false );
+
+            delete_post_meta( $meta_id, '_dokan_pending_downloadable' );
+        }
 
         if ( null === $staged ) {
             continue;
@@ -1484,6 +1656,7 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
         if ( 'yes' !== get_post_meta( $meta_id, '_downloadable', true ) ) {
             // the product no longer serves downloads; the submission is moot
             delete_post_meta( $meta_id, '_dokan_pending_downloadable_files' );
+            delete_post_meta( $meta_id, '_dokan_pending_downloadable_files_author' );
 
             continue;
         }
@@ -1507,9 +1680,155 @@ function dokan_apply_staged_downloadable_files( $post_id, $post ) {
 
         // cleared last so a fatal in a permission hook does not drop the vendor's submission
         delete_post_meta( $meta_id, '_dokan_pending_downloadable_files' );
+        delete_post_meta( $meta_id, '_dokan_pending_downloadable_files_author' );
     }
+
+    delete_post_meta( $post_id, '_dokan_pending_downloadable_children' );
 }
 add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );
+
+/**
+ * Keep download permissions aligned when a CRUD save changes a product's files.
+ *
+ * The classic vendor form fires `dokan_process_file_download` itself, so a file change made
+ * there moves existing customers onto the new file. WooCommerce CRUD saves — the REST
+ * endpoints, the new product editor, the wp-admin screen and WP-CLI — fire
+ * `woocommerce_process_product_file_download_paths` instead, and nothing listens to it:
+ * neither WooCommerce core nor Dokan. So a file swap made through any of those paths
+ * rewrote `_downloadable_files` and left every existing permission pointing at a download
+ * id the product no longer offers, and the customer's My Account -> Downloads went empty.
+ *
+ * Forwarding the action to the same handler closes that: permissions follow the files
+ * whichever path wrote them. While a product is held the permission change is blocked by
+ * `dokan_block_held_download_permission_change()` exactly as it is on the classic form, so
+ * this does not weaken the approval gate.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int   $product_id   Product ID.
+ * @param int   $variation_id Variation ID, 0 for a simple product.
+ * @param array $downloads    The files being written, keyed by download id.
+ *
+ * @return void
+ */
+function dokan_sync_download_permissions_on_crud_save( $product_id, $variation_id, $downloads ) {
+    $meta_id = $variation_id ? $variation_id : $product_id;
+
+    // A release earlier in this same request has already moved existing customers onto the
+    // approved files. WooCommerce fires this action afterwards carrying the product object's
+    // own set, which is either an echo the meta filter swallows, or an approver's genuine
+    // edit that the meta filter re-points permissions to itself. Acting here would move the
+    // permission onto a file set that never lands.
+    if ( null !== dokan_downloadable_files_released_this_request( $meta_id ) ) {
+        return;
+    }
+
+    do_action( 'dokan_process_file_download', $product_id, $variation_id, $downloads );
+}
+add_action( 'woocommerce_process_product_file_download_paths', 'dokan_sync_download_permissions_on_crud_save', 10, 3 );
+
+/**
+ * Give a vendor's REST product save the same status treatment as the vendor product form.
+ *
+ * `handle_product_update()` runs the submitted status through `dokan_update_product_post_data`,
+ * which is where Dokan Pro downgrades an untrusted vendor's `publish` back to pending review.
+ * No REST controller applied that filter, so the same edit made through the new product
+ * editor stayed published and skipped review entirely — the approval setting simply did not
+ * apply to that editor.
+ *
+ * Only a vendor saving their own product is affected: somebody who can manage WooCommerce is
+ * the reviewer, and their save must not be downgraded.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param WC_Product      $product  Product object about to be saved.
+ * @param WP_REST_Request $request  Request object.
+ * @param bool            $creating True when the product is being created.
+ *
+ * @return WC_Product
+ */
+function dokan_rest_apply_vendor_product_status( $product, $request, $creating = false ) {
+    if ( ! $product instanceof WC_Product ) {
+        return $product;
+    }
+
+    /**
+     * Filter whether a vendor's REST product save is put through the review status rules.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param bool       $apply   Whether to apply the vendor status rules.
+     * @param WC_Product $product Product being saved.
+     */
+    if ( ! apply_filters( 'dokan_rest_apply_vendor_product_status', true, $product ) ) {
+        return $product;
+    }
+
+    $user_id = dokan_get_current_user_id();
+
+    if ( ! $user_id || user_can( $user_id, 'manage_woocommerce' ) || ! dokan_is_user_seller( $user_id ) ) {
+        return $product;
+    }
+
+    // only the vendor's own product; an existing product keeps its recorded author
+    $author_id = $creating || ! $product->get_id() ? $user_id : (int) get_post_field( 'post_author', $product->get_id() );
+
+    if ( $author_id !== $user_id ) {
+        return $product;
+    }
+
+    $status = $product->get_status();
+
+    // `auto-draft` is the quick-create flow, not a submission; leave it alone
+    if ( ! $status || 'auto-draft' === $status ) {
+        return $product;
+    }
+
+    $data = apply_filters(
+        'dokan_update_product_post_data',
+        [
+            'ID'          => $product->get_id(),
+            'post_status' => $status,
+        ]
+    );
+
+    if ( ! empty( $data['post_status'] ) && $data['post_status'] !== $status ) {
+        $product->set_status( $data['post_status'] );
+    }
+
+    return $product;
+}
+add_filter( 'woocommerce_rest_pre_insert_product_object', 'dokan_rest_apply_vendor_product_status', 20, 3 );
+
+/**
+ * Discard a product's pending downloadable file submission, variations included.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $post_id Product ID.
+ *
+ * @return void
+ */
+function dokan_discard_staged_downloadable_files( $post_id ) {
+    if ( 'product' !== get_post_type( $post_id ) ) {
+        return;
+    }
+
+    $ids     = [ $post_id ];
+    $product = wc_get_product( $post_id );
+
+    if ( $product && $product->is_type( 'variable' ) ) {
+        $ids = array_merge( $ids, array_map( 'absint', $product->get_children() ) );
+    }
+
+    foreach ( $ids as $id ) {
+        delete_post_meta( $id, '_dokan_pending_downloadable_files' );
+        delete_post_meta( $id, '_dokan_pending_downloadable_files_author' );
+        delete_post_meta( $id, '_dokan_pending_downloadable' );
+    }
+
+    delete_post_meta( $post_id, '_dokan_pending_downloadable_children' );
+}
 
 /**
  * Discard staged downloadable files when a product is trashed.
@@ -1524,29 +1843,75 @@ add_action( 'save_post', 'dokan_apply_staged_downloadable_files', 999, 2 );
  * @return void
  */
 function dokan_discard_staged_downloadable_files_on_trash( $post_id ) {
-    if ( 'product' !== get_post_type( $post_id ) ) {
+    dokan_discard_staged_downloadable_files( $post_id );
+}
+add_action( 'trashed_post', 'dokan_discard_staged_downloadable_files_on_trash' );
+
+/**
+ * Discard staged downloadable files when a product is rejected.
+ *
+ * Rejection is the marketplace's explicit "no". Without this the submission would sit
+ * staged and be delivered by the next approval, handing the administrator the exact file
+ * they turned down.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ *
+ * @return void
+ */
+function dokan_discard_staged_downloadable_files_on_rejection( $new_status, $old_status, $post ) {
+    if ( ! $post instanceof WP_Post || 'product' !== $post->post_type || $new_status === $old_status ) {
         return;
     }
 
-    $ids     = [ $post_id ];
-    $product = wc_get_product( $post_id );
-
-    if ( $product && $product->is_type( 'variable' ) ) {
-        $ids = array_merge( $ids, array_map( 'absint', $product->get_children() ) );
+    if ( ! in_array( $new_status, dokan_get_downloadable_files_rejected_statuses( $post->ID ), true ) ) {
+        return;
     }
 
-    foreach ( $ids as $id ) {
-        delete_post_meta( $id, '_dokan_pending_downloadable_files' );
-    }
+    dokan_discard_staged_downloadable_files( $post->ID );
 }
-add_action( 'trashed_post', 'dokan_discard_staged_downloadable_files_on_trash' );
+add_action( 'transition_post_status', 'dokan_discard_staged_downloadable_files_on_rejection', 10, 3 );
+
+/**
+ * Discard a pending submission when an administrator presses "Discard pending files".
+ *
+ * Runs ahead of the release handler so a save that both discards and publishes keeps the
+ * currently approved files rather than delivering the submission.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param int $post_id Post ID.
+ *
+ * @return void
+ */
+function dokan_handle_discard_staged_downloadable_files_request( $post_id ) {
+    if ( empty( $_POST['dokan_discard_pending_downloads'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        return;
+    }
+
+    if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
+        return;
+    }
+
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        return;
+    }
+
+    dokan_discard_staged_downloadable_files( $post_id );
+}
+add_action( 'save_post', 'dokan_handle_discard_staged_downloadable_files_request', 998 );
 
 /**
  * Build the REST `downloads` shape from a staged file set.
  *
  * @since DOKAN_SINCE
  *
- * @param array $staged Staged files keyed by download id.
+ * @param array $staged            Staged files keyed by download id.
+ * @param bool  $as_attachment_ids True to key rows by attachment id (the product editor's
+ *                                 shape) instead of download id (the REST product schema's).
  *
  * @return array
  */
@@ -1590,10 +1955,18 @@ function dokan_rest_show_staged_downloadable_files( $response, $product ) {
     $staged     = dokan_get_staged_downloadable_files( $product_id );
     $data       = $response->get_data();
 
-    $data['dokan_downloads_awaiting_approval'] = null !== $staged;
+    $staged_flag = dokan_get_staged_downloadable_flag( $product_id );
 
-    if ( null !== $staged && dokan_is_product_author( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product_id ) ) {
-        $data['downloads'] = dokan_staged_downloads_for_rest( $staged );
+    $data['dokan_downloads_awaiting_approval'] = null !== $staged || null !== $staged_flag;
+
+    if ( dokan_is_product_author( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product_id ) ) {
+        if ( null !== $staged ) {
+            $data['downloads'] = dokan_staged_downloads_for_rest( $staged );
+        }
+
+        if ( null !== $staged_flag && isset( $data['downloadable'] ) ) {
+            $data['downloadable'] = 'yes' === $staged_flag;
+        }
     }
 
     $response->set_data( $data );
@@ -1602,6 +1975,10 @@ function dokan_rest_show_staged_downloadable_files( $response, $product ) {
 }
 add_filter( 'woocommerce_rest_prepare_product_object', 'dokan_rest_show_staged_downloadable_files', 20, 2 );
 add_filter( 'woocommerce_rest_prepare_product_variation_object', 'dokan_rest_show_staged_downloadable_files', 20, 2 );
+// `dokan/v1` and `dokan/v2` build their own payload and never run WooCommerce's filter, so
+// without this the vendor namespace hands a vendor the approved files while their own
+// submission is held — and the withdraw rule below then reads the echo as a cancellation
+add_filter( 'dokan_rest_prepare_product_object', 'dokan_rest_show_staged_downloadable_files', 20, 2 );
 
 /**
  * Show a vendor their own pending downloadable files in the product editor schema.
@@ -1625,9 +2002,15 @@ function dokan_editor_show_staged_downloadable_files( $data, $product_id = 0 ) {
         return $data;
     }
 
+    $notice = __( 'These files are awaiting admin approval. Customers who already purchased keep the currently approved files until the product is published.', 'dokan-lite' );
+
     foreach ( $data['form_items'] as &$item ) {
         if ( isset( $item['id'] ) && 'downloads' === $item['id'] ) {
             $item['value'] = dokan_staged_downloads_for_rest( $staged, true );
+
+            // the editor renders `description` under the field, so the vendor is told the
+            // hold exists rather than silently shown files that are not live
+            $item['description'] = $notice;
         }
     }
 

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1764,16 +1764,27 @@ function dokan_rest_apply_vendor_product_status( $product, $request, $creating =
         return $product;
     }
 
+    // Creation is deliberately out of scope here. A new product has no ID yet, and the
+    // `dokan_update_product_post_data` consumers are written against the vendor form, which
+    // only ever fires on a product that already exists — Pro's subscription module calls
+    // `wc_get_product( $data['ID'] )->get_status()` with no guard, so handing it `ID => 0`
+    // is fatal.
+    //
+    // Note that this leaves a separate, pre-existing hole: creating over REST with
+    // `status: publish` publishes immediately without review. That is its own bug and wants
+    // its own fix rather than being folded in here.
+    if ( $creating || ! $product->get_id() ) {
+        return $product;
+    }
+
     $user_id = dokan_get_current_user_id();
 
     if ( ! $user_id || user_can( $user_id, 'manage_woocommerce' ) || ! dokan_is_user_seller( $user_id ) ) {
         return $product;
     }
 
-    // only the vendor's own product; an existing product keeps its recorded author
-    $author_id = $creating || ! $product->get_id() ? $user_id : (int) get_post_field( 'post_author', $product->get_id() );
-
-    if ( $author_id !== $user_id ) {
+    // only the vendor's own product
+    if ( (int) get_post_field( 'post_author', $product->get_id() ) !== $user_id ) {
         return $product;
     }
 

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1963,3 +1963,25 @@ function dokan_editor_show_staged_downloadable_files( $data, $product_id = 0 ) {
     return $data;
 }
 add_filter( 'dokan_product_editor_args', 'dokan_editor_show_staged_downloadable_files', 10, 2 );
+
+/**
+ * Show a vendor their own pending downloadable files when the editor loads a product.
+ *
+ * The product editor has two data endpoints and they apply different filters:
+ * `/dokan/v3/products/init/fields` fires `dokan_product_editor_args`, while
+ * `/dokan/v3/products/<id>/fields` — the one used to open an existing product, and so the
+ * only one that matters for a held submission — fires this filter instead. Without it the
+ * vendor is handed the approved files with no sign that their upload is being held, and
+ * saving that back reads as a withdrawal.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param array           $data    Editor payload.
+ * @param WC_Product|null $product Product being edited.
+ *
+ * @return array
+ */
+function dokan_rest_editor_fields_show_staged_downloadable_files( $data, $product = null ) {
+    return dokan_editor_show_staged_downloadable_files( $data, $product instanceof WC_Product ? $product->get_id() : 0 );
+}
+add_filter( 'dokan_rest_prepare_product_editor_fields', 'dokan_rest_editor_fields_show_staged_downloadable_files', 20, 2 );

--- a/templates/products/downloadable.php
+++ b/templates/products/downloadable.php
@@ -43,8 +43,8 @@
                     <tbody>
                         <?php
                         // while an edit awaits admin approval, show the staged files, not the approved ones
-                        $staged_files       = get_post_meta( $post_id, '_dokan_pending_downloadable_files', true );
-                        $downloadable_files = is_array( $staged_files ) ? $staged_files : get_post_meta( $post_id, '_downloadable_files', true );
+                        $staged_files       = dokan_get_staged_downloadable_files( $post_id );
+                        $downloadable_files = null !== $staged_files ? $staged_files : get_post_meta( $post_id, '_downloadable_files', true );
 
                         if ( $downloadable_files ) {
                             foreach ( $downloadable_files as $key => $file ) {
@@ -55,7 +55,7 @@
                     </tbody>
                 </table>
 
-                <?php if ( is_array( $staged_files ) ) : ?>
+                <?php if ( null !== $staged_files ) : ?>
                     <p class="dokan-alert dokan-alert-warning">
                         <?php esc_html_e( 'These files are awaiting admin approval. Customers who already purchased keep the currently approved files until the product is published.', 'dokan-lite' ); ?>
                     </p>

--- a/templates/products/downloadable.php
+++ b/templates/products/downloadable.php
@@ -55,6 +55,12 @@
                     </tbody>
                 </table>
 
+                <?php if ( is_array( $staged_files ) ) : ?>
+                    <p class="dokan-alert dokan-alert-warning">
+                        <?php esc_html_e( 'These files are awaiting admin approval. Customers who already purchased keep the currently approved files until the product is published.', 'dokan-lite' ); ?>
+                    </p>
+                <?php endif; ?>
+
                 <div class="dokan-clearfix">
                     <div class="content-half-part">
                         <label for="_download_limit" class="form-label"><?php esc_html_e( 'Download Limit', 'dokan-lite' ); ?></label>

--- a/templates/products/downloadable.php
+++ b/templates/products/downloadable.php
@@ -42,7 +42,9 @@
                     </thead>
                     <tbody>
                         <?php
-                        $downloadable_files = get_post_meta( $post_id, '_downloadable_files', true );
+                        // while an edit awaits admin approval, show the staged files, not the approved ones
+                        $staged_files       = get_post_meta( $post_id, '_dokan_pending_downloadable_files', true );
+                        $downloadable_files = is_array( $staged_files ) ? $staged_files : get_post_meta( $post_id, '_downloadable_files', true );
 
                         if ( $downloadable_files ) {
                             foreach ( $downloadable_files as $key => $file ) {

--- a/tests/php/src/Product/DownloadableApprovalHoldTest.php
+++ b/tests/php/src/Product/DownloadableApprovalHoldTest.php
@@ -1,0 +1,445 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Product;
+
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as DownloadApprovedDirectories;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WC_Order;
+use WC_Product;
+use WC_Product_Download;
+
+/**
+ * Downloadable files a vendor changes while a product awaits approval must not reach
+ * existing customers until an administrator approves the update (dokan-pro#6045).
+ *
+ * @since DOKAN_SINCE
+ *
+ * @group dokan-product-downloads
+ * @group dokan-downloadable-approval
+ *
+ * @covers ::dokan_hold_downloadable_files_meta_write
+ * @covers ::dokan_apply_staged_downloadable_files
+ * @covers ::dokan_downloadable_hold_applies
+ */
+class DownloadableApprovalHoldTest extends DokanTestCase {
+
+    /**
+     * URL of the approved file customers already hold.
+     *
+     * @var string
+     */
+    protected string $approved_url;
+
+    /**
+     * URL of the replacement file the vendor submits.
+     *
+     * @var string
+     */
+    protected string $replacement_url;
+
+    /**
+     * Approved-directories mode captured in set_up() and restored in tear_down().
+     *
+     * @var string
+     */
+    protected string $previous_download_mode;
+
+    public function set_up() {
+        parent::set_up();
+
+        // Disable the approved-directories gate so the example.com files validate.
+        $approved_directories         = wc_get_container()->get( DownloadApprovedDirectories::class );
+        $this->previous_download_mode = $approved_directories->get_mode();
+        $approved_directories->set_mode( DownloadApprovedDirectories::MODE_DISABLED );
+
+        $this->approved_url    = 'https://example.com/approved-' . uniqid() . '.pdf';
+        $this->replacement_url = 'https://example.com/replacement-' . uniqid() . '.pdf';
+    }
+
+    public function tear_down() {
+        wp_set_current_user( 0 );
+
+        wc_get_container()->get( DownloadApprovedDirectories::class )->set_mode( $this->previous_download_mode );
+
+        parent::tear_down();
+    }
+
+    /**
+     * A vendor's replacement file is held while the product awaits review: the live files
+     * and the customer's permission both stay on the approved file.
+     */
+    public function test_replacement_file_is_held_while_awaiting_review() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ), 'The replacement should be staged.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ), 'Customers must keep the approved file.' );
+        $this->assertSame( [ $this->approved_url ], $this->permission_urls( $product ), 'The download permission must not move.' );
+    }
+
+    /**
+     * Publishing the product delivers the staged file and moves existing customers onto it.
+     */
+    public function test_publishing_releases_the_staged_file_to_existing_customers() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+        $this->set_status( $product, 'publish' );
+
+        $this->assertNull( $this->staged( $product ), 'Staging should be cleared on release.' );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ), 'The approved replacement should be live.' );
+        $this->assertSame( [ $this->replacement_url ], $this->permission_urls( $product ), 'Existing customers should be moved onto it.' );
+    }
+
+    /**
+     * `private` is an administrator decision too, so it releases the submission.
+     */
+    public function test_private_status_also_releases_the_staged_file() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+        $this->set_status( $product, 'private' );
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * Draft is not an approval, so a change saved as draft is held just like pending.
+     */
+    public function test_draft_status_is_held_too() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'draft' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ) );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+        $this->assertSame( [ $this->approved_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * Removing every file is held as well, and the removal applies on approval.
+     */
+    public function test_removing_every_file_is_held_then_applied_on_approval() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [] );
+
+        $this->assertSame( [], $this->staged( $product ), 'An empty submission is still a submission.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ), 'Customers keep their file until approval.' );
+
+        $this->set_status( $product, 'publish' );
+
+        $this->assertSame( [], $this->live_urls( $product ) );
+        $this->assertSame( [], $this->permission_urls( $product ), 'Approval applies the removal.' );
+    }
+
+    /**
+     * Editing the product again while it waits replaces the pending submission rather
+     * than stacking a second one.
+     */
+    public function test_a_second_edit_replaces_the_pending_submission() {
+        $product = $this->create_sold_downloadable_product();
+        $third   = 'https://example.com/third-' . uniqid() . '.pdf';
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+        $this->submit_files( $product, [ $third ] );
+
+        $this->assertSame( [ $third ], $this->staged_urls( $product ) );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+    }
+
+    /**
+     * Putting the approved files back withdraws the pending submission.
+     */
+    public function test_resubmitting_the_approved_files_withdraws_the_submission() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        // only the vendor withdraws their own submission; anyone else saving the product
+        // is re-submitting the rendered approved set and must not discard it
+        wp_set_current_user( $this->seller_id1 );
+        $this->submit_files( $product, [ $this->approved_url ] );
+        wp_set_current_user( 0 );
+
+        $this->assertNull( $this->staged( $product ), 'Nothing is pending once the approved files are back.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+    }
+
+    /**
+     * An administrator opening a pending product to review it, and saving without
+     * publishing, must not destroy the vendor's submission.
+     */
+    public function test_an_admin_saving_without_publishing_keeps_the_submission() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        // the wp-admin meta box re-submits the rendered rows, which show the approved set
+        wp_set_current_user( $this->admin_id );
+        $this->submit_files( $product, [ $this->approved_url ] );
+        wp_set_current_user( 0 );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ), 'The submission must survive an admin review save.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+    }
+
+    /**
+     * Nobody has bought the product yet, so there is no one to protect and the change
+     * goes live immediately.
+     */
+    public function test_a_product_without_buyers_is_not_held() {
+        $product = $this->create_downloadable_product( $this->seller_id1 );
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+    }
+
+    /**
+     * A vendor allowed to publish directly has no review step, so nothing is held.
+     */
+    public function test_a_trusted_vendor_is_not_held() {
+        update_user_meta( $this->seller_id1, 'dokan_publishing', 'yes' );
+
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'draft' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+
+        delete_user_meta( $this->seller_id1, 'dokan_publishing' );
+    }
+
+    /**
+     * A shop manager is the reviewer, not the reviewed, so their own product is not held.
+     */
+    public function test_a_shop_managers_own_product_is_not_held() {
+        $product = $this->create_sold_downloadable_product( $this->admin_id );
+
+        $this->set_status( $product, 'draft' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+    }
+
+    /**
+     * Approving through the REST/CRUD path — read the product, flip the status, save the
+     * files it handed back — must deliver the staged submission rather than orphaning the
+     * customer's permission.
+     */
+    public function test_approving_through_a_crud_save_delivers_the_staged_file() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_status( 'publish' );
+        $saving->set_downloads( $this->downloads_for( [ $this->approved_url ] ) );
+        $saving->save();
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+        $this->assertSame( [ $this->replacement_url ], $this->permission_urls( $product ), 'The permission must match the live file.' );
+    }
+
+    /**
+     * An administrator who actually edits the files while approving overrides the
+     * vendor's submission, and existing customers follow the administrator's file.
+     */
+    public function test_an_admin_editing_the_files_while_approving_wins() {
+        $product   = $this->create_sold_downloadable_product();
+        $admin_url = 'https://example.com/admin-' . uniqid() . '.pdf';
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_status( 'publish' );
+        $saving->set_downloads( $this->downloads_for( [ $admin_url ] ) );
+        $saving->save();
+
+        $this->assertNull( $this->staged( $product ) );
+        $this->assertSame( [ $admin_url ], $this->live_urls( $product ) );
+        $this->assertSame( [ $admin_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * Trashing a pending product discards the submission, so untrashing and publishing
+     * later does not silently deliver it.
+     */
+    public function test_trashing_discards_the_pending_submission() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        wp_trash_post( $product->get_id() );
+
+        $this->assertNull( $this->staged( $product ) );
+
+        wp_untrash_post( $product->get_id() );
+        $this->set_status( $product, 'publish' );
+
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+    }
+
+    /* ---------------------------------------------------------------------- helpers */
+
+    /**
+     * Create a downloadable product owned by a seller, holding the approved file.
+     */
+    protected function create_downloadable_product( int $author ): WC_Product {
+        $product = $this->factory()->product->create_downloadable_product( $this->downloads_for( [ $this->approved_url ] ) );
+
+        wp_update_post(
+            [
+                'ID'          => $product->get_id(),
+                'post_author' => $author,
+            ]
+        );
+
+        return wc_get_product( $product->get_id() );
+    }
+
+    /**
+     * Create a downloadable product a customer has already purchased and can download.
+     */
+    protected function create_sold_downloadable_product( ?int $author = null ): WC_Product {
+        $product = $this->create_downloadable_product( $author ?? $this->seller_id1 );
+
+        $order = new WC_Order();
+        $order->set_customer_id( $this->customer_id );
+        $order->add_product( $product, 1 );
+        $order->calculate_totals();
+        $order->set_status( 'completed' );
+        $order->save();
+
+        return $product;
+    }
+
+    /**
+     * Build WC_Product_Download objects for a list of file URLs.
+     *
+     * @return WC_Product_Download[]
+     */
+    protected function downloads_for( array $urls ): array {
+        $downloads = [];
+
+        foreach ( $urls as $url ) {
+            $download = new WC_Product_Download();
+            $download->set_id( md5( $url ) );
+            $download->set_name( basename( $url ) );
+            $download->set_file( $url );
+
+            $downloads[] = $download;
+        }
+
+        return $downloads;
+    }
+
+    /**
+     * Save a vendor's submitted file set the way the product editor does.
+     */
+    protected function submit_files( WC_Product $product, array $urls ): void {
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_downloads( $this->downloads_for( $urls ) );
+        $saving->save();
+    }
+
+    /**
+     * Move the product to a status without touching its files.
+     */
+    protected function set_status( WC_Product $product, string $status ): void {
+        wp_update_post(
+            [
+                'ID'          => $product->get_id(),
+                'post_status' => $status,
+            ]
+        );
+    }
+
+    /**
+     * Staged submission, or null when nothing is pending.
+     */
+    protected function staged( WC_Product $product ): ?array {
+        return dokan_get_staged_downloadable_files( $product->get_id() );
+    }
+
+    /**
+     * File URLs of the staged submission.
+     */
+    protected function staged_urls( WC_Product $product ): array {
+        return $this->urls_of( (array) $this->staged( $product ) );
+    }
+
+    /**
+     * File URLs currently live on the product.
+     */
+    protected function live_urls( WC_Product $product ): array {
+        $live = get_post_meta( $product->get_id(), '_downloadable_files', true );
+
+        return $this->urls_of( is_array( $live ) ? $live : [] );
+    }
+
+    /**
+     * File URLs the customer's download permissions currently point at.
+     */
+    protected function permission_urls( WC_Product $product ): array {
+        global $wpdb;
+
+        $ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+            $wpdb->prepare(
+                "SELECT DISTINCT download_id FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d",
+                $product->get_id()
+            )
+        );
+
+        $live = get_post_meta( $product->get_id(), '_downloadable_files', true );
+        $live = is_array( $live ) ? $live : [];
+        $urls = [];
+
+        foreach ( $ids as $id ) {
+            // an id that is no longer on the product means an orphaned permission
+            $urls[] = isset( $live[ $id ] ) ? $live[ $id ]['file'] : 'orphaned:' . $id;
+        }
+
+        sort( $urls );
+
+        return $urls;
+    }
+
+    /**
+     * Sorted file URLs of a `_downloadable_files` style array.
+     */
+    protected function urls_of( array $files ): array {
+        $urls = [];
+
+        foreach ( $files as $file ) {
+            if ( is_array( $file ) && ! empty( $file['file'] ) ) {
+                $urls[] = $file['file'];
+            }
+        }
+
+        sort( $urls );
+
+        return $urls;
+    }
+}

--- a/tests/php/src/Product/DownloadableApprovalHoldTest.php
+++ b/tests/php/src/Product/DownloadableApprovalHoldTest.php
@@ -95,21 +95,6 @@ class DownloadableApprovalHoldTest extends DokanTestCase {
     }
 
     /**
-     * `private` is an administrator decision too, so it releases the submission.
-     */
-    public function test_private_status_also_releases_the_staged_file() {
-        $product = $this->create_sold_downloadable_product();
-
-        $this->set_status( $product, 'pending' );
-        $this->submit_files( $product, [ $this->replacement_url ] );
-        $this->set_status( $product, 'private' );
-
-        $this->assertNull( $this->staged( $product ) );
-        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
-        $this->assertSame( [ $this->replacement_url ], $this->permission_urls( $product ) );
-    }
-
-    /**
      * Draft is not an approval, so a change saved as draft is held just like pending.
      */
     public function test_draft_status_is_held_too() {
@@ -301,6 +286,300 @@ class DownloadableApprovalHoldTest extends DokanTestCase {
         $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
     }
 
+    /**
+     * `private` is not an approval a vendor can grant themselves, so it holds like any
+     * other non-published status (dokan-pro#6045 was reachable through it).
+     */
+    public function test_private_status_is_held_not_released() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'private' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ) );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+        $this->assertSame( [ $this->approved_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * A vendor cannot post a status the dashboard never offered them, so they cannot put
+     * their own product into a state that releases their submission.
+     */
+    public function test_a_vendor_cannot_submit_a_status_they_were_not_offered() {
+        $product = $this->create_sold_downloadable_product();
+        $this->set_status( $product, 'pending' );
+
+        wp_set_current_user( $this->seller_id1 );
+
+        $offered = array_keys( (array) dokan_get_available_post_status( $product->get_id() ) );
+
+        $this->assertNotContains( 'private', $offered, 'The dashboard must never offer `private`.' );
+        $this->assertNotContains( 'private', dokan_get_downloadable_files_released_statuses( $product->get_id() ), 'A vendor-reachable status must not release files.' );
+
+        wp_set_current_user( 0 );
+    }
+
+    /**
+     * Rejecting a product discards the submission, so the next approval cannot deliver the
+     * very file the administrator turned down.
+     */
+    public function test_rejecting_discards_the_pending_submission() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ) );
+
+        $this->set_status( $product, 'reject' );
+
+        $this->assertNull( $this->staged( $product ), 'A rejection must drop the submission.' );
+
+        $this->set_status( $product, 'publish' );
+
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ), 'A rejected file must never be delivered.' );
+        $this->assertSame( [ $this->approved_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * Unticking "Downloadable" is held too: it revokes access rather than substituting it,
+     * so an existing customer keeps their download until an admin approves the removal.
+     */
+    public function test_unticking_downloadable_is_held_then_applied_on_approval() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_downloadable( false );
+        $saving->save();
+
+        $this->assertSame( 'yes', get_post_meta( $product->get_id(), '_downloadable', true ), 'The flag must stay live while held.' );
+        $this->assertSame( 'no', dokan_get_staged_downloadable_flag( $product->get_id() ), 'The untick must be staged.' );
+        $this->assertCount( 1, wc_get_customer_available_downloads( $this->customer_id ), 'The customer keeps their download.' );
+
+        $this->set_status( $product, 'publish' );
+
+        $this->assertSame( 'no', get_post_meta( $product->get_id(), '_downloadable', true ), 'Approval applies the removal.' );
+        $this->assertNull( dokan_get_staged_downloadable_flag( $product->get_id() ) );
+        $this->assertCount( 0, wc_get_customer_available_downloads( $this->customer_id ) );
+    }
+
+    /**
+     * Re-ticking "Downloadable" while the product waits withdraws the pending removal.
+     */
+    public function test_reticking_downloadable_withdraws_the_pending_removal() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_downloadable( false );
+        $saving->save();
+
+        $this->assertSame( 'no', dokan_get_staged_downloadable_flag( $product->get_id() ) );
+
+        // the vendor re-ticks the box on the product form and saves
+        $this->submit_classic_form( $product, [ $this->approved_url ], true );
+
+        $this->assertNull( dokan_get_staged_downloadable_flag( $product->get_id() ) );
+        $this->assertSame( 'yes', get_post_meta( $product->get_id(), '_downloadable', true ) );
+    }
+
+    /**
+     * The vendor namespace must hand a vendor their own held submission, otherwise saving
+     * back what it showed them silently destroys their upload.
+     */
+    public function test_the_vendor_rest_namespace_shows_the_staged_files() {
+        $product = $this->create_sold_downloadable_product();
+        $id      = $product->get_id();
+
+        $this->set_status( $product, 'pending' );
+        wp_set_current_user( $this->seller_id1 );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        $response = rest_do_request( new \WP_REST_Request( 'GET', '/dokan/v1/products/' . $id ) );
+        $data     = $response->get_data();
+
+        $this->assertSame( 200, $response->get_status() );
+        $this->assertTrue( $data['dokan_downloads_awaiting_approval'], 'The vendor must be told the files are held.' );
+        $this->assertSame( [ $this->replacement_url ], wp_list_pluck( $data['downloads'], 'file' ), 'The vendor must be shown what they submitted.' );
+
+        // saving back exactly what the API handed them must not read as a withdrawal
+        $request = new \WP_REST_Request( 'PUT', '/dokan/v1/products/' . $id );
+        $request->set_body_params( [ 'downloads' => $data['downloads'] ] );
+        rest_do_request( $request );
+
+        $this->assertSame( [ $this->replacement_url ], $this->staged_urls( $product ), 'The submission must survive the round trip.' );
+
+        wp_set_current_user( 0 );
+    }
+
+    /**
+     * An administrator pressing "Discard pending files" drops the submission and leaves the
+     * approved files with existing customers.
+     */
+    public function test_discarding_drops_the_submission_and_keeps_the_approved_files() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+
+        wp_set_current_user( $this->admin_id );
+        $_POST['dokan_discard_pending_downloads'] = '1';
+        $_POST['woocommerce_meta_nonce']          = wp_create_nonce( 'woocommerce_save_data' );
+
+        $this->set_status( $product, 'publish' );
+
+        unset( $_POST['dokan_discard_pending_downloads'], $_POST['woocommerce_meta_nonce'] );
+        wp_set_current_user( 0 );
+
+        $this->assertNull( $this->staged( $product ), 'The submission must be discarded.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ), 'The approved files must stay live.' );
+        $this->assertSame( [ $this->approved_url ], $this->permission_urls( $product ) );
+    }
+
+    /**
+     * The staging records who wrote it, so the admin review panel does not attribute a
+     * reviewer's own edit to the vendor.
+     */
+    public function test_staging_records_who_submitted_it() {
+        $product = $this->create_sold_downloadable_product();
+
+        $this->set_status( $product, 'pending' );
+
+        wp_set_current_user( $this->seller_id1 );
+        $this->submit_files( $product, [ $this->replacement_url ] );
+        wp_set_current_user( 0 );
+
+        $this->assertSame(
+            $this->seller_id1,
+            (int) get_post_meta( $product->get_id(), '_dokan_pending_downloadable_files_author', true )
+        );
+    }
+
+    /**
+     * A variation's files are held by its parent's status and released when the parent is
+     * published, so a variable product gets the same protection as a simple one.
+     */
+    public function test_a_variation_is_held_by_its_parent_and_released_with_it() {
+        $parent = new \WC_Product_Variable();
+        $parent->set_name( 'Variable downloadable' );
+        $parent->set_status( 'publish' );
+        $parent->save();
+
+        wp_update_post(
+            [
+                'ID'          => $parent->get_id(),
+                'post_author' => $this->seller_id1,
+            ]
+        );
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id( $parent->get_id() );
+        $variation->set_regular_price( '10' );
+        $variation->set_downloadable( true );
+        $variation->set_downloads( $this->downloads_for( [ $this->approved_url ] ) );
+        $variation->save();
+
+        $order = new WC_Order();
+        $order->set_customer_id( $this->customer_id );
+        $order->add_product( wc_get_product( $variation->get_id() ), 1 );
+        $order->calculate_totals();
+        $order->set_status( 'completed' );
+        $order->save();
+
+        wp_update_post(
+            [
+                'ID'          => $parent->get_id(),
+                'post_status' => 'pending',
+            ]
+        );
+
+        $saving = wc_get_product( $variation->get_id() );
+        $saving->set_downloads( $this->downloads_for( [ $this->replacement_url ] ) );
+        $saving->save();
+
+        $this->assertSame( [ $this->replacement_url ], $this->urls_of( (array) dokan_get_staged_downloadable_files( $variation->get_id() ) ) );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( wc_get_product( $variation->get_id() ) ), 'The customer keeps the approved file.' );
+        $this->assertSame( 'yes', get_post_meta( $parent->get_id(), '_dokan_pending_downloadable_children', true ), 'The parent must know a child is staged.' );
+
+        wp_update_post(
+            [
+                'ID'          => $parent->get_id(),
+                'post_status' => 'publish',
+            ]
+        );
+
+        $this->assertNull( dokan_get_staged_downloadable_files( $variation->get_id() ) );
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( wc_get_product( $variation->get_id() ) ) );
+        $this->assertSame(
+            [ $this->replacement_url ],
+            array_map( static fn( $download ) => $download['file']['file'], wc_get_customer_available_downloads( $this->customer_id ) ),
+            'The customer follows the approved replacement.'
+        );
+    }
+
+    /**
+     * Saving the same files through a different path re-keys their download ids (the classic
+     * form uses md5(url), CRUD saves use UUIDs or attachment ids). Permissions are keyed by
+     * download id, so they must follow the re-key even while the product is held — otherwise
+     * the customer loses access to a file that never changed.
+     */
+    public function test_a_download_id_rekey_keeps_the_customer_permission_aligned() {
+        $product = $this->create_sold_downloadable_product();
+        $id      = $product->get_id();
+
+        $this->set_status( $product, 'pending' );
+
+        // same file, different id — exactly what a CRUD save followed by a classic-form save does
+        $rekeyed = new WC_Product_Download();
+        $rekeyed->set_id( 'attachment-9999' );
+        $rekeyed->set_name( basename( $this->approved_url ) );
+        $rekeyed->set_file( $this->approved_url );
+
+        $saving = wc_get_product( $id );
+        $saving->set_downloads( [ $rekeyed ] );
+        $saving->save();
+
+        $this->assertNull( $this->staged( $product ), 'An id-only change is not a submission.' );
+        $this->assertSame( [ $this->approved_url ], $this->live_urls( $product ) );
+        $this->assertSame(
+            [ $this->approved_url ],
+            $this->permission_urls( $product ),
+            'The permission must follow the re-key rather than being orphaned.'
+        );
+        $this->assertCount( 1, wc_get_customer_available_downloads( $this->customer_id ), 'The customer keeps their download.' );
+    }
+
+    /**
+     * A CRUD/REST file change must move existing customers onto the new file, exactly as the
+     * classic vendor form does. WooCommerce fires its own action for these saves and nothing
+     * listened to it, so the permission was left pointing at a download id the product no
+     * longer offered and the customer's Downloads page went empty.
+     */
+    public function test_a_crud_file_change_keeps_the_customer_permission_aligned() {
+        $product = $this->create_sold_downloadable_product();
+
+        // published and trusted: no hold, so the change applies immediately and the
+        // permission has to follow it
+        update_user_meta( $this->seller_id1, 'dokan_publishing', 'yes' );
+
+        $saving = wc_get_product( $product->get_id() );
+        $saving->set_downloads( $this->downloads_for( [ $this->replacement_url ] ) );
+        $saving->save();
+
+        delete_user_meta( $this->seller_id1, 'dokan_publishing' );
+
+        $this->assertSame( [ $this->replacement_url ], $this->live_urls( $product ) );
+        $this->assertSame(
+            [ $this->replacement_url ],
+            $this->permission_urls( $product ),
+            'The permission must follow a CRUD file change, not be orphaned.'
+        );
+        $this->assertCount( 1, wc_get_customer_available_downloads( $this->customer_id ), 'The customer must keep a working download.' );
+    }
+
     /* ---------------------------------------------------------------------- helpers */
 
     /**
@@ -362,6 +641,29 @@ class DownloadableApprovalHoldTest extends DokanTestCase {
         $saving = wc_get_product( $product->get_id() );
         $saving->set_downloads( $this->downloads_for( $urls ) );
         $saving->save();
+    }
+
+    /**
+     * Save the product the way the classic vendor product form does.
+     */
+    protected function submit_classic_form( WC_Product $product, array $urls, bool $downloadable = true ): void {
+        $data = [
+            '_visibility'    => 'visible',
+            '_stock_status'  => 'instock',
+            'product_type'   => 'simple',
+            '_regular_price' => '10',
+            '_sku'           => '',
+        ];
+
+        if ( $downloadable ) {
+            $data['_downloadable']    = 'on';
+            $data['_download_limit']  = '';
+            $data['_download_expiry'] = '';
+            $data['_wc_file_urls']    = $urls;
+            $data['_wc_file_names']   = array_map( 'basename', $urls );
+        }
+
+        dokan_process_product_meta( $product->get_id(), $data );
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

On a marketplace where vendor products require admin approval, a vendor could replace the file of an already-approved digital product and the new, unreviewed file reached **existing paying customers immediately** at save time. Customers simultaneously lost access to the approved file they paid for, and their download count and access date were reset.

This PR holds file delivery until approval, and makes the approval an actual review rather than a delay.

**The hold** — `dokan_hold_downloadable_files_meta_write()` filters the `_downloadable_files` meta write itself. Every save path writes that meta, so one seam covers the classic vendor form, `dokan/v1`, `dokan/v2`, `dokan/v3`, `wc/v3`, the new product editor, the wp-admin screen, WP-CLI and variations. While a product is awaiting review the submitted set is stored in `_dokan_pending_downloadable_files` and the live value is left untouched. The permission handler is blocked for the same period, so existing customers keep both their file and their download count.

The hold applies only where a review actually exists: the product is not published, the vendor's saves are genuinely subject to approval (not a trusted vendor, not someone who can manage WooCommerce), and at least one customer already holds a download permission.

**Unticking "Downloadable" is held too.** `WC_Product::has_file()` gates on `is_downloadable()`, so writing `no` dropped the product out of `wc_get_customer_available_downloads()` entirely — one click, no gate, and it revoked access rather than substituting it. The flag is now staged alongside the files and applied together on approval.

**Release** — `dokan_apply_staged_downloadable_files()` runs on `save_post` at priority 999. Publishing through any route swaps the permissions and applies the staged set. If the approving save set the files itself, the approver's set wins.

**Reject** — Pro's `reject` status and trashing both discard the submission, so a later approval cannot deliver a file the administrator turned down. An administrator can also reject the files while keeping the product, via a **Discard pending files** button on the product screen.

**Review surface** — the wp-admin product screen shows the pending files with an `admin_notices` warning, listing the real filename first (the vendor's display label is a free-text field the media picker never rewrites, so after a swap it still reads as the previous file). The staging records who submitted it, so a reviewer's own edit is not attributed to the vendor.

**Vendor surface** — the classic form and the REST/product-editor payloads all show the vendor their own held submission plus an "awaiting approval" notice, so the "resubmitting the approved files withdraws the submission" rule is true on every path.

#### Download permissions

Three permission bugs surfaced while testing this end to end. Each is called out with its origin:

* **Introduced by this PR, now fixed.** Saving a held product through a different path re-keys its download ids (`md5( url )` on the classic form, UUIDs or attachment ids on CRUD) with the file unchanged. The hold blocked the permission update and nothing was staged because the URLs matched, so the permission orphaned with no later step to repair it. Permissions now follow a re-key.
* **Pre-existing.** A CRUD/REST file change never updated download permissions at all. WooCommerce fires `woocommerce_process_product_file_download_paths` and nothing listened — not WooCommerce core, not Dokan — so any swap through REST, the new editor, wp-admin or WP-CLI left the customer's My Account → Downloads empty. Verified A/B against `develop`: 1 → 0 downloads there, 1 → 1 with this change.
> **A third, related bug is fixed separately.** A vendor's REST save skipped review entirely — `dokan_update_product_post_data` is where Pro downgrades an untrusted vendor's `publish` to pending, and no REST controller applied it, so the approval setting did not exist for the new product editor. That was originally part of this PR; on review it was split out, because its blast radius is every product saved through the new editor rather than downloadable files. It now lives on `fix/vendor-product-status-on-rest-save`.
>
> **This matters for testing this PR:** without that change, a store running the new product editor never reaches Pending Review on an edit, so the hold here never engages. Test scenario 2 below needs both branches, or the legacy editor.

#### Known follow-ups (deliberately not in this PR)

* Creating a product over REST with `status: publish` publishes without review — verified (HTTP 201, status `publish`). Pre-existing and unrelated to file delivery.
* On the new product editor a staged untick of "Downloadable" cannot be withdrawn by re-ticking, because CRUD only writes the meta when it differs from the stored value. Withdraw from the classic form, or have an administrator discard it.
* The hold requires an existing row in `wp_woocommerce_downloadable_product_permissions`. An order that is paid but not yet granted its permission — processing on a grant-on-completion setup, or an order in flight during the swap — has no row yet, so a file change goes live and that customer later receives the unreviewed file. Narrow, but real.
* Option B from getdokan/dokan-pro#6045 — staging the whole pending edit, not just files.
* The documentation gap from getdokan/dokan-pro#6045 — two published pages still describe the removed "Edited Product Status" setting.
* Lite-only: `handle_product_update()` now validates the submitted status against `dokan_get_available_post_status()`, which closes vendor self-approval on Lite as well.

### Closes

* Closes getdokan/dokan-pro#6045

### How to test the changes in this Pull Request:

Setup: Dokan → Settings → Selling Options → **Product Status** = *Pending Review*, and an **untrusted** vendor (one without publish-directly). The hold only engages when a customer already owns the product, so every scenario needs a completed purchase first.

**1. Classic vendor form — the core case**
1. As the vendor, publish a downloadable product with file A; approve it as admin.
2. As a customer, buy it, complete the order, download file A once.
3. As the vendor, replace file A with file B and save. The product returns to Pending Review.
4. **Customer → My Account → Downloads still offers file A**, with the original download count. The row in `wp_woocommerce_downloadable_product_permissions` is untouched.
5. As admin, open the product: a warning notice appears and **General → Downloadable files** lists the pending file B underneath the approved rows.
6. Publish. The customer now gets file B and the permission has moved with it.

**2. New product editor / REST** — Dokan → Settings → Appearance → **Vendor Product Editor** = *New UI*. Requires `fix/vendor-product-status-on-rest-save` as well, otherwise the product never drops to Pending Review and there is nothing to hold. With both: repeat steps 3–6. The vendor must be shown their own pending file with an "awaiting approval" notice, and the customer must keep file A.

**3. Approving over REST** — `GET` the product, flip `status` to `publish`, `PUT` the payload back unchanged. The customer must end up on file B with a working download, not an empty Downloads page.

**4. Admin edits while approving** — with file B staged, set file C on the wp-admin screen and publish. C wins, and existing customers follow C.

**5. Admin saves without publishing** — with file B staged, save the pending product without publishing. B must survive.

**6. Reject** — with file B staged, reject the product. The submission is discarded; approving later delivers file A, never B. Trashing behaves the same.

**7. Discard button** — with file B staged, press **Discard pending files**. The submission is dropped and customers keep file A.

**8. Unticking Downloadable** — with the product pending, untick **Downloadable** and save. The customer must keep their download until an admin publishes; on publish, access is correctly revoked.

**9. Variations** — stage a file on a variation of a variable product. It is held by the parent's status and released when the parent is published.

**10. Regression checks** — trusted vendors and marketplaces with approval disabled still apply file changes instantly; unsold pending products still write files directly; a vendor re-submitting the approved files cancels their staged swap.

### Changelog entry

*fix: Unreviewed replacement files were delivered to existing customers before admin approval*

Previously, when a vendor replaced the file of a downloadable product on a marketplace requiring admin approval, existing customers received the unreviewed file immediately at vendor-save time and lost access to the approved file, while the product sat in Pending Review. Now customers keep the last approved file until an administrator reviews and publishes the update, and administrators can see and discard a pending file before it ships.

### Before Changes

A vendor saving a file swap instantly switched every existing customer to the unreviewed file and reset their download count and access date, while the product sat in Pending Review. Approval status was never consulted. Unticking "Downloadable" revoked access outright. File changes made through REST, the new product editor, wp-admin or WP-CLI left customers' permissions pointing at a file that no longer existed, so their Downloads page went empty. Edits made through the new product editor skipped review altogether.

### After Changes

Customers keep the approved file, with their original download count, until an administrator publishes the update. The administrator can see what they are approving, override it, or discard it. Rejecting or trashing drops the submission. Download permissions follow the files on every save path, and edits made through the new product editor go through the same review as the vendor product form.

### Tests

`tests/php/src/Product/DownloadableApprovalHoldTest.php` — 24 tests covering the hold, every negative case, release through `wp_update_post` and CRUD, admin override, reject, discard, the id re-key, CRUD permission alignment, the vendor REST round trip, and variations.

Full Lite suite: 291 tests, 1 failure (`OrderStatusChangeTest`, already failing on `develop`). PHPCS clean on the new code.
