### PR TITLE
fix(product-editor): paginate async_select fields so all tags/options are reachable

### DIFF
--- a/src/dashboard/product-editor/components/AsyncSelectEdit.tsx
+++ b/src/dashboard/product-editor/components/AsyncSelectEdit.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { AsyncSelect, Select } from '@src/components';
+import { Select } from '@src/components';
 import { TaggableSelect } from '@getdokan/dokan-ui';
 import CustomField, { getValidationError } from './CustomField';
 import { components as rsComponents } from 'react-select';
@@ -9,7 +9,13 @@ import { addQueryArgs } from '@wordpress/url';
 import { debounce } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from '@wordpress/element';
 
 type FieldProps = {
     data: any;
@@ -36,27 +42,112 @@ const decodeLabel = ( option: any ) =>
 const decodeValue = ( value: any ) =>
     Array.isArray( value ) ? value.map( decodeLabel ) : decodeLabel( value );
 
-// Fetch `{ value, label }` options from an endpoint, optionally filtered by `search`.
+const OPTIONS_PER_PAGE = 20;
+
+// Fetch one page of `{ value, label }` options from an endpoint, optionally
+// filtered by `search`. `hasMore` is inferred from a full page rather than the
+// X-WP-TotalPages header so a proxy stripping custom headers can't disable
+// pagination; the only cost is one empty request when the total is an exact
+// multiple of the page size.
 const fetchOptions = async (
     endpoint?: string,
-    search = ''
-): Promise< any[] > => {
+    search = '',
+    page = 1
+): Promise< { options: any[]; hasMore: boolean } > => {
     if ( ! endpoint ) {
-        return [];
+        return { options: [], hasMore: false };
     }
     try {
         const result: any = await apiFetch( {
-            path: addQueryArgs( endpoint, { search, per_page: 20 } ),
+            path: addQueryArgs( endpoint, {
+                search,
+                per_page: OPTIONS_PER_PAGE,
+                page,
+            } ),
         } );
-        return Array.isArray( result )
+        const options = Array.isArray( result )
             ? result.map( ( item: any ) => ( {
                   value: item.id,
                   label: decodeEntities( item.name ),
               } ) )
             : [];
+        return { options, hasMore: options.length === OPTIONS_PER_PAGE };
     } catch {
-        return [];
+        return { options: [], hasMore: false };
     }
+};
+
+// Options state shared by the non-tree async fields: page 1 replaces the list,
+// scrolling the open menu to its end appends the next page for the current
+// search term, and a new search resets back to page 1.
+const usePaginatedOptions = ( endpoint?: string ) => {
+    const [ options, setOptions ] = useState< any[] >( [] );
+    const [ isLoading, setIsLoading ] = useState( false );
+    // Mutable request state: lets the scroll handler read the latest
+    // page/search without re-rendering, and `requestId` discards responses
+    // that arrive after a newer request has been issued.
+    const stateRef = useRef( {
+        search: '',
+        page: 1,
+        hasMore: false,
+        loading: false,
+        requestId: 0,
+    } );
+
+    const load = useCallback(
+        ( search: string, page: number ) => {
+            const requestId = ++stateRef.current.requestId;
+            stateRef.current.loading = true;
+            setIsLoading( true );
+            fetchOptions( endpoint, search, page ).then( ( result ) => {
+                if ( requestId !== stateRef.current.requestId ) {
+                    return; // superseded by a newer search/page request
+                }
+                stateRef.current = {
+                    ...stateRef.current,
+                    search,
+                    page,
+                    hasMore: result.hasMore,
+                    loading: false,
+                };
+                setIsLoading( false );
+                setOptions( ( previous ) => {
+                    const merged =
+                        page === 1
+                            ? result.options
+                            : [ ...previous, ...result.options ];
+                    // Terms can shift between pages while browsing (e.g. a tag
+                    // created mid-session); keep the first occurrence of each.
+                    const seen = new Set();
+                    return merged.filter(
+                        ( option ) =>
+                            ! seen.has( option.value ) &&
+                            seen.add( option.value )
+                    );
+                } );
+            } );
+        },
+        [ endpoint ]
+    );
+
+    const onSearch = useMemo(
+        () => debounced( ( input: string ) => load( input, 1 ) ),
+        [ load ]
+    );
+
+    const onMenuScrollToBottom = () => {
+        const { search, page, hasMore, loading } = stateRef.current;
+        if ( hasMore && ! loading ) {
+            load( search, page + 1 );
+        }
+    };
+
+    useEffect( () => {
+        load( '', 1 );
+        return () => onSearch.cancel();
+    }, [ load, onSearch ] );
+
+    return { options, isLoading, onSearch, onMenuScrollToBottom };
 };
 
 // Flatten a nested tree into ordered options carrying their depth level.
@@ -185,31 +276,15 @@ const CreatableSelectField = ( {
     onChange,
     validity,
 }: FieldProps ) => {
-    const [ options, setOptions ] = useState< any[] >( [] );
-    const search = useMemo(
-        () =>
-            debounced( ( input ) =>
-                fetchOptions( field.api_endpoint, input ).then( setOptions )
-            ),
-        [ field.api_endpoint ]
-    );
-
-    useEffect( () => {
-        let active = true;
-        fetchOptions( field.api_endpoint ).then(
-            ( opts ) => active && setOptions( opts )
-        );
-        return () => {
-            active = false;
-            search.cancel();
-        };
-    }, [ field.api_endpoint, search ] );
+    const { options, isLoading, onSearch, onMenuScrollToBottom } =
+        usePaginatedOptions( field.api_endpoint );
 
     return (
         <CustomField field={ field } error={ getValidationError( validity ) }>
             <TaggableSelect
                 isMulti={ field.multiple }
                 options={ options }
+                isLoading={ isLoading }
                 value={ decodeValue( data[ field.id ] ?? [] ) }
                 placeholder={ field.placeholder }
                 // Server already filters by `search`; keep all returned options.
@@ -217,9 +292,10 @@ const CreatableSelectField = ( {
                 isValidNewOption={ makeIsValidNewOption( field, data ) }
                 onInputChange={ ( input: string, meta: any ) => {
                     if ( meta.action === 'input-change' ) {
-                        search( input );
+                        onSearch( input );
                     }
                 } }
+                onMenuScrollToBottom={ onMenuScrollToBottom }
                 onChange={ ( value: any ) =>
                     onChange( { [ field.id ]: value ?? [] } )
                 }
@@ -228,31 +304,33 @@ const CreatableSelectField = ( {
     );
 };
 
-// Upsells/cross-sells etc.: plain async multi-select with debounced search.
+// Upsells/cross-sells etc.: multi-select with debounced server search. Options
+// are state-driven (rather than AsyncSelect's internal loadOptions cache) so
+// scrolling the menu can append further pages.
 const AsyncMultiSelectField = ( {
     data,
     field,
     onChange,
     validity,
 }: FieldProps ) => {
-    const loadOptions = useMemo(
-        () =>
-            debounced( ( input, callback ) =>
-                fetchOptions( field.api_endpoint, input ).then( callback )
-            ),
-        [ field.api_endpoint ]
-    );
-
-    useEffect( () => () => loadOptions.cancel(), [ loadOptions ] );
+    const { options, isLoading, onSearch, onMenuScrollToBottom } =
+        usePaginatedOptions( field.api_endpoint );
 
     return (
         <CustomField field={ field } error={ getValidationError( validity ) }>
-            <AsyncSelect
+            <Select
                 isMulti={ field.multiple }
-                cacheOptions
-                defaultOptions
+                options={ options }
+                isLoading={ isLoading }
                 value={ decodeValue( data[ field.id ] ) }
-                loadOptions={ loadOptions }
+                // Server already filters by `search`; keep all returned options.
+                filterOption={ null }
+                onInputChange={ ( input: string, meta: any ) => {
+                    if ( meta.action === 'input-change' ) {
+                        onSearch( input );
+                    }
+                } }
+                onMenuScrollToBottom={ onMenuScrollToBottom }
                 onChange={ ( value: any ) =>
                     onChange( { [ field.id ]: value } )
                 }

--- a/src/dashboard/product-editor/components/AsyncSelectEdit.tsx
+++ b/src/dashboard/product-editor/components/AsyncSelectEdit.tsx
@@ -9,6 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { debounce } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 import {
     useCallback,
     useEffect,
@@ -42,20 +43,32 @@ const decodeLabel = ( option: any ) =>
 const decodeValue = ( value: any ) =>
     Array.isArray( value ) ? value.map( decodeLabel ) : decodeLabel( value );
 
+// Wrapper that satisfies @wordpress/compose debounce's `(...args: unknown[])` constraint.
+const debounced = ( fn: ( ...args: any[] ) => void ) =>
+    debounce( ( ...args: unknown[] ) => fn( ...args ), 300 );
+
 const OPTIONS_PER_PAGE = 20;
 
+// How close to the end of the menu list (in px) a scroll must get before the
+// next page is requested.
+const LOAD_MORE_THRESHOLD_PX = 24;
+
+type OptionsPage = { options: any[]; hasMore: boolean; failed: boolean };
+
 // Fetch one page of `{ value, label }` options from an endpoint, optionally
-// filtered by `search`. `hasMore` is inferred from a full page rather than the
-// X-WP-TotalPages header so a proxy stripping custom headers can't disable
-// pagination; the only cost is one empty request when the total is an exact
-// multiple of the page size.
+// filtered by `search`. `hasMore` is inferred from receiving a full page:
+// apiFetch only exposes response headers under `parse: false`, so reading
+// X-WP-TotalPages would mean unwrapping every response by hand. The only cost
+// is one empty request when the total is an exact multiple of the page size.
+// A failed request is reported separately from an empty page so the caller
+// can leave its paging state intact and retry.
 const fetchOptions = async (
     endpoint?: string,
     search = '',
     page = 1
-): Promise< { options: any[]; hasMore: boolean } > => {
+): Promise< OptionsPage > => {
     if ( ! endpoint ) {
-        return { options: [], hasMore: false };
+        return { options: [], hasMore: false, failed: false };
     }
     try {
         const result: any = await apiFetch( {
@@ -71,26 +84,52 @@ const fetchOptions = async (
                   label: decodeEntities( item.name ),
               } ) )
             : [];
-        return { options, hasMore: options.length === OPTIONS_PER_PAGE };
+        return {
+            options,
+            hasMore: options.length === OPTIONS_PER_PAGE,
+            failed: false,
+        };
     } catch {
-        return { options: [], hasMore: false };
+        return { options: [], hasMore: false, failed: true };
     }
 };
 
-// Options state shared by the non-tree async fields: page 1 replaces the list,
-// scrolling the open menu to its end appends the next page for the current
-// search term, and a new search resets back to page 1.
+// Keep the first occurrence of each option value. Terms can shift between
+// pages while browsing (e.g. a tag created mid-session), so appended pages may
+// repeat an option that is already listed.
+const dedupeByValue = ( items: any[] ): any[] => {
+    const seen = new Set();
+    const unique: any[] = [];
+    for ( const item of items ) {
+        if ( ! seen.has( item.value ) ) {
+            seen.add( item.value );
+            unique.push( item );
+        }
+    }
+    return unique;
+};
+
+// Options state shared by the non-tree async fields. Page 1 is fetched when
+// the menu first opens and replaces the list; scrolling the open menu near its
+// end appends the next page for the current search term; a new search resets
+// to page 1; and clearing the input (blur, menu close, selection) drops the
+// stale search so the next open shows the unfiltered list again.
 const usePaginatedOptions = ( endpoint?: string ) => {
     const [ options, setOptions ] = useState< any[] >( [] );
     const [ isLoading, setIsLoading ] = useState( false );
-    // Mutable request state: lets the scroll handler read the latest
-    // page/search without re-rendering, and `requestId` discards responses
-    // that arrive after a newer request has been issued.
+    const [ hasError, setHasError ] = useState( false );
+    // Mutable request state: lets event handlers read the latest page/search
+    // without re-rendering, and `requestId` discards responses that arrive
+    // after a newer request has been issued.
     const stateRef = useRef( {
         search: '',
         page: 1,
         hasMore: false,
+        loaded: false, // page 1 of the current search has been fetched
         loading: false,
+        searchPending: false, // a debounced search is waiting to fire
+        inFlight: { search: '', page: 1 }, // what the current request asked for
+        menuOpen: false,
         requestId: 0,
     } );
 
@@ -98,33 +137,36 @@ const usePaginatedOptions = ( endpoint?: string ) => {
         ( search: string, page: number ) => {
             const requestId = ++stateRef.current.requestId;
             stateRef.current.loading = true;
+            stateRef.current.searchPending = false;
+            stateRef.current.inFlight = { search, page };
             setIsLoading( true );
             fetchOptions( endpoint, search, page ).then( ( result ) => {
                 if ( requestId !== stateRef.current.requestId ) {
                     return; // superseded by a newer search/page request
+                }
+                if ( result.failed ) {
+                    // Leave search/page/hasMore untouched so the next scroll
+                    // or menu open retries this same page.
+                    stateRef.current.loading = false;
+                    setIsLoading( false );
+                    setHasError( true );
+                    return;
                 }
                 stateRef.current = {
                     ...stateRef.current,
                     search,
                     page,
                     hasMore: result.hasMore,
+                    loaded: true,
                     loading: false,
                 };
+                setHasError( false );
                 setIsLoading( false );
-                setOptions( ( previous ) => {
-                    const merged =
-                        page === 1
-                            ? result.options
-                            : [ ...previous, ...result.options ];
-                    // Terms can shift between pages while browsing (e.g. a tag
-                    // created mid-session); keep the first occurrence of each.
-                    const seen = new Set();
-                    return merged.filter(
-                        ( option ) =>
-                            ! seen.has( option.value ) &&
-                            seen.add( option.value )
-                    );
-                } );
+                setOptions( ( previous ) =>
+                    page === 1
+                        ? result.options
+                        : dedupeByValue( [ ...previous, ...result.options ] )
+                );
             } );
         },
         [ endpoint ]
@@ -135,19 +177,124 @@ const usePaginatedOptions = ( endpoint?: string ) => {
         [ load ]
     );
 
-    const onMenuScrollToBottom = () => {
-        const { search, page, hasMore, loading } = stateRef.current;
-        if ( hasMore && ! loading ) {
+    const loadMore = useCallback( () => {
+        const { search, page, hasMore, loaded, loading } = stateRef.current;
+        if ( loaded && hasMore && ! loading ) {
             load( search, page + 1 );
         }
-    };
+    }, [ load ] );
 
+    const onInputChange = useCallback(
+        ( input: string, meta: any ) => {
+            if ( meta.action === 'input-change' ) {
+                // Blank the list straight away so the loading state gives
+                // feedback during the debounce + round trip instead of the
+                // previous results sitting there looking ignored.
+                stateRef.current.searchPending = true;
+                setOptions( [] );
+                setIsLoading( true );
+                onSearch( input );
+            } else if ( meta.prevInputValue ) {
+                // react-select clears its own input on blur, menu close and
+                // selection; drop the stale search so the next open shows
+                // page 1 of the unfiltered list again. Those actions fire in
+                // quick succession for one selection, so skip when that reset
+                // is already in flight.
+                const { loading, inFlight } = stateRef.current;
+                if (
+                    loading &&
+                    inFlight.search === '' &&
+                    inFlight.page === 1
+                ) {
+                    return;
+                }
+                onSearch.cancel();
+                load( '', 1 );
+            }
+        },
+        [ load, onSearch ]
+    );
+
+    const onMenuOpen = useCallback( () => {
+        stateRef.current.menuOpen = true;
+        const { loaded, loading, searchPending } = stateRef.current;
+        // Lazy initial load: nothing is fetched until the vendor opens the
+        // menu. Skipped when a typed search is already about to fire.
+        if ( ! loaded && ! loading && ! searchPending ) {
+            load( '', 1 );
+        }
+    }, [ load ] );
+
+    const onMenuClose = useCallback( () => {
+        stateRef.current.menuOpen = false;
+    }, [] );
+
+    // Detect the menu list being scrolled near its end. react-select's own
+    // onMenuScrollToBottom only listens to wheel/touch events and is disabled
+    // entirely on touch-capable devices, so listen for native scroll events
+    // instead (captured at the document because scroll does not bubble and
+    // the menu renders in a portal). This fires for wheel, touch, scrollbar
+    // drag and keyboard navigation alike. The menu list is identified by its
+    // listbox role, and only while this field's menu is open.
     useEffect( () => {
-        load( '', 1 );
+        const onScroll = ( event: Event ) => {
+            const target = event.target as HTMLElement | null;
+            if (
+                ! stateRef.current.menuOpen ||
+                ! target ||
+                typeof target.getAttribute !== 'function' ||
+                target.getAttribute( 'role' ) !== 'listbox'
+            ) {
+                return;
+            }
+            const remaining =
+                target.scrollHeight - target.scrollTop - target.clientHeight;
+            if ( remaining < LOAD_MORE_THRESHOLD_PX ) {
+                loadMore();
+            }
+        };
+        document.addEventListener( 'scroll', onScroll, true );
+        return () => document.removeEventListener( 'scroll', onScroll, true );
+    }, [ loadMore ] );
+
+    // Reset when the endpoint changes so the old endpoint's options never
+    // show against the new one; the next menu open fetches page 1 afresh.
+    useEffect( () => {
+        stateRef.current = {
+            ...stateRef.current,
+            search: '',
+            page: 1,
+            hasMore: false,
+            loaded: false,
+            searchPending: false,
+        };
+        setOptions( [] );
+        setHasError( false );
+        if ( stateRef.current.menuOpen ) {
+            load( '', 1 );
+        }
         return () => onSearch.cancel();
     }, [ load, onSearch ] );
 
-    return { options, isLoading, onSearch, onMenuScrollToBottom };
+    const noOptionsMessage = useCallback(
+        () =>
+            hasError
+                ? __(
+                      'Could not load options. Please try again.',
+                      'dokan-lite'
+                  )
+                : __( 'No options', 'dokan-lite' ),
+        [ hasError ]
+    );
+
+    return {
+        options,
+        isLoading,
+        onInputChange,
+        onMenuOpen,
+        onMenuClose,
+        noOptionsMessage,
+    };
 };
 
 // Flatten a nested tree into ordered options carrying their depth level.
@@ -208,10 +355,6 @@ const makeIsValidNewOption =
             data
         ) as boolean;
     };
-
-// Wrapper that satisfies @wordpress/compose debounce's `(...args: unknown[])` constraint.
-const debounced = ( fn: ( ...args: any[] ) => void ) =>
-    debounce( ( ...args: unknown[] ) => fn( ...args ), 300 );
 
 // Categories etc.: load the full nested tree once and render it indented.
 const TreeSelectField = ( { data, field, onChange, validity }: FieldProps ) => {
@@ -276,26 +419,23 @@ const CreatableSelectField = ( {
     onChange,
     validity,
 }: FieldProps ) => {
-    const { options, isLoading, onSearch, onMenuScrollToBottom } =
-        usePaginatedOptions( field.api_endpoint );
+    const paginated = usePaginatedOptions( field.api_endpoint );
 
     return (
         <CustomField field={ field } error={ getValidationError( validity ) }>
             <TaggableSelect
                 isMulti={ field.multiple }
-                options={ options }
-                isLoading={ isLoading }
+                options={ paginated.options }
+                isLoading={ paginated.isLoading }
                 value={ decodeValue( data[ field.id ] ?? [] ) }
                 placeholder={ field.placeholder }
                 // Server already filters by `search`; keep all returned options.
                 filterOption={ null }
                 isValidNewOption={ makeIsValidNewOption( field, data ) }
-                onInputChange={ ( input: string, meta: any ) => {
-                    if ( meta.action === 'input-change' ) {
-                        onSearch( input );
-                    }
-                } }
-                onMenuScrollToBottom={ onMenuScrollToBottom }
+                onInputChange={ paginated.onInputChange }
+                onMenuOpen={ paginated.onMenuOpen }
+                onMenuClose={ paginated.onMenuClose }
+                noOptionsMessage={ paginated.noOptionsMessage }
                 onChange={ ( value: any ) =>
                     onChange( { [ field.id ]: value ?? [] } )
                 }
@@ -313,24 +453,21 @@ const AsyncMultiSelectField = ( {
     onChange,
     validity,
 }: FieldProps ) => {
-    const { options, isLoading, onSearch, onMenuScrollToBottom } =
-        usePaginatedOptions( field.api_endpoint );
+    const paginated = usePaginatedOptions( field.api_endpoint );
 
     return (
         <CustomField field={ field } error={ getValidationError( validity ) }>
             <Select
                 isMulti={ field.multiple }
-                options={ options }
-                isLoading={ isLoading }
+                options={ paginated.options }
+                isLoading={ paginated.isLoading }
                 value={ decodeValue( data[ field.id ] ) }
                 // Server already filters by `search`; keep all returned options.
                 filterOption={ null }
-                onInputChange={ ( input: string, meta: any ) => {
-                    if ( meta.action === 'input-change' ) {
-                        onSearch( input );
-                    }
-                } }
-                onMenuScrollToBottom={ onMenuScrollToBottom }
+                onInputChange={ paginated.onInputChange }
+                onMenuOpen={ paginated.onMenuOpen }
+                onMenuClose={ paginated.onMenuClose }
+                noOptionsMessage={ paginated.noOptionsMessage }
                 onChange={ ( value: any ) =>
                     onChange( { [ field.id ]: value } )
                 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Fixes two defects in the new product editor's `async_select` fields (Tags, and Pro's Upsells / Cross-sells / Grouped products), reported in getdokan/dokan-pro#6026:

**1. Options were capped at the first 20 (the reported bug).** `fetchOptions()` in `AsyncSelectEdit.tsx` fetched a single hardcoded `per_page=20` page with no `page` parameter and no scroll handler, so a store with 100+ tags could never browse beyond the first 20. The legacy jQuery form has paginated this dropdown via select2 since v3.0.10; the React rewrite dropped that behavior.

**2. The non-creatable variant could not search at all (discovered while validating).** The debounced function passed as `AsyncSelect`'s `loadOptions` returns the *previous* invocation's promise while a call is pending. react-select therefore attached to a stale, already-resolved promise, rendered "No options", cleared its request token, and discarded the real server response when it arrived 300ms later. With "vendors can create tags" **off**, tag search was completely broken — the server found the tag, the UI threw it away.

**The fix** replaces the per-variant fetch logic with a shared `usePaginatedOptions` hook that explicitly owns option state:

- Page 1 is fetched lazily when the menu first opens, so fields the vendor never opens cost no requests; scrolling the menu list near its end appends the next page for the current search term.
- Pagination is driven by native `scroll` events on the menu list rather than react-select's `onMenuScrollToBottom`. That prop is routed through `ScrollCaptor`, whose `captureMenuScroll` defaults to `!isTouchCapable()` — so it is disabled outright on Android, iOS and touch-screen laptops — and even where it is active it binds only `wheel`/`touchstart`/`touchmove`, meaning scrollbar drag and keyboard navigation never reach it. Listening for `scroll` covers every mechanism. (A `MenuList` override is not usable here: dokan-ui's `TaggableSelect` spreads caller props and then replaces `components` with its own.)
- Clearing the input — blur, menu close, or selecting an option — resets the search, so reopening a field after picking a searched option shows the unfiltered list again rather than one still filtered by the previous term.
- A failed request is reported separately from a genuinely empty last page: the paging state is left intact so the next scroll or menu open retries, and the failure is surfaced to the vendor instead of being indistinguishable from "this store has no options".
- Typing blanks the list immediately so the loading state carries the feedback during the debounce, instead of stale results sitting there looking ignored.
- A new search term resets to page 1 and replaces the list.
- Out-of-order responses are discarded via a request id, and appended pages are deduped by term id.
- `hasMore` is inferred from receiving a full page rather than the `X-WP-TotalPages` header, so proxies that strip custom headers cannot silently disable pagination (cost: one empty request when the total is an exact multiple of 20).
- The non-creatable variant now uses the state-driven `Select` instead of `AsyncSelect`, because `AsyncSelect` owns its options internally and cannot have pages appended — this is also what eliminates the stale-promise search bug.

No backend changes: the WooCommerce/Dokan REST endpoints already supported `page`/`per_page`.

### Closes

* Closes getdokan/dokan-pro#6026

### How to test the changes in this Pull Request:

1. Create 100+ product tags (WP Admin → Products → Tags).
2. Log in as a vendor → Vendor Dashboard → Add New Product (new product editor).
3. Open the **Tags** dropdown: the first 20 tags appear, and scrolling the menu keeps loading pages of 20 until every tag is reachable. **Check each scroll mechanism**, since they do not share a code path in react-select: mouse wheel, dragging the menu's scrollbar, keyboard arrow keys, and a touch device (or DevTools device emulation) — touch is the case react-select's own `onMenuScrollToBottom` cannot serve at all.
4. Type a term beyond the first 20 (e.g. the 115th tag's name): it is found and rendered. Repeat with admin setting "vendors can create tags" both on and off.
5. Search for a tag, select it, then reopen the dropdown: the list is back to page 1 unfiltered, not still filtered by the term you typed.
6. With Pro active, verify the Linked Products fields (Upsells / Cross-sells, and Grouped products with product type "Grouped") also paginate on scroll with 20+ products.

### Changelog entry

*fix: Product tag selector did not show all tags in the vendor dashboard product form*

Previously the product editor's tag/linked-product dropdowns loaded only the first 20 options with no way to browse the rest, and (when tag creation was disabled for vendors) typing in the Tags field always showed "No options" even though the tag existed. Now the dropdowns load further pages as the vendor scrolls, and searching works in both configurations.

### Before Changes

Opening the Tags dropdown with 120 tags showed only "Tag 001"–"Tag 020"; scrolling loaded nothing more. With vendor tag creation off, typing "115" fired the server search (which returned Tag 115) but the menu displayed "No options".

### After Changes

Opening the Tags dropdown shows the first 20 tags and wheel-scrolling appends pages of 20 until all 120 are listed; typing "115" renders "Tag 115".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
