### PR TITLE
fix(i18n): make vendor dashboard list-view labels translatable

### DIFF
--- a/src/components/dataviews/DokanDataViews.tsx
+++ b/src/components/dataviews/DokanDataViews.tsx
@@ -1,60 +1,51 @@
 import { DataViews as PluginUIDataViews } from '@wedevs/plugin-ui';
 import type { DataViewsProps } from '@wedevs/plugin-ui';
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-// TS cannot forward DataViewsProps<Item> into plugin-ui's own generic because that type defers a
-// conditional on Item, so the generic is erased at this boundary alone; runtime props are unchanged.
+// plugin-ui's generic defers a conditional on Item that TS cannot forward; runtime props are unchanged.
 const ForwardedDataViews = PluginUIDataViews as (
     props: any // eslint-disable-line @typescript-eslint/no-explicit-any
 ) => JSX.Element;
 
-// plugin-ui labels its own chrome with core's `default` domain, which only translates the wording core
-// happens to ship; the rest is unreachable from Dokan's language files, so re-declare it under ours.
-// Wording core does own — "Search", "Reset", "Cancel" — is deliberately left alone.
+// plugin-ui labels its chrome with core's `default` domain, which Dokan's language files can never reach.
 function DokanDataViews< Item >( props: DataViewsProps< Item > ) {
-    const { actions, filter } = props;
+    const { actions, filter, emptyTitle } = props;
 
-    const localizedActions = useMemo(
-        () =>
-            actions?.map( ( action ) => ( {
-                ...action,
-                confirmMessage:
-                    action.confirmMessage ??
-                    __(
-                        'Are you sure? This action cannot be undone.',
-                        'dokan-lite'
-                    ),
-            } ) ),
-        [ actions ]
+    // Only a destructive action reaches the confirm dialog, so leave every other action object untouched.
+    const localizedActions = actions?.map( ( action ) =>
+        action.isDestructive && ! action.confirmMessage
+            ? {
+                  ...action,
+                  confirmMessage: __(
+                      'Are you sure? This action cannot be undone.',
+                      'dokan-lite'
+                  ),
+              }
+            : action
     );
 
-    const localizedFilter = useMemo(
-        () =>
-            filter && {
-                ...filter,
-                labels: {
-                    removeFilter: __( 'Remove filter', 'dokan-lite' ),
-                    addFilter: __( 'Add Filter', 'dokan-lite' ),
-                    ...filter.labels,
-                },
-            },
-        [ filter ]
-    );
+    // "Reset" stays on core, which already translates it for locales Dokan has not.
+    const localizedFilter = filter && {
+        ...filter,
+        labels: {
+            removeFilter: __( 'Remove filter', 'dokan-lite' ),
+            addFilter: __( 'Add Filter', 'dokan-lite' ),
+            ...filter.labels,
+        },
+    };
 
+    // The tab-scroll aria-labels and the skeleton "Actions" header take no prop, so they stay on core.
     return (
         <ForwardedDataViews
             { ...props }
             actions={ localizedActions }
             filter={ localizedFilter }
-            emptyTitle={
-                props.emptyTitle ?? __( 'No data found', 'dokan-lite' )
-            }
+            emptyTitle={ emptyTitle ?? __( 'No data found', 'dokan-lite' ) }
         />
     );
 }
 
-// Keep plugin-ui's compound sub-components reachable through the Dokan export.
+// Callers render these directly, so they must survive the wrap.
 export default Object.assign( DokanDataViews, {
     Pagination: PluginUIDataViews.Pagination,
     Layout: PluginUIDataViews.Layout,

--- a/src/components/dataviews/DokanDataViews.tsx
+++ b/src/components/dataviews/DokanDataViews.tsx
@@ -1,0 +1,64 @@
+import { DataViews as PluginUIDataViews } from '@wedevs/plugin-ui';
+import type { DataViewsProps } from '@wedevs/plugin-ui';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+// TS cannot forward DataViewsProps<Item> into plugin-ui's own generic because that type defers a
+// conditional on Item, so the generic is erased at this boundary alone; runtime props are unchanged.
+const ForwardedDataViews = PluginUIDataViews as (
+    props: any // eslint-disable-line @typescript-eslint/no-explicit-any
+) => JSX.Element;
+
+// plugin-ui labels its own chrome with core's `default` domain, which only translates the wording core
+// happens to ship; the rest is unreachable from Dokan's language files, so re-declare it under ours.
+// Wording core does own — "Search", "Reset", "Cancel" — is deliberately left alone.
+function DokanDataViews< Item >( props: DataViewsProps< Item > ) {
+    const { actions, filter } = props;
+
+    const localizedActions = useMemo(
+        () =>
+            actions?.map( ( action ) => ( {
+                ...action,
+                confirmMessage:
+                    action.confirmMessage ??
+                    __(
+                        'Are you sure? This action cannot be undone.',
+                        'dokan-lite'
+                    ),
+            } ) ),
+        [ actions ]
+    );
+
+    const localizedFilter = useMemo(
+        () =>
+            filter && {
+                ...filter,
+                labels: {
+                    removeFilter: __( 'Remove filter', 'dokan-lite' ),
+                    addFilter: __( 'Add Filter', 'dokan-lite' ),
+                    ...filter.labels,
+                },
+            },
+        [ filter ]
+    );
+
+    return (
+        <ForwardedDataViews
+            { ...props }
+            actions={ localizedActions }
+            filter={ localizedFilter }
+            emptyTitle={
+                props.emptyTitle ?? __( 'No data found', 'dokan-lite' )
+            }
+        />
+    );
+}
+
+// Keep plugin-ui's compound sub-components reachable through the Dokan export.
+export default Object.assign( DokanDataViews, {
+    Pagination: PluginUIDataViews.Pagination,
+    Layout: PluginUIDataViews.Layout,
+    Search: PluginUIDataViews.Search,
+    Filters: PluginUIDataViews.Filters,
+    BulkActionToolbar: PluginUIDataViews.BulkActionToolbar,
+} );

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -6,7 +6,7 @@ export {
     VIEW_LAYOUTS,
 } from '@wordpress/dataviews/wp';
 export { default as AdminDataViews } from './dataviews/AdminDataViewTable';
-export { DataViews } from '@wedevs/plugin-ui';
+export { default as DataViews } from './dataviews/DokanDataViews';
 export { default as DokanModal } from './modals/DokanModal';
 export { default as SortableList } from './sortable-list';
 export { default as ListEmpty } from './dataviews/ListEmpty';


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Every vendor-dashboard list renders plugin-ui's `DataViews`, which Lite re-exports from its component barrel as `@dokan/components`' `DataViews`. plugin-ui labels its own chrome with `__( '…', 'default' )` — **WordPress core's** text domain, not Dokan's.

So a label only translates if core happens to ship that exact string in the site's locale. Core-owned wording ("Search", "Reset", "Cancel", "Actions") resolves fine — which is why the problem looked sporadic — but plugin-ui's own phrasings never do. `No data found` is the visible one: it is the empty state on Withdraw Requests, Reverse Withdrawal, Coupons, Reviews, Product Q&A and every other list, and **no amount of translating Dokan can reach it**, because `wp i18n make-pot --domain=dokan-lite` skips `default`-domain calls.

This PR wraps the re-export so Dokan re-declares those labels under `dokan-lite`, putting them in reach of a marketplace's own language files. Doing it at the barrel fixes every consumer at once — including Pro's lists, which resolve `@dokan/components` to `window.dokan.components` at runtime and need no rebuild of their own.

Re-homed (core cannot supply these):

| String | Where it shows |
|---|---|
| `No data found` | empty state on every list |
| `Add Filter` / `Remove filter` | filter bar |
| `Are you sure? This action cannot be undone.` | destructive-action confirm dialog (e.g. Reviews → Trash) |

Deliberately **left to core**: `Search`, `Reset`, `Cancel`. Moving those would *lose* the translation core already provides for locales that have not translated them in Dokan — verified in `bn_BD`, where `__( 'Search', 'default' )` is `অনুসন্ধান` but `__( 'Search', 'dokan-lite' )` is untranslated.

Callers keep the last word: an explicit `emptyTitle`, `filter.labels` or per-action `confirmMessage` still wins, and a caller-supplied `empty` element bypasses the default entirely. plugin-ui's compound sub-components (`DataViews.Pagination`, `.Layout`, `.Search`, `.Filters`, `.BulkActionToolbar`) stay reachable through the Dokan export.

**Not fixable from this side:** plugin-ui hardcodes the `Scroll tabs left` / `Scroll tabs right` aria-labels with no prop to override them. Those need an upstream change in `getdokan/plugin-ui` (ideally: make plugin-ui take a configurable text domain instead of `default`), at which point this wrapper can be retired — the code says so, and names the plugin-ui version it was written against, so the next bump prompts a re-audit.

### Closes

* Closes getdokan/dokan-pro#6027

### Scope note — the second string in #6027 is not a code bug

The issue reports two strings. The one above was a real defect. The other:

> No payment methods found to submit a withdrawal request. Please set up your payment methods first.

…is **already translatable and needs no change**. It is wrapped correctly in `src/dashboard/withdraw/RequestWithdrawBtn.tsx` (lines 266 and 275), it *is* extracted — `languages/dokan-lite.pot:15824`, sourced from `assets/js/frontend.js` — and it renders translated the moment a `msgstr` exists. Verified at runtime in `bn_BD` on a vendor-dashboard page:

```js
wp.i18n.__( 'No payment methods found to submit a withdrawal request.', 'dokan-lite' );
// → "উত্তোলনের অনুরোধ জমা দেওয়ার জন্য কোনো পেমেন্ট পদ্ধতি পাওয়া যায়নি।"
```

The reporter's `msgstr` for it was simply empty. Legacy pages behave the same — the legacy withdraw modal and the reverse-withdrawal empty state both translate once filled in. So this PR closes #6027 by fixing the half that was a defect and documenting the half that was not; **QA should not expect a code change for the withdraw notice.**

### Note for translators

`No data found`, `Add Filter` and `Remove filter` are already msgids in `dokan-lite.pot`, so **existing translations light up immediately** — no new translation work, which is why the fix shows up with no change to the language files at all. `Are you sure? This action cannot be undone.` is a new msgid and lands in the POT at the next release regeneration (the POT is only rebuilt in `chore: Release version` commits, never in feature PRs).

### How to test the changes in this Pull Request:

1. Install Loco Translate, set the site language to a locale with an incomplete WordPress translation — `bn_BD` was used here.
2. In Loco, open **Plugins → Dokan (dokan-lite) → your locale** and translate `No data found`. Save (Loco recompiles the MO **and** the JSON).
3. Log in as a vendor and open a list with no rows — `/dashboard/new/#/withdraw-requests` (Lite) or `/dashboard/new/#/reviews` → **Spam (0)** (Pro).
4. **Before:** the empty state reads `No data found` in English while the rest of the page is translated. **After:** it shows the translation.
5. Confirm no regression: the search placeholder must still be translated (it comes from core), and the row `⋮` actions menu must still open.

Quick console check on any vendor-dashboard page — the first is the bug, the second is what renders now:

```js
wp.i18n.__( 'No data found', 'default' );      // untranslated → the bug
wp.i18n.__( 'No data found', 'dokan-lite' );   // translated  → what renders now
```

### Changelog entry

*Fix – Untranslatable strings in the vendor dashboard list views*

Empty-state, filter and delete-confirmation labels in the vendor dashboard lists were registered under WordPress core's text domain instead of Dokan's, so they could not be translated — `No data found` stayed in English on Withdraw, Coupons, Reviews, Return Requests and every other list no matter how completely a marketplace was translated. These labels are now registered under Dokan's own text domain and translate along with the rest of the dashboard. Marketplaces that already translated `No data found` get the fix with no new translation work.

### Before Changes

Site language `bn_BD`, `No data found` **already translated** in `dokan-lite-bn_BD.po` (and compiled into the JSON) — `/dashboard/new/#/withdraw-requests`, Pending Requests (0). The heading `প্রত্যাহার করুন` is translated, the empty state below it is not:

> **No data found**

### After Changes

Same page, same translation file, no change to the language files — the empty state now renders the translation:

> **কোন ডেটা পাওয়া যায়নি**

Verified live in `bn_BD`, every string this PR touches plus every one it deliberately leaves alone:

| Checked | Renders | Source domain |
|---|---|---|
| `No data found` — Lite, `#/withdraw-requests` → Pending (0) | কোন ডেটা পাওয়া যায়নি | `dokan-lite` ✅ |
| `No data found` — Pro, `#/reviews` → Spam (0), **no Pro rebuild** | কোন ডেটা পাওয়া যায়নি | `dokan-lite` ✅ |
| `Remove filter` — filter bar | ফিল্টার সরান | `dokan-lite` ✅ |
| `Add Filter` — `#/products` filter bar | ফিল্টার যোগ করুন | `dokan-lite` ✅ |
| `Are you sure? …` — Reviews → Trash dialog | আপনি কি নিশ্চিত? এই কাজটি ফিরিয়ে আনা যাবে না। | `dokan-lite` ✅ |
| `Reset` — filter bar | রিসেট | core, **still translated** ✅ |
| `Cancel` — confirm dialog | বাতিল | core, **still translated** ✅ |
| `Search` — list search box | অনুসন্ধান | core, **still translated** ✅ |

No regression: the row `⋮` actions menu still opens, and the three core-owned labels above would each have *lost* their translation had they been re-homed.

<!-- Screenshots to attach: before/after of the withdraw-requests empty state, and the Pro Reviews → Spam empty state. -->
