### PR TITLE
fix(settings): admin settings UI issues on the flat-array screens

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1399,6 +1399,10 @@ class SettingsSchema {
                 'subpage_id'  => 'vendor_onboarding',
                 'title'       => esc_html__( 'Vendor Setup Wizard Message', 'dokan-lite' ),
                 'description' => esc_html__( 'Welcome message shown to vendors during setup.', 'dokan-lite' ),
+                // Carries the legacy default verbatim: with no default the field
+                // rendered empty and the first save of an untouched page replaced
+                // the shipped welcome copy with a blank string.
+                'default'     => __( 'Thank you for choosing The Marketplace to power your online store! This quick setup wizard will help you configure the basic settings. <strong>It’s completely optional and shouldn’t take longer than two minutes.</strong>', 'dokan-lite' ),
                 'legacy_key'    => [
                     'option' => 'dokan_general',
                     'field'  => 'setup_wizard_message',
@@ -1901,7 +1905,7 @@ class SettingsSchema {
                 'section_id'    => 'dokan_font_section',
                 'title'         => esc_html__( 'Dokan font-awesome Functionality', 'dokan-lite' ),
                 'description'   => esc_html__( "If disabled then Dokan font-awesome library won't be loaded in frontend.", 'dokan-lite' ),
-                'default'       => 'off',
+                'default'       => 'on',
                 'enable_state'  => [
 					'label' => esc_html__( 'Enable', 'dokan-lite' ),
 					'value' => 'on',
@@ -2091,6 +2095,10 @@ class SettingsSchema {
                 'section_id' => 'privacy_policy_section',
                 'title'      => esc_html__( 'Privacy Policy Content', 'dokan-lite' ),
                 'description' => esc_html__( 'Create or edit your privacy policy text that will be displayed to users.', 'dokan-lite' ),
+                // Carries the legacy default verbatim: with no default the field
+                // rendered empty and the first save of an untouched page replaced
+                // the shipped policy text with a blank string.
+                'default'    => __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [dokan_privacy_policy]', 'dokan-lite' ),
                 'legacy_key' => [
 					'option' => 'dokan_privacy',
 					'field' => 'privacy_policy',

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2126,6 +2126,10 @@ class SettingsSchema {
                 'id'         => 'data_clear_section',
                 'type'       => 'section',
                 'subpage_id' => 'privacy',
+                // Renders the section card itself in destructive tones. The
+                // danger_switch field inside draws no card of its own, so this
+                // is what gives the block its red border and background.
+                'is_danger'  => true,
             ],
             [
                 'id'             => 'data_clear_on_uninstall',

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2056,6 +2056,7 @@ class SettingsSchema {
                 'section_id' => 'privacy_settings',
                 'title'      => esc_html__( 'Privacy Policy Page', 'dokan-lite' ),
                 'description' => esc_html__( 'Choose which page displays your privacy policy.', 'dokan-lite' ),
+                'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
                 'options'    => self::get_lazy_page_options(),
                 'legacy_key' => [
 					'option' => 'dokan_privacy',

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -1343,7 +1343,7 @@ class SettingsSchema {
                 'title'         => esc_html__( 'Address Fields', 'dokan-lite' ),
                 'description'   => esc_html__( 'Add Address Fields on the Vendor Registration form.', 'dokan-lite' ),
                 'tooltip'       => esc_html__( 'Add Address Fields on the Vendor Registration form.', 'dokan-lite' ),
-                'default'       => 'on',
+                'default'       => 'off',
                 'enable_state'  => [
 					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
 					'value' => 'on',
@@ -1449,7 +1449,7 @@ class SettingsSchema {
                 'title'         => esc_html__( 'One Page Product Creation', 'dokan-lite' ),
                 'description'   => esc_html__( 'Add new product in single page view.', 'dokan-lite' ),
                 'tooltip'       => esc_html__( 'If disabled, instead of a single add product page it will open a pop up window or vendor will redirect to product page when adding new product.', 'dokan-lite' ),
-                'default'       => 'off',
+                'default'       => 'on',
                 'enable_state'  => [
 					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
 					'value' => 'on',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8706,7 +8706,7 @@
     },
     "node_modules/@wedevs/plugin-ui": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/getdokan/plugin-ui.git#3404c77c543bed1990c6edd9fad4726d8d97cbb3",
+      "resolved": "git+ssh://git@github.com/getdokan/plugin-ui.git#49abb30d69302e6e803f74a7a307ef2734aad690",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.1.0",
@@ -9005,6 +9005,18 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@wedevs/plugin-ui/node_modules/@wordpress/ui/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wedevs/plugin-ui/node_modules/lucide-react": {
@@ -26181,7 +26193,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/src/admin/dashboard/pages/settings/index.tsx
+++ b/src/admin/dashboard/pages/settings/index.tsx
@@ -1,17 +1,25 @@
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import apiFetch from '@wordpress/api-fetch';
 import {
     Settings,
     useSettings,
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
     Button,
     Spinner,
     Toaster,
     toast,
     type SettingsElement,
 } from '@wedevs/plugin-ui';
-import { useSearchParams } from 'react-router-dom';
+import { useBlocker, useSearchParams } from 'react-router-dom';
 import { registerSettingsFields } from './register-fields';
 
 // Side effect: register custom field renderers exactly once when this module
@@ -99,6 +107,21 @@ export default function SettingsPage() {
     const [ schema, setSchema ] = useState< SettingsElement[] >( [] );
     const [ loading, setLoading ] = useState< boolean >( true );
     const [ saving, setSaving ] = useState< boolean >( false );
+    const [ hasUnsavedChanges, setHasUnsavedChanges ] =
+        useState< boolean >( false );
+
+    // Plugin-ui guards its own sidebar navigation and the browser unload, but it
+    // can't see this app's router. Block route changes here while settings are
+    // dirty. Compare pathnames only — UrlSync rewrites the query string on every
+    // subpage switch, and those must not trip the guard.
+    const blocker = useBlocker(
+        useCallback(
+            ( { currentLocation, nextLocation } ) =>
+                hasUnsavedChanges &&
+                currentLocation.pathname !== nextLocation.pathname,
+            [ hasUnsavedChanges ]
+        )
+    );
 
     useEffect( () => {
         apiFetch< SettingsElement[] >( { path: '/dokan/v1/admin/settings' } )
@@ -166,6 +189,16 @@ export default function SettingsPage() {
                 onSave={ handleSave }
                 initialPage={ initialPage }
                 onNavigate={ handleNavigate }
+                onDirtyChange={ setHasUnsavedChanges }
+                unsavedChangesDialog={ {
+                    title: __( 'Unsaved changes', 'dokan-lite' ),
+                    description: __(
+                        'You have unsaved changes on this page. Leaving now discards them.',
+                        'dokan-lite'
+                    ),
+                    confirmText: __( 'Discard and leave', 'dokan-lite' ),
+                    cancelText: __( 'Stay on this page', 'dokan-lite' ),
+                } }
                 renderSaveButton={ ( { dirty, hasErrors, onSave } ) => (
                     <>
                         <UrlSync />
@@ -181,6 +214,42 @@ export default function SettingsPage() {
                     </>
                 ) }
             />
+
+            { /* Route-change guard: leaving the settings screen entirely. */ }
+            <AlertDialog
+                open={ blocker.state === 'blocked' }
+                onOpenChange={ ( open: boolean ) => {
+                    if ( ! open ) {
+                        blocker.reset?.();
+                    }
+                } }
+            >
+                <AlertDialogContent data-testid="settings-route-guard-dialog">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            { __( 'Unsaved changes', 'dokan-lite' ) }
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            { __(
+                                'You have unsaved settings changes. Leaving this page discards them.',
+                                'dokan-lite'
+                            ) }
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={ () => blocker.reset?.() }>
+                            { __( 'Stay on this page', 'dokan-lite' ) }
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                            variant="destructive"
+                            onClick={ () => blocker.proceed?.() }
+                        >
+                            { __( 'Discard and leave', 'dokan-lite' ) }
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
             <Toaster richColors />
         </>
     );

--- a/src/components/commission/CommissionInputs.tsx
+++ b/src/components/commission/CommissionInputs.tsx
@@ -53,7 +53,7 @@ const CommissionInputs: React.FC< CommissionInputsProps > = ( {
                             isAllCategory
                         )
                     }
-                    className={ `w-full h-10 pl-6  text-sm bg-white focus:border-[#7047EB] focus:ring-1 focus:ring-[#7047EB]/20 transition-colors placeholder-[#828282] text-[#575757] !border-r-0 !rounded-r-none` }
+                    className={ `w-full h-10 pl-6  text-sm bg-white focus:border-[#7047EB] focus:ring-1 focus:ring-[#7047EB]/20 transition-colors placeholder-[#828282] text-[#575757] !m-0 !border-r-0 !rounded-r-none` }
                     maskRule={ {
                         numeral: true,
                         delimiter: currency.thousand,
@@ -91,7 +91,10 @@ const CommissionInputs: React.FC< CommissionInputsProps > = ( {
                         numeralDecimalMark: currency.decimal,
                         numeralDecimalScale: currency.precision,
                     } }
-                    className={ `w-full h-10 pl-6 pr-3 text-sm  rounded-r-[3px] bg-white focus:border-[#7047EB] focus:ring-1 focus:ring-[#7047EB]/20 transition-colors placeholder-[#828282] text-[#575757] !border-l-0 !rounded-l-none` }
+                    // Left border stays: dokan-ui's addOnLeft span already ships
+                    // `border-r-0`, so removing this side too leaves a 1px hole
+                    // at the seam rather than a single shared line.
+                    className={ `w-full h-10 pl-6 pr-3 text-sm  rounded-r-[3px] bg-white focus:border-[#7047EB] focus:ring-1 focus:ring-[#7047EB]/20 transition-colors placeholder-[#828282] text-[#575757] !m-0 !rounded-l-none` }
                 />
             </div>
         </div>

--- a/src/components/commission/FixedCommissionInput.tsx
+++ b/src/components/commission/FixedCommissionInput.tsx
@@ -182,7 +182,10 @@ const FixedCommissionInput = ( {
                                 numeralDecimalMark: currency?.decimal ?? '.',
                                 numeralDecimalScale: currency?.precision ?? 2,
                             } }
-                            className={ `w-24 h-10 rounded focus:border-gray-300 focus:ring-0 !border-r-0 !rounded-r-none` }
+                            // `!m-0` kills WordPress admin's `input { margin: 0 1px }`,
+                            // which otherwise pushes a 1px gap into the seam with
+                            // the addon and breaks the shared frame.
+                            className={ `w-24 h-10 rounded focus:border-gray-300 focus:ring-0 !m-0 !border-r-0 !rounded-r-none` }
                         />
 
                         <div className="text-gray-500 text-lg">
@@ -201,7 +204,11 @@ const FixedCommissionInput = ( {
                                 numeralDecimalMark: currency?.decimal ?? '.',
                                 numeralDecimalScale: currency?.precision ?? 2,
                             } }
-                            className={ `w-24 h-10 rounded focus:border-gray-300 focus:ring-0 !border-l-0 !rounded-l-none` }
+                            // Keep the left border — dokan-ui's addOnLeft span ships
+                            // `border-r-0`, so the input has to draw the seam — and
+                            // `!m-0` removes WP admin's 1px input margin that would
+                            // otherwise hold the two halves apart.
+                            className={ `w-24 h-10 rounded focus:border-gray-300 focus:ring-0 !m-0 !rounded-l-none` }
                         />
                     </>
                 ) }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

A batch of admin settings UI fixes on top of the flat-array schema work.

**Data Clear Consent renders one card, not two** — `data_clear_section` now
carries `'is_danger' => true`. The `danger_switch` field used to draw its own
destructive card inside the section card the renderer already draws, so the block
showed two borders a pixel apart. Plugin UI drops the field's own chrome (see the
related PR); this flag is what gives the block its red border and background.

**Schema defaults match the legacy readers** — three commits align `default`
values in the schema with the fallbacks the option readers have always used, so a
site that never saved a value renders the same before and after the migration,
and adds the missing "Select page" placeholder on the privacy policy page field.

**Unsaved changes warning** — leaving the settings screen with pending edits now
prompts before discarding them.

**Commission combined inputs** — closes the 1px seam between the two halves of
the combined fixed/percentage input.

### Related Pull Request(s)

* https://github.com/getdokan/plugin-ui/pull/104 (danger switch layout,
  radius consistency, rich-text toolbar chevrons). The Data Clear Consent block
  needs both PRs to look right.

### How to test the changes in this Pull Request:

1. Check out this branch with the matching plugin-ui build and run `npm run build`.
2. Dokan → Settings → Compliance → Privacy → **Data Clear Consent**: a single
   destructive-tinted border, description wrapping to a readable measure, radius
   matching the Admin Area Access card above it.
3. Same page → **Privacy Policy Content**: field offers a "Select page"
   placeholder.
4. Edit any field, then navigate away without saving — a confirmation appears.
5. Settings → Selling Options → commission: the combined fixed/percentage input
   shows no seam between its halves.
6. On a site that has never saved Dokan settings, compare rendered field values
   before and after this branch — they should be identical.

### Changelog entry

*Fix: Admin settings UI issues on the new settings screens*

Previously the Data Clear Consent block rendered a destructive card nested inside
the section card, producing a doubled border; several fields fell back to defaults
that differed from what the legacy option readers returned; leaving the settings
screen silently discarded unsaved edits; and the combined commission input showed
a 1px seam between its two halves. Those are fixed — the danger block is now a
single card driven by the section's `is_danger` flag, schema defaults match the
reader fallbacks, unsaved changes prompt before discarding, and the commission
input renders seamlessly.

### Verified

* `composer phpcs includes/Admin/Settings/Schema/SettingsSchema.php` — clean
* `npm run build` — clean
* Checked in a live WP admin: the danger block resolves to one border, matching
  the radius of its sibling section cards.
