### PR TITLE
fix(dashboard): hide the Downloadable Product Permission section on orders without downloadable products

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,15 @@ A return of money to the customer, recorded against a Vendor order and mirrored
 up to its Order. A refund created directly on a parent Order is outside the
 model: vendor accounting does not see it.
 
+**Download Permission**:
+A grant of file access to the customer, recorded against an order — created
+automatically when a paid order contains a downloadable product, or granted
+manually by the Vendor or admin. Independent of the order's current items: a
+permission can exist on an order with no downloadable item (granted manually,
+or the product changed since purchase), and a downloadable item confers no
+access until a permission exists.
+_Avoid_: Download access, download link
+
 ### Money
 
 **Commission**:

--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -192,6 +192,34 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
 
             <div class="clear"></div>
 
+            <?php
+            // Permissions can exist without a downloadable item in the order (granted
+            // manually, or the product was made non-downloadable later) — keep the
+            // section visible in that case so existing grants stay manageable.
+            $show_download_permissions = $order->has_downloadable_item();
+
+            if ( ! $show_download_permissions && 0 !== $order->get_id() ) {
+                $existing_download_permissions = WC_Data_Store::load( 'customer-download' )->get_downloads(
+                    array(
+                        'order_id' => $order->get_id(),
+                        'limit'    => 1,
+                        'return'   => 'ids',
+                    )
+                );
+
+                $show_download_permissions = ! empty( $existing_download_permissions );
+            }
+
+            /**
+             * Filters whether the Downloadable Product Permission section is shown on the order details page.
+             *
+             * @since DOKAN_SINCE
+             *
+             * @param bool      $show_download_permissions Whether to render the section.
+             * @param \WC_Order $order                     Order object.
+             */
+            if ( apply_filters( 'dokan_order_details_show_download_permissions', $show_download_permissions, $order ) ) :
+                ?>
             <div class="" style="width: 100%">
                 <div class="dokan-panel dokan-panel-default">
                     <div class="dokan-panel-heading"><strong><?php esc_html_e( 'Downloadable Product Permission', 'dokan-lite' ); ?></strong></div>
@@ -202,6 +230,7 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
                     </div>
                 </div>
             </div>
+            <?php endif; ?>
         </div>
     </div>
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

On the vendor dashboard → order details page, the **Downloadable Product Permission** panel rendered on every order, including physical-only orders where it is always empty. This PR renders the panel only when it is relevant:

* the order contains at least one downloadable item (`WC_Order::has_downloadable_item()`), **or**
* the order already has download-permission rows (cheap existence check via the `customer-download` data store, `limit: 1`).

The second condition matters: permissions can exist on an order whose product was later made non-downloadable (or was granted manually) — the section stays visible there so vendors can still see and revoke existing grants.

A new filter `dokan_order_details_show_download_permissions( bool $show, WC_Order $order )` (tagged `@since DOKAN_SINCE`) lets extensions/themes force the section on or off without overriding the template.

Note: WooCommerce core shows its equivalent wp-admin meta box unconditionally; we deliberately deviate for the vendor dashboard since the empty panel confuses vendors selling physical goods, and admins keep the full tool in wp-admin. Also adds a **Download Permission** entry to the `CONTEXT.md` glossary capturing this distinction.

### Closes

* Closes getdokan/dokan-pro#6055
* Discussion: getdokan/dokan-pro#6052

### How to test the changes in this Pull Request:

1. As a vendor, open an order containing only physical products → the Downloadable Product Permission section is **not** rendered.
2. Open an order containing a downloadable product → the section renders as before (permission rows + Grant Access).
3. On a downloadable order with granted permissions, edit the product and untick **Downloadable**, then reload the order details → the section is **still** rendered so the existing grants can be revoked.
4. Add `add_filter( 'dokan_order_details_show_download_permissions', '__return_true' );` → the section renders on every order again.

### Changelog entry

*fix(dashboard): hide the Downloadable Product Permission section on orders without downloadable products*

Previously the vendor dashboard order details page always rendered the Downloadable Product Permission section, even for orders with no downloadable products, where it was permanently empty and confusing. Now the section only appears when the order contains a downloadable item or already has download permissions granted; a new `dokan_order_details_show_download_permissions` filter can override the behaviour.

### Before Changes

Every order details page showed the (empty) section — see https://snipboard.io/hQYPI7.jpg

### After Changes

Physical-only orders: section absent. Downloadable orders and orders with existing permissions: unchanged. Verified all three states plus the filter override as a vendor on a local site (template render + browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHqzbMyKg4rJ4wzkjhMWcc