### PR TITLE
Restyle the Vendor order details panel — items, totals, refund and shipments

### DIFF
--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -470,6 +470,16 @@ jQuery(function($) {
                 .datepicker({
                     dateFormat: datepickerFormat
                 });
+
+            // Download access-expiry fields, on the same site date format as above so a
+            // picked date reads the way every other date on the page does.
+            $( scope || document )
+                .find( 'input.datepicker' )
+                .addBack( 'input.datepicker' )
+                .filter( ':not(.hasDatepicker)' )
+                .datepicker({
+                    dateFormat: datepickerFormat
+                });
         },
 
         showTrackingForm: function(e) {

--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -471,18 +471,12 @@ jQuery(function($) {
                     dateFormat: datepickerFormat
                 });
 
-            // Download access-expiry fields, which script.js binds at DOM-ready and so
-            // misses entirely once the fragment is injected. Kept inside the permissions
-            // block on purpose: `input.datepicker` is script.js's own selector, and since
-            // jQuery UI keeps whichever binding lands first, matching it at page scope
-            // would take every sale-price and coupon date field on the dashboard and
-            // rebind it to a different format than the ISO their `pattern` accepts.
+            // Scoped to the permissions block rather than `input.datepicker` at page scope: that selector is script.js's own, and jQuery UI keeps whichever binding lands first, so a page-wide match would rebind every sale-price and coupon date field on the dashboard to a format their `pattern` rejects.
             $( scope || document )
                 .find( '.order_download_permissions input.datepicker' )
                 .filter( ':not(.hasDatepicker)' )
                 .datepicker({
-                    // The format script.js gives these fields on the legacy page, so the
-                    // two surfaces read and write the same thing.
+                    // The format script.js gives these fields on the legacy page, so both surfaces read and write the same thing.
                     dateFormat: 'yy-mm-dd'
                 });
         },

--- a/assets/src/js/orders.js
+++ b/assets/src/js/orders.js
@@ -413,7 +413,7 @@ jQuery(function($) {
         },
 
         /**
-         * Attach the shipped-date picker.
+         * Attach the order details date pickers.
          *
          * Runs at DOM-ready on the legacy page and again whenever the order details
          * fragment is injected into the Vendor panel.
@@ -471,14 +471,19 @@ jQuery(function($) {
                     dateFormat: datepickerFormat
                 });
 
-            // Download access-expiry fields, on the same site date format as above so a
-            // picked date reads the way every other date on the page does.
+            // Download access-expiry fields, which script.js binds at DOM-ready and so
+            // misses entirely once the fragment is injected. Kept inside the permissions
+            // block on purpose: `input.datepicker` is script.js's own selector, and since
+            // jQuery UI keeps whichever binding lands first, matching it at page scope
+            // would take every sale-price and coupon date field on the dashboard and
+            // rebind it to a different format than the ISO their `pattern` accepts.
             $( scope || document )
-                .find( 'input.datepicker' )
-                .addBack( 'input.datepicker' )
+                .find( '.order_download_permissions input.datepicker' )
                 .filter( ':not(.hasDatepicker)' )
                 .datepicker({
-                    dateFormat: datepickerFormat
+                    // The format script.js gives these fields on the legacy page, so the
+                    // two surfaces read and write the same thing.
+                    dateFormat: 'yy-mm-dd'
                 });
         },
 

--- a/assets/src/less/orders.less
+++ b/assets/src/less/orders.less
@@ -6,18 +6,13 @@
         .dokan-order-left-content {
             margin-right: 3%;
 
-            // Both columns are shrink-to-fit floats, so `min-width` only set a floor and
-            // the content decided the real width. A long address made its column wider
-            // than half the row, the pair no longer fit, and the shipping block dropped to
-            // a line of its own. An explicit width makes it a real pair; the 1px keeps the
-            // total just under 100% so sub-pixel rounding cannot push it over again.
+            // These are shrink-to-fit floats, so `min-width` let a long address outgrow half the row and drop shipping to its own line; the 1px keeps the pair under 100% against rounding.
             .dokan-order-billing-address,
             .dokan-order-shipping-address {
                 width: ~"calc(49% - 1px)";
                 min-width: 0;
 
-                // A single unbroken word — some place names and reference numbers are very
-                // long — would otherwise overflow a column that can no longer grow.
+                // A single unbroken word — long place names, reference numbers — would overflow a column that can no longer grow.
                 .dokan-panel-body {
                     overflow-wrap: anywhere;
                 }

--- a/assets/src/less/orders.less
+++ b/assets/src/less/orders.less
@@ -6,13 +6,25 @@
         .dokan-order-left-content {
             margin-right: 3%;
 
-            .dokan-order-billing-address {
-                min-width: 49%;
-                margin-right:2%;
+            // Both columns are shrink-to-fit floats, so `min-width` only set a floor and
+            // the content decided the real width. A long address made its column wider
+            // than half the row, the pair no longer fit, and the shipping block dropped to
+            // a line of its own. An explicit width makes it a real pair; the 1px keeps the
+            // total just under 100% so sub-pixel rounding cannot push it over again.
+            .dokan-order-billing-address,
+            .dokan-order-shipping-address {
+                width: ~"calc(49% - 1px)";
+                min-width: 0;
+
+                // A single unbroken word — some place names and reference numbers are very
+                // long — would otherwise overflow a column that can no longer grow.
+                .dokan-panel-body {
+                    overflow-wrap: anywhere;
+                }
             }
 
-            .dokan-order-shipping-address {
-                min-width: 49%;
+            .dokan-order-billing-address {
+                margin-right:2%;
             }
         }
 

--- a/assets/src/less/rtl.less
+++ b/assets/src/less/rtl.less
@@ -82,9 +82,7 @@
                 margin-right: 0;
                 margin-left: 3%;
 
-                // Width comes from the LTR rule; only the gutter side flips. The floor is
-                // cleared here too, or it would put back the minimum that made the pair
-                // outgrow its row.
+                // Only the gutter side flips — width comes from the LTR rule; the floor is cleared here too or it puts back the minimum that outgrew the row.
                 .dokan-order-billing-address {
                     min-width: 0;
                     margin-right:0;

--- a/assets/src/less/rtl.less
+++ b/assets/src/less/rtl.less
@@ -82,15 +82,10 @@
                 margin-right: 0;
                 margin-left: 3%;
 
-                // Only the gutter side flips — width comes from the LTR rule; the floor is cleared here too or it puts back the minimum that outgrew the row.
+                // Only the gutter side flips; the width and its cleared floor both come from the LTR rule, which is not direction-scoped.
                 .dokan-order-billing-address {
-                    min-width: 0;
                     margin-right:0;
                     margin-left:2%;
-                }
-
-                .dokan-order-shipping-address {
-                    min-width: 0;
                 }
             }
         }

--- a/assets/src/less/rtl.less
+++ b/assets/src/less/rtl.less
@@ -82,14 +82,17 @@
                 margin-right: 0;
                 margin-left: 3%;
 
+                // Width comes from the LTR rule; only the gutter side flips. The floor is
+                // cleared here too, or it would put back the minimum that made the pair
+                // outgrow its row.
                 .dokan-order-billing-address {
-                    min-width: 49%;
+                    min-width: 0;
                     margin-right:0;
                     margin-left:2%;
                 }
 
                 .dokan-order-shipping-address {
-                    min-width: 49%;
+                    min-width: 0;
                 }
             }
         }

--- a/includes/Admin/Dashboard/LegacySwitcher.php
+++ b/includes/Admin/Dashboard/LegacySwitcher.php
@@ -205,6 +205,49 @@ class LegacySwitcher implements Hookable {
     }
 
     /**
+     * Whether the given user prefers the legacy order list and order details.
+     *
+     * Defaults to `false` — the new (React) order list with in-panel details. That is the
+     * opposite of the product editor's default on purpose: in-panel order details shipped
+     * on for everyone before this setting existed, so defaulting to legacy here would take
+     * a working screen away from sites that never asked for the change.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int $user_id Optional. Defaults to current user.
+     *
+     * @return bool
+     */
+    public function is_order_details_legacy_preferred( int $user_id = 0 ): bool {
+        if ( ! $user_id ) {
+            $user_id = get_current_user_id();
+        }
+
+        // Anonymous context (cron, emails without a current user) → prefer the new list.
+        if ( ! $user_id ) {
+            return false;
+        }
+
+        $appearance = get_option( 'dokan_appearance', [] );
+
+        return isset( $appearance['vendor_order_details'] ) && 'legacy' === $appearance['vendor_order_details'];
+    }
+
+    /**
+     * Build the new (React) order details URL.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param int $order_id
+     *
+     * @return string
+     */
+    public function get_new_order_details_url( int $order_id ): string {
+        // `dokan_get_navigation_url( 'orders', true )` already ends with `#orders/`.
+        return dokan_get_navigation_url( 'orders', true ) . $order_id;
+    }
+
+    /**
      * Build the new (React) product editor URL.
      *
      * @since 5.0.0

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -849,6 +849,18 @@ class Settings {
                         'legacy' => esc_html__( 'Legacy UI', 'dokan-lite' ),
                     ],
                 ],
+                'vendor_order_details'         => [
+                    'name'    => 'vendor_order_details',
+                    'label'   => esc_html__( 'Vendor Order Details', 'dokan-lite' ),
+                    'desc'    => esc_html__( 'Select the user interface for the vendor order list and order details.', 'dokan-lite' ),
+                    'type'    => 'radio',
+                    // `latest` where the product editor defaults to `legacy`: the in-panel order details were already on for everyone before this setting existed, so defaulting to legacy would take a working screen away on upgrade.
+                    'default' => 'latest',
+                    'options' => [
+                        'latest' => esc_html__( 'New UI', 'dokan-lite' ),
+                        'legacy' => esc_html__( 'Legacy UI', 'dokan-lite' ),
+                    ],
+                ],
                 'show_register_as_vendor'      => [
                     'name'    => 'show_register_as_vendor',
                     'label'   => esc_html__( 'Show "Register as a Vendor" in Sign Up Page', 'dokan-lite' ),

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -830,7 +830,6 @@ class Assets {
         // load dokan style on every pages. requires for shortcodes in other pages
         if ( DOKAN_LOAD_STYLE ) {
             wp_enqueue_style( 'dokan-style' );
-            wp_add_inline_style( 'dokan-style', $this->get_currency_symbol_custom_property() );
             wp_enqueue_style( 'dokan-modal' );
             if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
                 wp_enqueue_style( 'dokan-fontawesome' );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -790,36 +790,6 @@ class Assets {
     }
 
     /**
-     * Expose the store's currency symbol to CSS as a custom property.
-     *
-     * Some controls need the symbol as an affix — a refund amount field reads as a bare
-     * number without one — and those fields are rendered by templates this plugin does
-     * not own, so the symbol cannot be added to their markup. A custom property lets a
-     * stylesheet place it with `content` and keeps the value where it belongs: with the
-     * store, not hard-coded per theme.
-     *
-     * @since DOKAN_SINCE
-     *
-     * @return string
-     */
-    protected function get_currency_symbol_custom_property() {
-        // The symbol arrives HTML-encoded (`&#2547;` for BDT, `&pound;` for GBP), which
-        // `content` would print literally.
-        $symbol = html_entity_decode( get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8' );
-
-        // Nothing in a currency symbol needs angle brackets; dropping them keeps the value
-        // from being able to close the style element it is printed into.
-        $symbol = str_replace( [ '<', '>' ], '', $symbol );
-
-        // JSON quoting is the right shape for a CSS string, but only with the unicode left
-        // alone — `\u09f3` is a JSON escape, and CSS would print those six characters.
-        return sprintf(
-            ':root{--dokan-currency-symbol:%s}',
-            wp_json_encode( $symbol, JSON_UNESCAPED_UNICODE )
-        );
-    }
-
-    /**
      * Enqueue front-end scripts
      */
     public function enqueue_front_scripts() {

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -790,6 +790,36 @@ class Assets {
     }
 
     /**
+     * Expose the store's currency symbol to CSS as a custom property.
+     *
+     * Some controls need the symbol as an affix — a refund amount field reads as a bare
+     * number without one — and those fields are rendered by templates this plugin does
+     * not own, so the symbol cannot be added to their markup. A custom property lets a
+     * stylesheet place it with `content` and keeps the value where it belongs: with the
+     * store, not hard-coded per theme.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return string
+     */
+    protected function get_currency_symbol_custom_property() {
+        // The symbol arrives HTML-encoded (`&#2547;` for BDT, `&pound;` for GBP), which
+        // `content` would print literally.
+        $symbol = html_entity_decode( get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8' );
+
+        // Nothing in a currency symbol needs angle brackets; dropping them keeps the value
+        // from being able to close the style element it is printed into.
+        $symbol = str_replace( [ '<', '>' ], '', $symbol );
+
+        // JSON quoting is the right shape for a CSS string, but only with the unicode left
+        // alone — `\u09f3` is a JSON escape, and CSS would print those six characters.
+        return sprintf(
+            ':root{--dokan-currency-symbol:%s}',
+            wp_json_encode( $symbol, JSON_UNESCAPED_UNICODE )
+        );
+    }
+
+    /**
      * Enqueue front-end scripts
      */
     public function enqueue_front_scripts() {
@@ -800,6 +830,7 @@ class Assets {
         // load dokan style on every pages. requires for shortcodes in other pages
         if ( DOKAN_LOAD_STYLE ) {
             wp_enqueue_style( 'dokan-style' );
+            wp_add_inline_style( 'dokan-style', $this->get_currency_symbol_custom_property() );
             wp_enqueue_style( 'dokan-modal' );
             if ( 'off' === dokan_get_option( 'disable_dokan_fontawesome', 'dokan_appearance', 'off' ) ) {
                 wp_enqueue_style( 'dokan-fontawesome' );

--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -983,16 +983,20 @@ function dokan_apply_bulk_order_status_change( $postdata ) {
 /**
  * Whether the Vendor panel opens order details in-panel.
  *
- * On by default: a Vendor clicking an order in the panel stays in the panel. Turning it
- * off sends the order list back to full-page navigation to the legacy order details URL.
- * That URL never stops working, so reverting is free — no data migration, no routing
- * consequences, and links already sitting in Vendors' inboxes keep resolving either way.
+ * Driven by Appearance → Vendor Order Details, so a store can put the whole order UI back
+ * on the legacy pages the same way it can for the product editor. The legacy URL never
+ * stops working, so switching is free either way — no data migration, no routing
+ * consequences, and links already sitting in Vendors' inboxes keep resolving.
  *
  * @since DOKAN_SINCE
  *
  * @return bool
  */
 function dokan_is_vendor_panel_order_details_enabled(): bool {
+    $enabled = ! dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Dashboard\LegacySwitcher::class )
+        ->is_order_details_legacy_preferred();
+
     /**
      * Filters whether the Vendor panel renders order details in-panel.
      *
@@ -1002,5 +1006,5 @@ function dokan_is_vendor_panel_order_details_enabled(): bool {
      *
      * @param bool $enabled Whether the in-panel order details route is enabled.
      */
-    return (bool) apply_filters( 'dokan_vendor_panel_order_details_enabled', true );
+    return (bool) apply_filters( 'dokan_vendor_panel_order_details_enabled', $enabled );
 }

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -912,8 +912,9 @@ class OrderController extends DokanRESTController {
     /**
      * Resolve the order a fragment request is asking for.
      *
-     * A trashed order is treated as missing so the panel gets a clean error rather
-     * than a blank view.
+     * Trashed orders are resolved like any other: the legacy order details page renders
+     * them, and the panel is the same view, so refusing them here would lose access to an
+     * order the Vendor can still open elsewhere.
      *
      * @since DOKAN_SINCE
      *
@@ -924,7 +925,7 @@ class OrderController extends DokanRESTController {
     protected function get_viewable_order( $request ) {
         $order = wc_get_order( absint( $request['id'] ) );
 
-        if ( ! $order || 'trash' === $order->get_status() ) {
+        if ( ! $order ) {
             return new WP_Error(
                 'dokan_rest_invalid_order_id',
                 __( 'Invalid Order ID.', 'dokan-lite' ),

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -912,9 +912,7 @@ class OrderController extends DokanRESTController {
     /**
      * Resolve the order a fragment request is asking for.
      *
-     * Trashed orders are resolved like any other: the legacy order details page renders
-     * them, and the panel is the same view, so refusing them here would lose access to an
-     * order the Vendor can still open elsewhere.
+     * Trashed orders resolve like any other — the legacy page renders them, and refusing them here would lose access to an order the Vendor can still open elsewhere.
      *
      * @since DOKAN_SINCE
      *

--- a/includes/functions-dashboard-navigation.php
+++ b/includes/functions-dashboard-navigation.php
@@ -34,6 +34,9 @@ function dokan_get_dashboard_nav(): array {
     // TODO: Drop this toggle once the legacy product pages are removed — then always register the new (React) product page.
     $use_new_product_ui = ! dokan_get_container()->get( LegacySwitcher::class )->is_product_editor_legacy_preferred();
 
+    // Same idea for orders: the "Vendor Order Details" setting drives the list menu too, so the legacy details page is always reached from the legacy list rather than from the React one.
+    $use_new_order_ui = ! dokan_get_container()->get( LegacySwitcher::class )->is_order_details_legacy_preferred();
+
     $menus = [
         'dashboard' => [
             'title'      => __( 'Dashboard', 'dokan-lite' ),
@@ -54,11 +57,12 @@ function dokan_get_dashboard_nav(): array {
         'orders'    => [
             'title'       => __( 'Orders', 'dokan-lite' ),
             'icon'        => '<i class="fas fa-shopping-cart"></i>',
-            'url'         => dokan_get_navigation_url( 'orders' ),
+            'url'         => dokan_get_navigation_url( 'orders', $use_new_order_ui ),
             'pos'         => 50,
             'icon_name'   => 'ShoppingCart',
             'permission'  => 'dokan_view_order_menu',
-            'react_route' => 'orders',
+            // Only a React route while the new order UI is on. On legacy this has to be empty or `VendorNavMenuChecker` rewrites the URL back to the panel and the setting has no effect — the products menu gets the same result by carrying no route at all.
+            'react_route' => $use_new_order_ui ? 'orders' : '',
         ],
         'withdraw'  => [
             'title'       => __( 'Withdraw', 'dokan-lite' ),

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -8,6 +8,7 @@ import {
     emitOrderDetailsEvent,
 } from './events';
 import type { OrderDetailsFragment, OrderDetailsInlineScript } from './types';
+import './order-details-fragment.scss';
 
 /**
  * Inline script elements this route currently has live in the document.
@@ -259,10 +260,21 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
     return (
         <div className="dokan-order-details-wrapper dokan-react-order-details">
             { isLoading && (
+                // Mirrors the rendered layout — two columns, 24px gaps, 320px sidebar —
+                // so the page does not visibly reflow once the fragment lands.
                 <div
-                    className="h-64 animate-pulse rounded-md bg-muted"
+                    className="flex flex-col gap-6 lg:flex-row"
                     aria-label={ __( 'Loading order details', 'dokan-lite' ) }
-                />
+                >
+                    <div className="flex flex-1 flex-col gap-6">
+                        <div className="h-72 animate-pulse rounded-md bg-gray-200" />
+                        <div className="h-40 animate-pulse rounded-md bg-gray-200" />
+                    </div>
+                    <div className="flex w-full flex-col gap-6 lg:w-80">
+                        <div className="h-52 animate-pulse rounded-md bg-gray-200" />
+                        <div className="h-64 animate-pulse rounded-md bg-gray-200" />
+                    </div>
+                </div>
             ) }
             <div ref={ containerRef } />
         </div>

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -238,6 +238,49 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
         };
     }, [ orderId ] );
 
+    // Legacy links parts of the details view to in-page targets — the downloadable
+    // permission titles carry `href="#collapse-<id>"`, which on the legacy page simply
+    // jumps to that block. In the panel the hash *is* the route, so letting the browser
+    // follow one would navigate off the order entirely. The markup keeps its href, and
+    // the same jump happens here; only who performs it changes.
+    useEffect( () => {
+        const container = containerRef.current;
+
+        if ( ! container ) {
+            return;
+        }
+
+        const jumpWithoutLeavingTheRoute = ( event: MouseEvent ) => {
+            const anchor = ( event.target as Element )?.closest?.( 'a' );
+
+            if ( ! anchor || event.defaultPrevented ) {
+                return;
+            }
+
+            const href = anchor.getAttribute( 'href' ) ?? '';
+
+            // `#/…` is a panel route, which the router is entitled to handle.
+            if ( ! href.startsWith( '#' ) || href.startsWith( '#/' ) ) {
+                return;
+            }
+
+            event.preventDefault();
+
+            const targetId = href.slice( 1 );
+            const target = targetId
+                ? container.querySelector( `#${ CSS.escape( targetId ) }` )
+                : null;
+
+            target?.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+        };
+
+        container.addEventListener( 'click', jumpWithoutLeavingTheRoute );
+
+        return () => {
+            container.removeEventListener( 'click', jumpWithoutLeavingTheRoute );
+        };
+    }, [] );
+
     // Leaving the route entirely takes the render's inline data with it, so a later
     // visit cannot read a global belonging to an order the Vendor is no longer on.
     useEffect( () => {

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -11,6 +11,15 @@ import type { OrderDetailsFragment, OrderDetailsInlineScript } from './types';
 import './order-details-fragment.scss';
 
 /**
+ * Marks the page while this route is mounted.
+ *
+ * The stylesheet ships in the panel's single CSS bundle, which every dashboard route
+ * loads, so the rules that reach outside the fragment wrapper need a way to say "only
+ * on this route". This class is that switch — see `order-details-fragment.scss`.
+ */
+const ORDER_DETAILS_BODY_CLASS = 'dokan-order-details-active';
+
+/**
  * Inline script elements this route currently has live in the document.
  *
  * Keyed by handle + position + code, so re-rendering the same order reuses the
@@ -247,7 +256,7 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
         }
 
         const jumpWithoutLeavingTheRoute = ( event: MouseEvent ) => {
-            const anchor = ( event.target as Element )?.closest?.( 'a' );
+            const anchor = ( event.target as Element )?.closest( 'a' );
 
             if ( ! anchor || event.defaultPrevented ) {
                 return;
@@ -263,11 +272,12 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
             event.preventDefault();
 
             const targetId = href.slice( 1 );
-            const target = targetId
-                ? container.querySelector( `#${ CSS.escape( targetId ) }` )
-                : null;
 
-            target?.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+            if ( targetId ) {
+                container
+                    .querySelector( `#${ CSS.escape( targetId ) }` )
+                    ?.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+            }
         };
 
         container.addEventListener( 'click', jumpWithoutLeavingTheRoute );
@@ -279,8 +289,15 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
 
     // Leaving the route entirely takes the render's inline data with it, so a later
     // visit cannot read a global belonging to an order the Vendor is no longer on.
+    // The body class goes with it: the page-level rules that dress this view — the grey
+    // canvas, the panel header, the date picker and select2 — sit outside the fragment
+    // wrapper, and matching them on a class beats making `body` a `:has()` subject on
+    // every panel route that will never render this view.
     useEffect( () => {
+        document.body.classList.add( ORDER_DETAILS_BODY_CLASS );
+
         return () => {
+            document.body.classList.remove( ORDER_DETAILS_BODY_CLASS );
             syncInlineScripts( [] );
         };
     }, [] );
@@ -299,18 +316,18 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
     return (
         <div className="dokan-order-details-wrapper dokan-react-order-details">
             { isLoading && (
-                // Mirrors the rendered layout — two columns, 24px gaps, 320px sidebar — so the page does not visibly reflow once the fragment lands.
+                // Mirrors the rendered layout — two columns, 24px gaps, 320px sidebar — so the page does not visibly reflow once the fragment lands. The blocks sit a step above the grey canvas the route paints from mount, without going all the way to the white of a finished card.
                 <div
                     className="flex flex-col gap-6 lg:flex-row"
                     aria-label={ __( 'Loading order details', 'dokan-lite' ) }
                 >
                     <div className="flex flex-1 flex-col gap-6">
-                        <div className="h-72 animate-pulse rounded-md bg-gray-200" />
-                        <div className="h-40 animate-pulse rounded-md bg-gray-200" />
+                        <div className="h-72 animate-pulse rounded-md bg-gray-50" />
+                        <div className="h-40 animate-pulse rounded-md bg-gray-50" />
                     </div>
                     <div className="flex w-full flex-col gap-6 lg:w-80">
-                        <div className="h-52 animate-pulse rounded-md bg-gray-200" />
-                        <div className="h-64 animate-pulse rounded-md bg-gray-200" />
+                        <div className="h-52 animate-pulse rounded-md bg-gray-50" />
+                        <div className="h-64 animate-pulse rounded-md bg-gray-50" />
                     </div>
                 </div>
             ) }

--- a/src/dashboard/orders/OrderDetails.tsx
+++ b/src/dashboard/orders/OrderDetails.tsx
@@ -238,11 +238,7 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
         };
     }, [ orderId ] );
 
-    // Legacy links parts of the details view to in-page targets — the downloadable
-    // permission titles carry `href="#collapse-<id>"`, which on the legacy page simply
-    // jumps to that block. In the panel the hash *is* the route, so letting the browser
-    // follow one would navigate off the order entirely. The markup keeps its href, and
-    // the same jump happens here; only who performs it changes.
+    // Legacy in-page `#` links jump to a block, but here the hash *is* the route — letting the browser follow one would navigate off the order, so we do the jump instead.
     useEffect( () => {
         const container = containerRef.current;
 
@@ -303,8 +299,7 @@ const OrderDetails = ( { params }: { params?: { orderId?: string } } ) => {
     return (
         <div className="dokan-order-details-wrapper dokan-react-order-details">
             { isLoading && (
-                // Mirrors the rendered layout — two columns, 24px gaps, 320px sidebar —
-                // so the page does not visibly reflow once the fragment lands.
+                // Mirrors the rendered layout — two columns, 24px gaps, 320px sidebar — so the page does not visibly reflow once the fragment lands.
                 <div
                     className="flex flex-col gap-6 lg:flex-row"
                     aria-label={ __( 'Loading order details', 'dokan-lite' ) }

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -809,9 +809,15 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .tracking-status-other-p-url {
         float: left;
         width: calc((100% - 32px) / 3);
-        margin-inline-end: 16px;
+        // The start side is zeroed rather than left alone: Pro sets `margin-right` physically, which in RTL is no longer the side this logical gutter writes to, so both would apply and the third column would wrap.
+        margin-inline: 0 16px;
         margin-bottom: 0;
         overflow: visible;
+
+        // The gutter follows the writing direction but the float does not, so the columns have to be turned over by hand or they keep reading left-to-right inside an RTL page.
+        [dir="rtl"] & {
+            float: right;
+        }
     }
 
     // `padding`, not `margin`, because these blocks carry `clear: both` and a top margin is absorbed into the clearance and rendered as nothing; stated unconditionally rather than behind `:not(.dokan-hide)`, since jQuery's `.show()` leaves `dokan-hide` sitting on the element and that test never matched.

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -605,6 +605,22 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border-bottom: 0;
     }
 
+    // Shipping, fee and refund rows carry a Font Awesome glyph where a product has its
+    // picture. Left alone it renders at 14px against the text baseline; given the same
+    // 44px slot it lines up with the thumbnails above it.
+    .woocommerce_order_items td.thumb > div {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+
+        i {
+            font-size: 20px;
+            color: #6b6b6b;
+        }
+    }
+
     // 44px at a 3px radius with a hairline, and 16px of air before the name.
     .woocommerce_order_items td.thumb {
         // Border-box, so this has to carry the card inset and the gap as well as the
@@ -616,9 +632,15 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             display: block;
             width: 44px;
             height: 44px;
+            // A product with no image falls back to WooCommerce's placeholder, which is
+            // not present on every install. When it 404s the element collapses to its alt
+            // text and spills across the row, so the box holds its size and clips.
+            overflow: hidden;
+            background-color: #f3f4f6;
             border: 1px solid #e9e9e9;
             border-radius: 3px;
             object-fit: cover;
+            font-size: 0;
         }
     }
 
@@ -641,25 +663,39 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Money and counts get fixed columns so they stop bunching against the right edge,
-    // and the heading sits over its own values.
+    // The design gives the item column roughly 46% and leaves the money columns wide and
+    // left-aligned — headings sit directly over their values rather than everything
+    // crowding the right edge. Fixed widths rather than percentages because refund mode
+    // puts a field in each of these columns and they need guaranteed room.
     .woocommerce_order_items th.item_cost,
-    .woocommerce_order_items td.item_cost,
-    .woocommerce_order_items th.line_cost,
-    .woocommerce_order_items td.line_cost,
-    .woocommerce_order_items th.line_tax,
-    .woocommerce_order_items td.line_tax {
-        width: 110px;
-        padding-right: 0;
-        text-align: right;
-        white-space: nowrap;
+    .woocommerce_order_items td.item_cost {
+        width: 150px;
     }
 
     .woocommerce_order_items th.quantity,
     .woocommerce_order_items td.quantity {
-        width: 70px;
-        padding-right: 0;
-        text-align: right;
+        width: 140px;
+    }
+
+    .woocommerce_order_items th.line_cost,
+    .woocommerce_order_items td.line_cost {
+        width: 190px;
+    }
+
+    .woocommerce_order_items th.line_tax,
+    .woocommerce_order_items td.line_tax {
+        width: 150px;
+    }
+
+    .woocommerce_order_items th.item_cost,
+    .woocommerce_order_items td.item_cost,
+    .woocommerce_order_items th.quantity,
+    .woocommerce_order_items td.quantity,
+    .woocommerce_order_items th.line_cost,
+    .woocommerce_order_items td.line_cost,
+    .woocommerce_order_items th.line_tax,
+    .woocommerce_order_items td.line_tax {
+        text-align: left;
         white-space: nowrap;
     }
 
@@ -717,7 +753,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Coupon codes are chips in the design, not a bulleted list.
     .wc-used-coupons {
-        margin-bottom: 12px;
+        margin: 20px 0 12px;
 
         .wc_coupon_list {
             display: flex;
@@ -755,6 +791,202 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         .add-items {
             margin: 0;
+        }
+    }
+
+    // ── Refund mode ────────────────────────────────────────────────────────────
+    //
+    // Asking for a refund puts an input into each money column of every line item and
+    // opens the panel below. None of it was styled, so the fields arrived as borderless
+    // grey slabs at a different height from every other control in the view.
+
+    .woocommerce_order_items .refund {
+        margin-top: 8px;
+    }
+
+    .woocommerce_order_items input.refund_order_item_qty,
+    .woocommerce_order_items input.refund_line_total,
+    .woocommerce_order_items input.refund_line_tax,
+    .woocommerce_order_items input.refund_line_subtotal {
+        // Beats the inline width the template sets, which left the last column's field
+        // hanging over the card edge.
+        width: 76px !important;
+        height: 34px;
+        padding: 6px 8px;
+        background: #fff;
+        border: 1px solid $od-border;
+        border-radius: 6px;
+        font-size: 13px;
+        line-height: 20px;
+        color: $od-text;
+        box-shadow: none;
+    }
+
+    // The design puts the currency on the amount fields as an attached affix, so a bare
+    // number is never mistaken for one. The templates that render these inputs are not
+    // ours to change, so the symbol comes from a custom property the plugin publishes
+    // with the rest of its styles, and the affix is drawn rather than inserted.
+    .woocommerce_order_items td.line_cost .refund,
+    .woocommerce_order_items td.line_tax .refund {
+        display: inline-flex;
+        align-items: stretch;
+
+        &::before {
+            display: flex;
+            align-items: center;
+            padding: 0 9px;
+            background: #f3f4f6;
+            border: 1px solid $od-border;
+            border-right: 0;
+            border-radius: 6px 0 0 6px;
+            font-size: 13px;
+            line-height: 20px;
+            color: #6b6b6b;
+            white-space: nowrap;
+            content: var(--dokan-currency-symbol, "");
+        }
+
+        input {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    }
+
+    .wc-order-data-row.wc-order-refund-items {
+        margin-left: -20px;
+        margin-right: -20px;
+        padding: 20px 0 0;
+        // No rule of its own: the item table's last row already draws one directly above,
+        // and the two sat 1px apart and read as a single thick stripe.
+        border-top: 0;
+    }
+
+    // Label and field belong on the same line. Left alone the label sat at the top of a
+    // 56px row while its 38px field centred below it.
+    .wc-order-refund-items .wc-order-totals td {
+        padding: 8px 0 8px 20px;
+        vertical-align: middle;
+    }
+
+    // The value side is laid out rather than merely right-aligned, so the currency affix
+    // can sit against its field the way it does on the line items.
+    .wc-order-refund-items .wc-order-totals td.total {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0;
+
+        // A float clearer has no job inside a flex row.
+        > .clear {
+            display: none;
+        }
+
+        > input[type="text"],
+        > input.wc_input_price {
+            flex: 1 1 auto;
+            min-width: 0;
+            width: auto;
+        }
+    }
+
+    .wc-order-refund-items .wc-order-totals td.total:has(> input.wc_input_price)::before {
+        flex: 0 0 auto;
+        align-self: stretch;
+        display: flex;
+        align-items: center;
+        padding: 0 10px;
+        background: #f3f4f6;
+        border: 1px solid $od-border;
+        border-right: 0;
+        border-radius: 6px 0 0 6px;
+        font-size: 14px;
+        color: #6b6b6b;
+        white-space: nowrap;
+        content: var(--dokan-currency-symbol, "");
+    }
+
+    .wc-order-refund-items .wc-order-totals td.total:has(> input.wc_input_price) > input {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    // The amount field stays disabled until a quantity or line amount is entered, so it
+    // should read that way rather than inviting a value it will not accept.
+    .wc-order-refund-items input:disabled {
+        background: #f3f4f6;
+        color: $od-muted;
+        cursor: not-allowed;
+    }
+
+    .wc-order-refund-items input[type="text"],
+    .wc-order-refund-items input.wc_input_price {
+        width: 100%;
+        height: 38px;
+        padding: 8px 12px;
+        background: #fff;
+        border: 1px solid $od-border;
+        border-radius: 6px;
+        font-size: 14px;
+        line-height: 20px;
+        color: $od-text;
+        box-shadow: none;
+    }
+
+    // The restock checkbox defaults to the browser accent, which is blue here and the
+    // only blue on the page. Tailwind's form reset paints the checked state with
+    // `background-color` rather than the accent, so both have to be set.
+    .wc-order-refund-items input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-dokan-btn, #7047eb);
+
+        &:checked {
+            background-color: var(--color-dokan-btn, #7047eb);
+            border-color: var(--color-dokan-btn, #7047eb);
+        }
+    }
+
+    // While a refund is being composed each money cell grows by an input, but the cost
+    // column has none — centred vertically, its figure dropped ~17px below the ones it
+    // should line up with. Top alignment holds the row's first line together, and applies
+    // only in refund mode: jQuery clears the panel's inline `display: none` to open it,
+    // so the closed state still centres against the 44px thumbnail.
+    .dokan-panel-body:has(> .wc-order-refund-items:not([style*="none"]))
+        .woocommerce_order_items tbody td {
+        vertical-align: top;
+    }
+
+    .wc-order-refund-items .refund-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 16px;
+        padding: 0 20px 4px;
+
+        // Legacy button margins pushed the pair 8px off the right edge the fields above
+        // them sit on.
+        button {
+            margin: 0 !important;
+        }
+
+        // Backing out reads first, committing reads last.
+        .cancel-action {
+            order: -1;
+        }
+    }
+
+    // Cancel backs out of the flow; it should not carry the same weight as the action
+    // that submits money.
+    .wc-order-refund-items .cancel-action {
+        background: #fff !important;
+        border: 1px solid $od-border !important;
+        color: $od-text !important;
+        text-shadow: none;
+
+        &:hover,
+        &:focus {
+            background: #f9fafb !important;
         }
     }
 }
@@ -814,7 +1046,29 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border: 0;
         border-top: 1px solid $od-border;
         border-radius: 0;
+        font-size: 14px;
+        line-height: 22px;
         color: #6b6b6b;
+
+        // The note arrived unstyled: a 12px label above a 16px body, so the caption read
+        // smaller than the thing it captions. It now matches the detail rows above it —
+        // dark semibold label, grey value — the only difference being that the note gets
+        // its own line, which suits a sentence rather than a field.
+        strong {
+            display: block;
+            margin-bottom: 2px;
+            font-size: 14px;
+            font-weight: 600;
+            line-height: 22px;
+            color: $od-text;
+        }
+
+        // The markup separates label from note with a `<br>`. Once the label is a block
+        // that break contributes a whole empty line of its own — 28px between the two
+        // instead of the 2px the label's own margin sets.
+        br {
+            display: none;
+        }
     }
 
     // Status change form: full-width select, actions right-aligned beneath it.

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -259,8 +259,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .order_download_permissions .select2-container .select2-selection {
-        // Height, not min-height: the inner search input grows the box, and pushed this to 46px next to the two 40px fields above it.
-        height: 40px;
+        // `min-height` with `height: auto`: this is a multi-select, so the box has to grow once a second product is chosen rather than clip the row of chips.
+        height: auto;
         min-height: 40px;
         padding-block: 3px 3px;
         padding-inline: 36px 12px;
@@ -272,6 +272,41 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border: 1px solid $od-border;
         border-radius: 6px;
         box-shadow: none;
+    }
+
+    // `background-position` has no logical keyword, so the search glyph is the one thing here that has to be told which way round it goes. `dir` sits on `<html>`, so the attribute has to lead the selector rather than be nested under the wrapper.
+    [dir="rtl"] & .order_download_permissions .select2-container .select2-selection {
+        background-position: right 12px center;
+    }
+
+    // Each chosen product arrives as a stock select2 chip — #e4e4e4 on a #aaa border at 16px — which is the only control in the view still wearing the plugin's own colours. Sized and coloured like the rest of the card instead.
+    .order_download_permissions .select2-container .select2-selection__choice {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 26px;
+        margin: 3px 6px 3px 0;
+        padding: 0 8px;
+        background-color: #f3f4f6;
+        border: 1px solid $od-border;
+        border-radius: 4px;
+        font-size: 13px;
+        line-height: 24px;
+        color: $od-text;
+    }
+
+    // select2 4.0 puts the remove control before the label as a bare `×` glyph, so it needs its own hit area rather than the text's.
+    .order_download_permissions .select2-container .select2-selection__choice__remove {
+        order: 2;
+        margin: 0;
+        color: $od-muted;
+        font-size: 15px;
+        font-weight: 400;
+        line-height: 1;
+
+        &:hover {
+            color: $od-text;
+        }
     }
 
     // Typed text inherited the placeholder's grey and read as invisible.

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -1,0 +1,573 @@
+// Vendor panel look and feel for the server-rendered order details fragment.
+//
+// Scoped to `.dokan-order-details-fragment`, a wrapper only the panel adds (see
+// DetailsFragment::wrap()). The legacy order details page never carries it and never
+// loads this bundle, so its appearance is untouched.
+//
+// Tokens follow the panel's own React screens rather than the legacy stylesheet — the
+// RFQ edit-quote screen is the reference: 8px radius, shadow instead of a border,
+// gray-200 dividers, 20px section padding, a 320px sidebar and a 24px column gap.
+//
+// Plain CSS on purpose: module SCSS compiles outside the `dokan-tailwind` bundle, so
+// `@apply` has no theme to resolve against here.
+
+$od-text: #25252d;
+$od-muted: #828282;
+$od-border: #e5e7eb;
+$od-radius: 6px;
+$od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
+
+// The grey ground white cards sit on, matching the product editor canvas.
+.dokan-dashboard-content:has(.dokan-order-details-fragment) {
+    background-color: #f0f0f1;
+
+    // The page-header status badge already shares the sidebar badge's colours through
+    // its `dokan-badge-*` class; `currentcolor` gives it the matching outline for free,
+    // whatever the status.
+    .dokan-header-title [class*="dokan-badge-"] {
+        border: 1px solid currentcolor;
+    }
+}
+
+.dokan-order-details-fragment {
+    // The legacy page insets its content by 48px because it sits beside a sidebar nav.
+    // In the panel that pushes the cards out of line with the page header on both edges.
+    //
+    // `!important` is required, not lazy: the legacy rule is
+    // `.dokan-dashboard #dokan-dashboard-fullwidth-wrapper .dokan-dashboard-wrap
+    // .dokan-dashboard-content`, whose ID no class selector can outrank.
+    .dokan-dashboard-content {
+        // The panel already leaves 16px under the header actions; 8px here makes it 24px.
+        padding: 8px 0 0 !important;
+        background: transparent !important;
+    }
+
+    .dokan-orders-area {
+        background: transparent;
+    }
+
+    // Legacy floats leave slack and a percentage gutter, so the row neither fills the
+    // width nor honours a fixed gap. Flex does both without moving either column.
+    .dokan-order-details-wrap {
+        display: flex;
+        align-items: flex-start;
+        gap: 24px;
+
+        // The clearfix pseudo-elements would otherwise become stray flex items.
+        &::before,
+        &::after {
+            content: none;
+        }
+    }
+
+    // Same story for the gutter: `.dokan-orders-content .dokan-orders-area
+    // .dokan-order-left-content { margin: 3% }` outranks a two-class selector.
+    .dokan-order-left-content,
+    .dokan-order-right-content {
+        float: none;
+        margin: 0 !important;
+        width: auto;
+    }
+
+    .dokan-order-left-content {
+        flex: 1 1 auto;
+        // Lets the items table shrink inside the column instead of overflowing it.
+        min-width: 0;
+    }
+
+    .dokan-order-right-content {
+        flex: 0 0 320px;
+        max-width: 320px;
+    }
+
+    // The legacy grid stacks these columns on narrow screens; keep that behaviour.
+    @media (max-width: 991px) {
+        .dokan-order-details-wrap {
+            flex-direction: column;
+        }
+
+        .dokan-order-right-content {
+            flex-basis: auto;
+            max-width: none;
+            width: 100%;
+        }
+    }
+
+    // Card shell — shared by both columns so the grey canvas reads consistently.
+    .dokan-panel {
+        // Cards sit on the same 24px rhythm as the header and the column gap.
+        margin-bottom: 24px;
+        overflow: hidden;
+        background: #fff;
+        border: 0;
+        border-radius: $od-radius;
+        box-shadow: $od-shadow;
+    }
+
+    // Qualified with `.dokan-panel-default >`: the legacy grey-heading rule has the
+    // same specificity as a two-class selector and wins on source order.
+    .dokan-panel-default > .dokan-panel-heading,
+    .dokan-panel-heading {
+        padding: 16px 20px;
+        background: #fff;
+        border-bottom: 1px solid $od-border;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 20px;
+        color: $od-text;
+
+        strong {
+            font-weight: 600;
+        }
+    }
+
+    .dokan-panel-body {
+        padding: 20px;
+    }
+}
+
+// Address cards carry plain body copy rather than the legacy dense block.
+.dokan-order-details-fragment {
+    .dokan-order-billing-address .dokan-panel-body,
+    .dokan-order-shipping-address .dokan-panel-body {
+        font-size: 14px;
+        line-height: 22px;
+        color: #6b6b6b;
+
+        address,
+        p {
+            margin: 0;
+            font-style: normal;
+        }
+    }
+
+    // Nested panels — one per downloadable file — are rows inside a card, not cards of
+    // their own. Flattened so their content keeps the card's single 20px inset.
+    .dokan-panel .dokan-panel {
+        margin: 0;
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
+
+        > .dokan-panel-heading {
+            padding: 12px 0;
+            border-bottom: 0;
+            font-weight: 500;
+        }
+
+        > .dokan-panel-body {
+            padding: 0 0 12px;
+        }
+
+        + .dokan-panel {
+            border-top: 1px solid $od-border;
+        }
+    }
+}
+
+// ── Sidebar ────────────────────────────────────────────────────────────────────
+
+.dokan-order-details-fragment .dokan-order-right-content {
+    // Detail rows: muted label, dark value. Notes carry `list-unstyled` too, and this
+    // selector would outrank the notes block below, so they are excluded here.
+    ul.list-unstyled:not(.order_notes) {
+        margin: 0;
+
+        li {
+            margin: 0;
+            padding: 0;
+            font-size: 14px;
+            line-height: 22px;
+            color: #6b6b6b;
+            list-style: none;
+
+            // Figma labels the value, not the other way round: dark semibold label,
+            // grey value.
+            > span:first-child {
+                margin-right: 6px;
+                font-size: 14px;
+                font-weight: 600;
+                color: $od-text;
+            }
+        }
+
+        li + li {
+            margin-top: 12px;
+        }
+    }
+
+    // The earning is the headline figure in this card, so it takes the accent colour.
+    li.earning-from-order .woocommerce-Price-amount,
+    li.earning-from-order bdi {
+        font-weight: 600;
+        color: var(--color-dokan-btn, #7047eb);
+    }
+
+    // Legacy hangs the divider off the order block, so with "Hide Customer Info" on it
+    // trails under the last row with nothing beneath it. The divider belongs to whatever
+    // follows instead, so it only exists when there is something to separate.
+    // Qualified to outrank `.dokan-orders-content .dokan-orders-area .general-details
+    // ul.order-status`, which draws the divider.
+    .dokan-panel-body.general-details ul.order-status {
+        padding-bottom: 0;
+        border-bottom: 0;
+    }
+
+    .dokan-panel-body.general-details .alert.customer-note {
+        margin: 16px -20px 0;
+        padding: 16px 20px 0;
+        background: transparent;
+        border: 0;
+        border-top: 1px solid $od-border;
+        border-radius: 0;
+        color: #6b6b6b;
+    }
+
+    // Status change form: full-width select, actions right-aligned beneath it.
+    #dokan-order-status-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 12px 0 0;
+
+        input[type="hidden"] {
+            display: none;
+        }
+
+        select {
+            flex: 0 0 100%;
+        }
+
+        // Update is the primary action, Cancel the secondary one. `!important` answers
+        // the vendor colour-scheme module, which emits its button fill inline.
+        input[type="submit"] {
+            background: var(--color-dokan-btn, #7047eb) !important;
+            border: 1px solid var(--color-dokan-btn, #7047eb) !important;
+            color: #fff !important;
+        }
+
+        .dokan-cancel-status {
+            background: #fff !important;
+            border: 1px solid var(--color-dokan-btn, #7047eb) !important;
+            color: var(--color-dokan-btn, #7047eb) !important;
+        }
+
+        input[type="submit"],
+        .dokan-cancel-status {
+            height: 34px;
+            padding: 0 14px;
+        }
+    }
+
+    // The design separates the customer block from the order block with a divider.
+    // Pulled out to the card edges so the rule reads full-bleed, matching the notes card.
+    // Qualified to outrank `.dokan-orders-content .dokan-orders-area .general-details
+    // ul.customer-details`, which zeroes margin and padding.
+    .dokan-panel-body.general-details ul.customer-details {
+        margin: 16px -20px 0;
+        padding: 16px 20px 0;
+        border-top: 1px solid $od-border;
+    }
+
+    // Status reads as a pill rather than a legacy square badge.
+    .dokan-label {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 10px;
+        border: 1px solid currentcolor;
+        border-radius: 9999px;
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 18px;
+        text-shadow: none;
+        box-shadow: none;
+    }
+
+    .dokan-label-success { background: #daf8e6; color: #04724d; }
+    .dokan-label-warning { background: #fff3cd; color: #8a6100; }
+    .dokan-label-danger  { background: #ffe5e5; color: #b42318; }
+    .dokan-label-info    { background: #e9f9ff; color: #0b76b7; }
+    .dokan-label-default { background: #f2f2f2; color: #5c5c5c; }
+
+    // Notes card: each row owns its padding so the dividers run edge to edge, the way
+    // the RFQ sidebar sections do. The card body therefore carries none.
+    #dokan-order-notes {
+        padding: 0;
+
+        // Qualified with `ul` to outrank `.dokan-orders-content .dokan-orders-area
+        // ul.order_notes .note_content`, which paints the legacy grey bubble.
+        ul.order_notes {
+            margin: 0;
+
+            li {
+                margin: 0;
+                padding: 20px;
+                border-bottom: 1px solid $od-border;
+                background: transparent;
+                list-style: none;
+
+                // The add-note block below draws the closing divider.
+                &:last-child {
+                    border-bottom: 0;
+                }
+            }
+
+            // Customer-visible notes keep a marker: the design tells them apart by a
+            // text label, which CSS cannot add without hardcoding an untranslatable
+            // string.
+            li.customer-note {
+                border-left: 2px solid var(--color-dokan-btn, #7047eb);
+            }
+
+            .note_content {
+                padding: 0;
+                background: transparent;
+                border: 0;
+                border-radius: 0;
+                font-size: 14px;
+                line-height: 22px;
+                color: $od-text;
+
+                // Legacy draws the bubble tail here.
+                &::after {
+                    content: none;
+                }
+
+                p {
+                    margin: 0;
+                }
+            }
+
+            .meta {
+                margin: 8px 0 0;
+                font-size: 12px;
+                line-height: 18px;
+                color: $od-muted;
+            }
+
+            // "Delete note" is an action, so it reads in the action colour.
+            .delete_note {
+                margin-left: 10px;
+                font-weight: 500;
+                color: var(--color-dokan-btn, #7047eb);
+
+                &:hover {
+                    color: var(--color-dokan-btn-hover, #502bbf);
+                }
+            }
+        }
+
+        // `div.add_note` is qualified: the delivery-time Update button carries the same
+        // class, and would otherwise pick up this block's spacing.
+        > div.add_note {
+            margin: 0;
+            padding: 20px;
+            border-top: 1px solid $od-border;
+
+            // Capped at the card title's size so it never outweighs the section heading.
+            h4 {
+                margin: 0 0 12px;
+                font-size: 14px;
+                font-weight: 600;
+                line-height: 18px;
+                color: $od-text;
+            }
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+
+            // Hidden inputs would otherwise take part in the flex gap.
+            input[type="hidden"] {
+                display: none;
+            }
+
+            p {
+                margin: 0;
+            }
+
+            // The note-type select and submit share a floated row; flex lets the select
+            // take the free space and pins the button to the right edge.
+            .clearfix {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+
+                &::before,
+                &::after {
+                    content: none;
+                }
+
+                .order_note_type {
+                    flex: 1 1 auto;
+                    min-width: 0;
+                    margin: 0;
+                    float: none;
+                }
+            }
+        }
+
+        input[type="submit"] {
+            flex: 0 0 auto;
+            margin-left: auto;
+            width: auto;
+        }
+    }
+
+    // Shared control styling across the sidebar (notes, delivery time).
+    input[type="text"],
+    input[type="number"],
+    input[type="email"],
+    select,
+    textarea,
+    .dokan-form-control,
+    .form-control {
+        width: 100%;
+        padding: 8px 12px;
+        background: #fff;
+        border: 1px solid $od-border;
+        border-radius: 6px;
+        font-size: 14px;
+        line-height: 20px;
+        color: $od-text;
+        box-shadow: none;
+
+        &::placeholder {
+            color: $od-muted;
+        }
+    }
+
+    // Legacy pins selects to 35px while the button sits at 43px, leaving the note row
+    // visibly uneven. One height for both settles it.
+    input[type="text"],
+    input[type="number"],
+    input[type="email"],
+    select {
+        height: 38px;
+    }
+
+    // Delivery / Store Pickup choice row.
+    #vendor-delivery-type {
+        // Flex rather than inline flow: the markup puts a newline between each input and
+        // its label, and that whitespace text node renders as an extra ~4px gap.
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        // The date field below carries its own 16px, which is the card's rhythm; adding
+        // more here stacked to 36px and broke the run of fields.
+        margin-bottom: 0;
+
+        // The module's `.delivery-type-*` classes sit on the label as well as the input,
+        // so the label picks up its padding too and widens the gap to its own control.
+        .delivery-type-delivery,
+        .delivery-type-pickup {
+            padding: 0;
+        }
+
+        // The module styles these radios as a custom pill via
+        // `.vendor-delivery-time-box form #vendor-delivery-type .delivery-type-delivery`
+        // (padding `0 30px 0 8px`), which under `border-box` inflates a 16px radio into a
+        // 40px lozenge. Scoped through the same id to outrank it.
+        input[type="radio"],
+        input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            min-height: 0;
+            padding: 0;
+            margin: 0 8px 0 0;
+            vertical-align: middle;
+            background-position: center;
+            background-size: 100% 100%;
+            // A hairline grey reads as a control; the token border is too faint to.
+            border: 1px solid #c4c4c4;
+            // Tailwind's form styles paint the checked state with `currentcolor`.
+            color: var(--color-dokan-btn, #7047eb);
+
+            &:checked {
+                border-color: var(--color-dokan-btn, #7047eb);
+            }
+
+            // The module also draws its own radio as a 19px pseudo-element over the real
+            // control, which is what rendered as a grey blob. Drop it and let the
+            // standard control show, matching the radios on the other panel screens.
+            &::before,
+            &::after,
+            &:checked::before,
+            &:checked::after {
+                content: none;
+            }
+        }
+
+        label {
+            margin: 0 24px 0 0;
+            font-size: 14px;
+            line-height: 20px;
+            font-weight: 400;
+            color: $od-text;
+            vertical-align: middle;
+            cursor: pointer;
+
+            &:last-of-type {
+                margin-right: 0;
+            }
+        }
+    }
+
+    // The current delivery window, styled like the other label/value rows.
+    .delivery-type-date-info {
+        margin-bottom: 16px;
+        font-size: 14px;
+        line-height: 22px;
+        color: #6b6b6b;
+
+        > span:first-child {
+            margin-right: 4px;
+            font-size: 14px;
+            font-weight: 600;
+            color: $od-text;
+        }
+    }
+
+    // Legacy strips the native arrow with `appearance: none` and puts nothing back, so
+    // the control reads as a plain text box. This restores the affordance.
+    // Also matched as `select.dokan-form-control`: the shared control rule above hits
+    // this element through its class (0,3,0), which outranks a bare element selector.
+    select,
+    select.dokan-form-control,
+    select.form-control {
+        padding-right: 34px;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: right 12px center;
+        background-size: 16px 16px;
+    }
+
+    form {
+        margin-bottom: 0;
+    }
+
+    textarea {
+        min-height: 90px;
+        resize: vertical;
+    }
+
+    a.dokan-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .dokan-btn,
+    input[type="submit"] {
+        height: 38px;
+        padding: 0 16px;
+        line-height: 20px;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 500;
+        text-shadow: none;
+        box-shadow: none;
+    }
+}

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -5,9 +5,12 @@ $od-muted: #828282;
 $od-border: #e5e7eb;
 $od-radius: 6px;
 $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
+$od-body: #6b6b6b;
+$od-fill: #f3f4f6;
+$od-hairline: #e9e9e9;
 
-// The grey ground white cards sit on, matching the product editor canvas.
-.dokan-dashboard-content:has(.dokan-order-details-fragment) {
+// The grey ground white cards sit on, matching the product editor canvas. Reached through the route class rather than `:has()`, so `body` is not a `:has()` subject on panel routes that never render this view; the fragment's own nested `.dokan-dashboard-content` is painted back to transparent below.
+.dokan-order-details-active .dokan-dashboard-content {
     background-color: #f0f0f1;
 
     // The header badge already carries the status colours through its `dokan-badge-*` class, so `currentcolor` gives it a matching outline whatever the status.
@@ -155,7 +158,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         font-size: 14px;
         // Addresses run to many short lines with no separators between fields, so they need more leading than the single-line rows elsewhere to read as distinct lines.
         line-height: 28px;
-        color: #6b6b6b;
+        color: $od-body;
         // Addresses are free text and can carry long unbroken tokens; wrap rather than push the card wider than its column.
         overflow-wrap: anywhere;
 
@@ -164,12 +167,6 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin: 0;
             font-style: normal;
         }
-    }
-
-    // Bootstrap's `.panel-collapse.collapse` collides with the panel's Tailwind `visibility: collapse` utility and hid the permission details the legacy page shows; the utility is emitted `!important`, so no specificity wins.
-    .panel-collapse.collapse {
-        visibility: visible !important;
-        height: auto;
     }
 
     // Title and Revoke share one justified row, which makes legacy's float on the button redundant.
@@ -262,7 +259,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // `min-height` with `height: auto`: this is a multi-select, so the box has to grow once a second product is chosen rather than clip the row of chips.
         height: auto;
         min-height: 40px;
-        padding-block: 3px 3px;
+        padding-block: 3px;
         padding-inline: 36px 12px;
         background-color: #fff;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
@@ -270,7 +267,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background-position: left 12px center;
         background-size: 16px 16px;
         border: 1px solid $od-border;
-        border-radius: 6px;
+        border-radius: $od-radius;
         box-shadow: none;
     }
 
@@ -316,7 +313,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         height: 26px;
         margin: 3px 6px 3px 0;
         padding: 0 8px;
-        background-color: #f3f4f6;
+        background-color: $od-fill;
         border: 1px solid $od-border;
         border-radius: 4px;
         font-size: 13px;
@@ -373,7 +370,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             border: 0;
             font-size: 14px;
             line-height: 22px;
-            color: #6b6b6b;
+            color: $od-body;
         }
 
         tr:last-child td:last-child {
@@ -420,7 +417,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             padding: 8px 12px !important;
             background-color: #fff !important;
             border: 1px solid $od-border !important;
-            border-radius: 6px !important;
+            border-radius: $od-radius !important;
             font-size: 14px !important;
             line-height: 22px;
             color: $od-text !important;
@@ -497,7 +494,6 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     .shipping-status-track-info-heading,
     .dokan-customer-shipment-notes-list-area h5 {
-        margin: 0 0 12px;
         font-size: 14px;
         font-weight: 600;
         line-height: 20px;
@@ -506,17 +502,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Air, not size, separates this heading from the 13px/600 labels under it — the card's own heading is 14px too, and an inner heading has no business being larger — so it takes the same 20px step the card leaves under its heading.
     .shipping-status-track-info-heading {
-        margin-bottom: 20px;
+        margin: 0 0 20px;
     }
 
-    // The strip holding Create New Shipment. Named through Pro's own panel id rather than the card
-    // body class: Pro styles the pieces below from selectors carrying that id, and a rule built only
-    // from classes cannot outrank one id no matter how many classes it stacks. Borrowing the id puts
-    // these one class ahead of Pro's, which is what `!important` was standing in for — and standing
-    // in badly, because a shorthand `margin: … !important` on the button also beat the adjacent-sibling
-    // rule below and pinned the empty-state gap at Pro's 10px + 16px instead of the 12px intended.
-    // The padding drops to nothing while the button is hidden so the strip cannot leave a sliver
-    // under the create form.
+    // The strip holding Create New Shipment, named through Pro's own panel id because Pro styles the pieces below from selectors carrying it and no stack of classes outranks one id; borrowing the id is what the `!important` here used to stand in for, and it stood in badly, beating the adjacent-sibling rule below and pinning the empty-state gap at Pro's 10px + 16px instead of the 12px intended.
     #dokan-order-shipping-status-tracking-panel .shipping-status-tracking-top-info {
         padding: 0 20px;
 
@@ -540,7 +529,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         font-size: 14px;
         line-height: 28px;
         // Legacy sets #999 from a deeper selector, which made this message read as less important than the empty state beside it.
-        color: #6b6b6b !important;
+        color: $od-body !important;
     }
 
     // Empty state left as legacy renders it: the design's left-aligned `+` link was built, but two theme rules repaint `.dokan-btn` on hover and the override could not be demonstrated working, so it was reverted on request rather than shipped unverified.
@@ -646,13 +635,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         height: 28px;
         top: auto;
         margin: 0;
-        border-radius: 6px;
-        color: #6b6b6b;
+        border-radius: $od-radius;
+        color: $od-body;
         text-indent: 0;
         cursor: pointer;
 
         &:hover {
-            background-color: #f3f4f6;
+            background-color: $od-fill;
             color: $od-text;
         }
 
@@ -704,7 +693,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
 
         td {
-            padding-block: 12px 12px;
+            padding-block: 12px;
             padding-inline: 0 12px;
             background-color: transparent !important;
             border: 0;
@@ -741,8 +730,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             width: 36px;
             min-width: 36px;
             height: 36px;
-            background-color: #f3f4f6;
-            border: 1px solid #e9e9e9;
+            background-color: $od-fill;
+            border: 1px solid $od-hairline;
             border-radius: 3px;
             object-fit: cover;
         }
@@ -800,8 +789,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // Equal thirds on a real gap instead of Pro's 33% with a 2% gutter, which left the last field 35px short; `margin-bottom: 0` is the important part, because a float's trailing margin extends the row box and pushes whatever clears it down on top of that element's own spacing.
-    // The "other provider" pair belongs here too: it is the second row of the same three-column
-    // grid, and on Pro's 33%/2% its two fields sat ~15px right of the columns above them.
+    // The "other provider" pair belongs here too — it is the second row of the same three-column grid, and on Pro's 33%/2% its two fields sat ~15px right of the columns above them.
     .shipping-status-provider,
     .shipped-status-date,
     .shipped-tracking-number,
@@ -879,7 +867,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .shippments-tracking-footer select:disabled,
     .shippments-tracking-footer input[readonly] {
         background-color: #f9fafb !important;
-        border-color: #e9e9e9 !important;
+        border-color: $od-hairline !important;
         color: #a1a1aa !important;
         pointer-events: none;
     }
@@ -896,7 +884,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // The heading is the section's header band, on the same grey as the card headings, with right padding keeping a long title clear of the toggle.
         h5 {
             margin: 0;
-            padding-block: 16px 16px;
+            padding-block: 16px;
             padding-inline: 20px 56px;
             background-color: #f9fafb;
         }
@@ -923,7 +911,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             padding-inline: 44px 0;
             font-size: 14px;
             line-height: 22px;
-            color: #6b6b6b;
+            color: $od-body;
 
             &:last-child {
                 padding-bottom: 0;
@@ -972,7 +960,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin: 12px 0 0;
             font-size: 13px;
             line-height: 20px;
-            color: #6b6b6b;
+            color: $od-body;
 
             &:first-child {
                 margin-top: 8px;
@@ -1043,7 +1031,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // The quantity is on screen from the start, greyed until its row is ticked, so the column reads as "this row has a quantity" rather than as empty space.
         .shipping-tracking.is-disabled input {
             background-color: #f9fafb;
-            border-color: #e9e9e9;
+            border-color: $od-hairline;
             color: #a1a1aa;
             cursor: not-allowed;
         }
@@ -1230,7 +1218,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .woocommerce_order_items tbody td {
-        padding-block: 16px 16px;
+        padding-block: 16px;
         padding-inline: 0 12px;
         border: 0;
         font-size: 14px;
@@ -1262,7 +1250,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         i {
             font-size: 20px;
-            color: #6b6b6b;
+            color: $od-body;
         }
     }
 
@@ -1278,8 +1266,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             height: 44px;
             // A product with no image falls back to WooCommerce's placeholder, which is not on every install — when it 404s the element collapses to its alt text and spills across the row, so the box holds its size and clips.
             overflow: hidden;
-            background-color: #f3f4f6;
-            border: 1px solid #e9e9e9;
+            background-color: $od-fill;
+            border: 1px solid $od-hairline;
             border-radius: 3px;
             object-fit: cover;
             font-size: 0;
@@ -1428,7 +1416,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         li.code {
             padding: 3px 10px;
-            background: #f3f4f6;
+            background: $od-fill;
             border: 1px solid $od-border;
             border-radius: 4px;
             font-size: 13px;
@@ -1468,7 +1456,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         padding: 6px 8px;
         background: #fff;
         border: 1px solid $od-border;
-        border-radius: 6px;
+        border-radius: $od-radius;
         font-size: 13px;
         line-height: 20px;
         color: $od-text;
@@ -1577,7 +1565,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             padding: 0;
             font-size: 14px;
             line-height: 22px;
-            color: #6b6b6b;
+            color: $od-body;
             list-style: none;
 
             // Figma labels the value, not the other way round: dark semibold label, grey value.
@@ -1616,7 +1604,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border-radius: 0;
         font-size: 14px;
         line-height: 22px;
-        color: #6b6b6b;
+        color: $od-body;
 
         // The note arrived unstyled as a 12px label above a 16px body, so the caption read smaller than the thing it captions; it now matches the detail rows above, except that the note gets its own line as a sentence should.
         strong {
@@ -1696,7 +1684,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             display: block;
             font-size: 14px;
             line-height: 22px;
-            color: #6b6b6b;
+            color: $od-body;
         }
 
         // Deliberately no `unicode-bidi: plaintext`: it takes direction from the first strong character, so a Latin pickup address turned this row LTR and aligned it against the opposite edge from every other row in the list. Latin content reordering under RTL is how every label on this page already behaves, and an RTL store has these strings translated anyway.
@@ -1908,7 +1896,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin-bottom: 16px;
         font-size: 14px;
         line-height: 22px;
-        color: #6b6b6b;
+        color: $od-body;
 
         > span:first-child {
             margin-inline-end: 4px;
@@ -1955,7 +1943,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         height: 38px;
         padding: 0 16px;
         line-height: 20px;
-        border-radius: 6px;
+        border-radius: $od-radius;
         font-size: 14px;
         font-weight: 500;
         text-shadow: none;
@@ -1968,7 +1956,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         .dokan-btn.dokan-btn-theme,
         .dokan-btn.dokan-btn-default,
         input[type="submit"].dokan-btn {
-            border-radius: 6px !important;
+            border-radius: $od-radius !important;
         }
     }
 }
@@ -1990,7 +1978,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         padding: 8px 12px;
         background: #fff;
         border: 1px solid $od-border;
-        border-radius: 6px;
+        border-radius: $od-radius;
         font-size: 14px;
         line-height: 20px;
         color: $od-text;
@@ -2032,7 +2020,6 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     input[type="text"]:focus,
     input[type="number"]:focus,
     input[type="email"]:focus,
-    input[type="date"]:focus,
     select:focus,
     textarea:focus,
     .select2-container--focus .select2-selection,
@@ -2044,18 +2031,18 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Panel header ───────────────────────────────────────────────────────────────
-// The header is React, outside the fragment, so it is reached through the page with the same `:has()` guard the grey canvas and the date picker use; its shared-library buttons come at Tailwind's 4px while every control inside the view sits at 6px.
-body:has(.dokan-order-details-fragment) {
+// The header is React, outside the fragment, so it is reached through the page with the same route class the grey canvas and the date picker use; its shared-library buttons come at Tailwind's 4px while every control inside the view sits at 6px.
+body.dokan-order-details-active {
     .dokan-header-actions button,
     .dokan-header-actions a {
         // Tailwind's `rounded` is emitted `!important` in this build.
-        border-radius: 6px !important;
+        border-radius: $od-radius !important;
     }
 }
 
 // ── jQuery UI date picker ───────────────────────────────────────────────────────
-// The picker is appended to `<body>`, outside the fragment, so it is reached through the page, with `:has()` keeping that to pages actually showing the fragment.
-body:has(.dokan-order-details-fragment) {
+// The picker is appended to `<body>`, outside the fragment, so it is reached through the page, with the route class keeping that to pages actually showing the fragment.
+body.dokan-order-details-active {
     #ui-datepicker-div {
         // jQuery UI writes `z-index: 1` inline from the input's own stacking context, so the calendar opened underneath select2's product search and the search box painted straight through it.
         z-index: 1100 !important;
@@ -2063,7 +2050,7 @@ body:has(.dokan-order-details-fragment) {
         padding: 8px;
         background: #fff;
         border: 1px solid $od-border;
-        border-radius: 6px;
+        border-radius: $od-radius;
         box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
         font-family: inherit;
         font-size: 13px;
@@ -2080,7 +2067,7 @@ body:has(.dokan-order-details-fragment) {
     .ui-datepicker .ui-datepicker-title {
         font-size: 14px;
         font-weight: 600;
-        color: #25252d;
+        color: $od-text;
     }
 
     // The stock arrows are sprite-backed and read as grey blobs against a white header.
@@ -2095,7 +2082,7 @@ body:has(.dokan-order-details-fragment) {
         cursor: pointer;
 
         &:hover {
-            background: #f3f4f6;
+            background: $od-fill;
             border: 0;
         }
 
@@ -2110,8 +2097,8 @@ body:has(.dokan-order-details-fragment) {
                 width: 8px;
                 height: 8px;
                 margin: 5px auto;
-                border-top: 2px solid #6b6b6b;
-                border-right: 2px solid #6b6b6b;
+                border-top: 2px solid $od-body;
+                border-right: 2px solid $od-body;
                 content: "";
             }
         }
@@ -2129,7 +2116,7 @@ body:has(.dokan-order-details-fragment) {
         padding: 6px 0;
         font-size: 12px;
         font-weight: 600;
-        color: #828282;
+        color: $od-muted;
     }
 
     .ui-datepicker td {
@@ -2142,11 +2129,11 @@ body:has(.dokan-order-details-fragment) {
         border: 0;
         border-radius: 4px;
         font-weight: 400;
-        color: #25252d;
+        color: $od-text;
         text-align: center;
 
         &:hover {
-            background: #f3f4f6;
+            background: $od-fill;
         }
     }
 
@@ -2159,12 +2146,12 @@ body:has(.dokan-order-details-fragment) {
 }
 
 // ── select2 product search dropdown ────────────────────────────────────────────
-// The dropdown is a sibling of the field rather than a descendant of the fragment wrapper in every select2 configuration, so it is matched on its own classes and kept to pages showing the fragment by the same `:has()` guard.
-body:has(.dokan-order-details-fragment) {
+// The dropdown is a sibling of the field rather than a descendant of the fragment wrapper in every select2 configuration, so it is matched on its own classes and kept to pages showing the fragment by the same route class.
+body.dokan-order-details-active {
     .select2-container--default .select2-dropdown {
         // Stock select2 draws a mid-grey #7f868d hairline with 4px corners, which reads as a black box against the card's #e5e7eb fields.
         border: 1px solid $od-border;
-        border-radius: 6px;
+        border-radius: $od-radius;
         background: #fff;
         box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
         overflow: hidden;
@@ -2186,16 +2173,16 @@ body:has(.dokan-order-details-fragment) {
         padding: 9px 12px;
         font-size: 14px;
         line-height: 20px;
-        color: #25252d;
+        color: $od-text;
     }
 
     // The "type 3 more characters" hint is guidance, not a choice.
     .select2-container--default .select2-results__message {
-        color: #828282;
+        color: $od-muted;
     }
 
     .select2-container--default .select2-results__option--highlighted[aria-selected] {
-        background-color: #f3f4f6;
-        color: #25252d;
+        background-color: $od-fill;
+        color: $od-text;
     }
 }

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -509,13 +509,19 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin-bottom: 20px;
     }
 
-    // The strip holding Create New Shipment, named through the card body because Pro's two-class rule ties and `orders.less` wins on source order; the padding drops to nothing while the button is hidden so the strip cannot leave a sliver under the create form.
-    .dokan-panel-body .shipping-status-tracking-top-info {
+    // The strip holding Create New Shipment. Named through Pro's own panel id rather than the card
+    // body class: Pro styles the pieces below from selectors carrying that id, and a rule built only
+    // from classes cannot outrank one id no matter how many classes it stacks. Borrowing the id puts
+    // these one class ahead of Pro's, which is what `!important` was standing in for — and standing
+    // in badly, because a shorthand `margin: … !important` on the button also beat the adjacent-sibling
+    // rule below and pinned the empty-state gap at Pro's 10px + 16px instead of the 12px intended.
+    // The padding drops to nothing while the button is hidden so the strip cannot leave a sliver
+    // under the create form.
+    #dokan-order-shipping-status-tracking-panel .shipping-status-tracking-top-info {
         padding: 0 20px;
 
-        // `!important` is the only lever here: Pro sets the bottom margin from a selector carrying two ids, which nothing built from classes can outrank.
         #create-tracking-status-action {
-            margin: 16px 0 !important;
+            margin: 16px 0;
         }
 
         // Pro's paragraph margin left the button adrift below the centred empty-state message.
@@ -794,9 +800,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // Equal thirds on a real gap instead of Pro's 33% with a 2% gutter, which left the last field 35px short; `margin-bottom: 0` is the important part, because a float's trailing margin extends the row box and pushes whatever clears it down on top of that element's own spacing.
+    // The "other provider" pair belongs here too: it is the second row of the same three-column
+    // grid, and on Pro's 33%/2% its two fields sat ~15px right of the columns above them.
     .shipping-status-provider,
     .shipped-status-date,
-    .shipped-tracking-number {
+    .shipped-tracking-number,
+    .tracking-status-other-provider,
+    .tracking-status-other-p-url {
         float: left;
         width: calc((100% - 32px) / 3);
         margin-inline-end: 16px;

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -279,6 +279,35 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background-position: right 12px center;
     }
 
+    // select2 renders this list as `inline-block`, so it sits on a text baseline and the line box's descender added ~6px under the chips — the field measured 46px beside 40px siblings. Flex removes the baseline and lets a second row of chips wrap instead of clipping.
+    .order_download_permissions .select2-container .select2-selection__rendered {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 0;
+    }
+
+    // The search input takes the rest of the row so clicking anywhere in the field still focuses it.
+    .order_download_permissions .select2-container .select2-search--inline {
+        order: 2;
+        flex: 1 1 80px;
+    }
+
+    // The clear-all control is stock select2 — 16px at weight 700 in its own grey — sitting in the same field as a chip remove this file already set to 15px in the muted grey. Two different crosses in one control.
+    .order_download_permissions .select2-container .select2-selection__clear {
+        order: 3;
+        margin: 0;
+        margin-inline-start: auto;
+        color: $od-muted;
+        font-size: 15px;
+        font-weight: 400;
+        line-height: 1;
+
+        &:hover {
+            color: $od-text;
+        }
+    }
+
     // Each chosen product arrives as a stock select2 chip — #e4e4e4 on a #aaa border at 16px — which is the only control in the view still wearing the plugin's own colours. Sized and coloured like the rest of the card instead.
     .order_download_permissions .select2-container .select2-selection__choice {
         display: inline-flex;

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -2046,7 +2046,7 @@ body:has(.dokan-order-details-fragment) {
         width: 260px;
         padding: 8px;
         background: #fff;
-        border: 1px solid #e5e7eb;
+        border: 1px solid $od-border;
         border-radius: 6px;
         box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
         font-family: inherit;
@@ -2147,7 +2147,7 @@ body:has(.dokan-order-details-fragment) {
 body:has(.dokan-order-details-fragment) {
     .select2-container--default .select2-dropdown {
         // Stock select2 draws a mid-grey #7f868d hairline with 4px corners, which reads as a black box against the card's #e5e7eb fields.
-        border: 1px solid #e5e7eb;
+        border: 1px solid $od-border;
         border-radius: 6px;
         background: #fff;
         box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -109,7 +109,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .dokan-panel-default > .dokan-panel-heading,
     .dokan-panel-heading {
         padding: 16px 20px;
-        background: #fff;
+        // The design's section headers sit on gray-50, one step off the card white.
+        background: #FDFDFD;
         border-bottom: 1px solid $od-border;
         font-size: 14px;
         font-weight: 600;
@@ -471,11 +472,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // The design puts the item count and the tracking link on one quiet line under the
-    // title, separated by a hairline.
+    // title, separated by a hairline tick.
     .shippments-tracking-via {
         display: flex;
         align-items: center;
-        gap: 10px;
+        // Word-sized, not 10px: "via" and the provider are one phrase, and the flex gap
+        // sits between them too, which read as a stray double space.
+        gap: 4px;
         margin: 4px 0 0;
         font-size: 14px;
         line-height: 20px;
@@ -492,6 +495,17 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             gap: 4px;
             font-weight: 500;
         }
+
+        // The tick between the provider phrase and the tracking link, drawn rather than
+        // typed so it cannot inherit the link colour or stretch to the line height.
+        a:first-of-type::before {
+            content: "";
+            align-self: center;
+            width: 1px;
+            height: 12px;
+            margin: 0 8px 0 6px;
+            background-color: $od-border;
+        }
     }
 
     .shipping-status-track-info-heading,
@@ -503,9 +517,46 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: $od-text;
     }
 
-    // A little more room top and bottom than legacy's own margins leave.
-    .shipping-status-tracking-top-info {
-        padding: 4px 20px;
+    // "Tracking Information" heads a group of fields, but it lands 14px/600 against
+    // labels that are 13px/600 in the same colour — one pixel apart, so it read as one
+    // more label rather than the heading over them. Size cannot carry the difference:
+    // the card's own heading is 14px too, and an inner heading has no business being
+    // larger than the card it sits in. Air does it instead — 20px below, the same step
+    // the card leaves under its heading, against the 8px each label leaves under itself.
+    .shipping-status-track-info-heading {
+        margin-bottom: 20px;
+    }
+
+    // The strip holding Create New Shipment. Named through the card body because Pro
+    // styles it from a two-class selector too, and a tie there goes to `orders.less` on
+    // source order — the strip kept Pro's 20px padding either side of a button that
+    // already carried its own 20px margin, so the action sat in ~76px of air.
+    //
+    // The padding is dropped to nothing while the button is hidden (the create form
+    // replaces it, and jQuery hides it with an inline `display`), so the strip cannot
+    // leave a sliver behind under the form.
+    .dokan-panel-body .shipping-status-tracking-top-info {
+        padding: 0 20px;
+
+        // 16px either side of the action, so the strip closes on the same step the rest of
+        // the card uses. `!important` is the only lever here: Pro sets the bottom margin
+        // from `#dokan-order-shipping-status-tracking-panel … #create-tracking-status-action`,
+        // which carries two ids — no selector built from classes can outrank that.
+        #create-tracking-status-action {
+            margin: 16px 0 !important;
+        }
+
+        // The empty state is centred, and Pro's paragraph margin left the button adrift
+        // below the message.
+        .no-shipment-found-desc {
+            margin: 16px 0 0;
+        }
+
+        // With the message present the button follows it, so its own top margin would
+        // double the gap between the two.
+        .no-shipment-found-desc + #create-tracking-status-action {
+            margin-top: 12px;
+        }
     }
 
     // Same voice as the other empty states in this view — "No shipping address set." and
@@ -544,8 +595,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border-radius: 0;
         box-shadow: none;
 
-        + .shipping-status-tracking-shippments-inner {
-            border-top: 1px solid $od-border;
+        // Every shipment rules off from the one above it. This was written as
+        // `+ .shipping-status-tracking-shippments-inner` and drew nothing, because the
+        // template closes each shipment with a `<div class="clear">` — so no two
+        // shipments are ever adjacent siblings and the combinator never matched. Drawn on
+        // all of them and lifted from the first instead, which does not care what sits
+        // between.
+        border-top: 1px solid $od-border;
+
+        &:first-child {
+            border-top: 0;
         }
 
         // Legacy insets the header, the item list and the tracking form by a further 20px
@@ -560,7 +619,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // Same tie, and the reason the rules around the item list stayed at legacy's 2px
         // #ddd while every other divider in the view is a 1px hairline.
         > .shippments-tracking-items {
-            padding: 16px 20px;
+            padding: 8px 20px;
             border-top: 1px solid $od-border;
             border-bottom: 1px solid $od-border;
         }
@@ -572,11 +631,15 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         display: none;
     }
 
+    // Grid rather than a wrapped flex row: the badge and its toggle centre against the
+    // full two-line title block (title over the via line), which flex cannot do once
+    // the via line wraps onto a row of its own.
     .shippments-tracking-header {
-        display: flex;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
         align-items: center;
-        flex-wrap: wrap;
-        gap: 8px 12px;
+        column-gap: 12px;
+        row-gap: 4px;
 
         > .clear {
             display: none;
@@ -585,22 +648,27 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Pro lays this row out with floats and percentage widths — the status block is
     // `width: 63%; float: right` from a two-class selector. Naming the header as well
-    // outranks it so the flex row can take over.
+    // outranks it so the grid can take over.
     .shippments-tracking-header .shippments-tracking-title {
-        flex: 1 1 auto;
-        order: 1;
+        grid-column: 1;
+        grid-row: 1;
         width: auto;
         float: none;
         margin: 0;
     }
 
     // Status is a pill, matching the badges the page header and sidebar already use.
+    // Spanning both title rows so the pill and the toggle sit on the block's midline.
     .shippments-tracking-header .shippments-statuses {
-        flex: 0 0 auto;
-        order: 2;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        grid-column: 2;
+        grid-row: 1 / span 2;
+        align-self: center;
         width: auto;
         float: none;
-        margin: 0 0 0 auto;
+        margin: 0;
 
         // Flex rather than `font-size: 0`, which is what closed the whitespace gap
         // between the badge and the toggle before. The toggle is an empty icon span, so
@@ -617,12 +685,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         strong {
             display: inline-flex;
             align-items: center;
-            padding: 2px 10px;
+            padding: 4px 12px;
             border: 1px solid currentcolor;
             border-radius: 999px;
             font-size: 12px;
             font-weight: 500;
             line-height: 18px;
+            white-space: nowrap;
         }
     }
 
@@ -635,8 +704,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 24px;
-        height: 24px;
+        width: 28px;
+        height: 28px;
         top: auto;
         margin: 0;
         border-radius: 6px;
@@ -652,10 +721,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // `currentcolor` through a mask, so the hover state comes for free.
         &::after {
             content: "";
-            width: 16px;
-            height: 16px;
+            width: 20px;
+            height: 20px;
             background-color: currentcolor;
-            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") no-repeat center / 16px 16px;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") no-repeat center / 20px 20px;
             transition: transform 0.15s ease;
         }
 
@@ -677,17 +746,18 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Pro pins this one to the corner of the block. Kept there rather than turned into a
     // flex row: the block is opened by toggling an inline `display`, and any `display` of
     // ours on the container would either outrank `.dokan-hide` while it is closed or be
-    // outranked by the inline value once it opens.
+    // outranked by the inline value once it opens. Centred in the 52px header band.
     .dokan-customer-shipment-notes-list-area .shipment-notes-details-tab-toggle {
-        top: 14px;
-        right: 20px;
+        top: 12px;
+        right: 16px;
     }
 
     .shippments-tracking-header .shippments-tracking-via {
-        flex: 1 1 100%;
-        order: 3;
+        grid-column: 1;
+        grid-row: 2;
         width: auto;
         float: none;
+        margin: 0;
     }
 
     // The shipment's own item list follows the order table's shape rather than the
@@ -698,18 +768,21 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // Legacy rules this block off with 2px of #ddd, twice the weight of every other
         // divider in the view.
         margin: 20px -20px;
-        padding: 16px 20px;
+        padding: 8px 20px;
         border-top: 1px solid $od-border;
         border-bottom: 1px solid $od-border;
 
+        // The table hangs over the block's inset and the edge cells put it back, the
+        // same trick as the order items table — otherwise every row separator stops
+        // 20px short of the card edge at both ends.
         table {
-            width: 100%;
-            margin: 0;
+            width: calc(100% + 40px);
+            margin: 0 -20px;
             border-collapse: collapse;
         }
 
         td {
-            padding: 10px 12px 10px 0;
+            padding: 12px 12px 12px 0;
             background-color: transparent !important;
             border: 0;
             font-size: 14px;
@@ -718,20 +791,38 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             vertical-align: middle;
         }
 
+        td:last-child {
+            padding-right: 20px;
+            text-align: right;
+            white-space: nowrap;
+        }
+
+        // The name column absorbs the leftover, so the quantity sits against the right
+        // edge instead of drifting to wherever auto layout leaves it.
+        td:nth-child(2) {
+            width: 100%;
+        }
+
         tr + tr td {
             border-top: 1px solid $od-border;
         }
 
         // `.shippments-tracking-items td.thumb img { width: 100% }` ships with Pro and is
         // one element deeper than a plain descendant selector, so the cell has to be named
-        // or the thumbnail fills its column at 163px.
+        // or the thumbnail fills its column at 163px. `min-width`, because the name
+        // column's `width: 100%` squeezes this one to its min-content — and Tailwind's
+        // `img { max-width: 100% }` makes the image's min-content zero, so the plain
+        // `width` hint was crushed to a 6px sliver.
         td.thumb {
-            width: 56px;
+            width: 68px;
+            min-width: 68px;
+            padding-left: 20px;
         }
 
         td.thumb img {
             display: block;
             width: 36px;
+            min-width: 36px;
             height: 36px;
             background-color: #f3f4f6;
             border: 1px solid #e9e9e9;
@@ -750,9 +841,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
+        // The quantity is metadata, not a second name — one step down from the row and
+        // muted, like the counters in the downloadable section, but weighted so the
+        // number still registers at a glance.
         strong {
-            font-size: 14px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 500;
+            line-height: 20px;
             color: $od-muted;
         }
     }
@@ -782,17 +877,57 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         &:last-child {
             margin-bottom: 0;
         }
+
+        // The floated tracking row gives its trailing margin up — see the float rule
+        // below for why. Declared here rather than there because this selector is one
+        // class deeper and would otherwise win the point back.
+        &.shipping-status-provider,
+        &.shipped-status-date,
+        &.shipped-tracking-number {
+            margin-bottom: 0;
+        }
     }
 
     // Pro floats the three tracking fields at 33% with a 2% gutter, which leaves the last
     // one 35px short of the other two. Equal thirds on a real gap instead.
+    //
+    // `margin-bottom: 0` is the important part: because these are floats, the 16px every
+    // field row carries extends the row box and pushes whatever clears it down by that
+    // much *on top of* that element's own top spacing. It read as 36px before the
+    // timeline where this card steps by 20, and would be 40px before the Update button
+    // where it should step by 24. The row gives up its trailing margin; the blocks that
+    // clear it own the gap.
     .shipping-status-provider,
     .shipped-status-date,
     .shipped-tracking-number {
         float: left;
         width: calc((100% - 32px) / 3);
         margin-right: 16px;
+        margin-bottom: 0;
         overflow: visible;
+    }
+
+    // Whichever of those blocks lands under the row needs its own step down from it — the
+    // other-provider pair when the provider is "Other", the comment field either way.
+    //
+    // `padding`, not `margin`: these carry `clear: both`, and when clearance is introduced
+    // the top margin is absorbed into it rather than drawn. A `margin-top: 16px` here
+    // computed correctly and rendered as nothing.
+    //
+    // Stated unconditionally, not behind `:not(.dokan-hide)`: jQuery reveals the pair with
+    // `.show()`, which writes an inline `display` and leaves `dokan-hide` sitting on the
+    // element — so that test never matched and the block got no spacing at all. While it
+    // is genuinely hidden the padding cannot be seen anyway.
+    .tracking-status-other-url,
+    .shipping-tracking-comments {
+        padding-top: 16px;
+    }
+
+    // Pro floats the two fields inside this block and nothing contained them, so it
+    // measured no height of its own and the comment field below landed ~95px adrift.
+    // `overflow` contains them without touching `display`, which jQuery owns here.
+    .tracking-status-other-url {
+        overflow: hidden;
     }
 
     .shipped-tracking-number {
@@ -841,38 +976,71 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The update timeline: a marker column with a connecting line, then the entry. Legacy
-    // paints the whole block on a grey band; here it is a plain closing section of the
-    // row, on the same hairline as the rest.
+    // A delivered or cancelled shipment keeps its form on screen but locked — Pro marks
+    // the selects `disabled` and the inputs `readonly`, yet legacy leaves both looking
+    // live. Painted inert, and mouse-blocked so the date picker cannot open a calendar
+    // over a field the handler will refuse to save anyway.
+    .shippments-tracking-footer select:disabled,
+    .shippments-tracking-footer input[readonly] {
+        background-color: #f9fafb !important;
+        border-color: #e9e9e9 !important;
+        color: #a1a1aa !important;
+        pointer-events: none;
+    }
+
+    // The update timeline is a full-width section closing the shipment row: a header band
+    // on the section grey, flush to the card edges, with its entries below on white. A
+    // nested-card and a painted-gap variant were both tried; this full-width section read
+    // cleanest. Full-bleed over the row's 20px inset, with the bottom margin cancelling
+    // the row's bottom padding so the section reaches the card edge.
     .shipping-status-tracking-shippments-inner .dokan-customer-shipment-notes-list-area {
         margin: 20px -20px -20px;
-        padding: 16px 20px;
+        padding: 0;
         background-color: transparent;
         border-top: 1px solid $od-border;
     }
 
     .dokan-customer-shipment-notes-list-area {
+        // The heading is the section's header band, full width on the same grey as the
+        // card headings. The right padding keeps a long title clear of the toggle.
         h5 {
-            // Room for the toggle in the corner, so a long heading cannot run under it.
             margin: 0;
-            padding-right: 32px;
+            padding: 16px 56px 16px 20px;
+            background-color: #f9fafb;
         }
 
+        // Toggled by jQuery, so no `display` here — padding and the rule above are safe.
+        // The bottom rule closes the section once it is open: the band above it is the
+        // header, and without this the entries ran straight into whatever followed.
         .customer-shipment-list-notes-inner-area {
-            margin-top: 16px;
+            margin: 0;
+            padding: 20px;
+            border-top: 1px solid $od-border;
+            border-bottom: 1px solid $od-border;
         }
 
-        // Legacy indents the list another 15px inside an already-inset block.
-        .dokan-order-updates {
+        // Pro sets `margin: 15px` on this list from a three-class selector nested inside
+        // `.customer-shipment-list-notes-inner-area`. A three-class rule here only ties,
+        // and Pro's `orders.less` is emitted after this bundle, so it won on source order
+        // and pushed every entry 15px right of the 20px inset the rest of the card sits
+        // on — the marker column never lined up with anything above it. Naming the
+        // element as well outranks it.
+        ol.dokan-order-updates {
             margin: 0;
             padding: 0;
         }
 
+        // Every value below is derived from one number — the 28px marker — so the column
+        // stays true if it ever changes: inset = marker + 16px gutter, the line sits on
+        // the marker's centre (28 / 2), and the marker is lifted half its height above the
+        // date's 20px line box so the two share a midline. The design's proportion is a
+        // glyph with clear air inside the ring; at 20px in a 32px circle it crowded the
+        // border, so both are back to the 28 / 15 pairing.
         li {
             margin: 0;
             // The left inset is what clears the marker column. A `padding` shorthand here
             // zeroed it and dropped the bullet on top of the date.
-            padding: 0 0 20px 24px;
+            padding: 0 0 24px 44px;
             font-size: 14px;
             line-height: 22px;
             color: #6b6b6b;
@@ -881,11 +1049,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 padding-bottom: 0;
             }
 
-            // The line joining one entry to the next, hanging from the dot rather than
-            // running the full height of the entry.
+            // The line joining one entry to the next, hanging just below the marker rather
+            // than running the full height of the entry. The marker bottoms out at 24px
+            // (-4 + 28), so 26px leaves the 2px breath that reads as connected rather than
+            // welded to it.
             &::before {
-                top: 10px;
-                left: 4px;
+                top: 26px;
+                left: 14px;
                 width: 1px;
                 // A shade darker than the card's dividers: at 1px the divider grey read as
                 // nothing at all and the entries lost the thread joining them.
@@ -896,24 +1066,47 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 content: none;
             }
 
+            // The marker is the design's delivery badge — a bordered circle with the truck
+            // glyph — drawn entirely here so the markup keeps its bare `li`. `-4px` is
+            // `(20px date line ÷ 2) − (28px marker ÷ 2)`, which puts the two on one midline.
             &::after {
-                top: 5px;
+                top: -4px;
                 left: 0;
-                width: 9px;
-                height: 9px;
-                background-color: #c4c4c4;
+                width: 28px;
+                height: 28px;
+                box-sizing: border-box;
+                background-color: #fff;
+                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236b6b6b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2'/%3E%3Cpath d='M15 18H9'/%3E%3Cpath d='M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14'/%3E%3Ccircle cx='17' cy='18' r='2'/%3E%3Ccircle cx='7' cy='18' r='2'/%3E%3C/svg%3E");
+                background-repeat: no-repeat;
+                background-position: center;
+                background-size: 15px 15px;
+                border: 1px solid $od-border;
             }
         }
 
+        // The date leads each entry, so it carries the entry's weight; the detail lines
+        // below stay quiet.
         .dokan-order-update-meta {
             margin: 0;
-            font-size: 13px;
-            line-height: 18px;
-            color: $od-muted;
+            font-size: 14px;
+            font-weight: 600;
+            line-height: 20px;
+            color: $od-text;
         }
 
+        // `wpautop` splits the note on its blank line, so the detail lines arrive as one
+        // paragraph and the comment as another. 8px sets the detail block under the date;
+        // 12px between blocks is what makes the comment read as a separate remark rather
+        // than a fifth detail line — at the 6px both shared, the two blocks ran together.
         .dokan-order-update-description p {
-            margin: 4px 0 0;
+            margin: 12px 0 0;
+            font-size: 13px;
+            line-height: 20px;
+            color: #6b6b6b;
+
+            &:first-child {
+                margin-top: 8px;
+            }
         }
 
         .clear {
@@ -939,13 +1132,23 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // The template pins 15px inline, which no selector can outrank.
         padding: 20px !important;
 
+        // The theme gives every `form` a rem-based bottom margin — 25.9px here — which
+        // stacked under this form's own 20px padding and left the action row sitting 46px
+        // off the card edge where the rest of the view closes at 20.
+        margin-bottom: 0;
+
         // The item picker leads the form, so it closes on the same step the fields use.
         .woocommerce_order_items_wrapper {
             margin-bottom: 20px;
         }
 
         // Four columns, one per cell the rows render. The checkbox and the quantity are
-        // fixed; the thumbnail takes its width from the order items table above.
+        // fixed; the thumbnail matches the order items table above — 44px on a 16px gap.
+        //
+        // One gutter for the whole row: 20px in to the checkbox, then 16px between each
+        // of checkbox, thumbnail and name. The thumbnail cell was leaving 36px on its
+        // right against 16px on its left, so the name sat visibly further from its image
+        // here than the same pairing does in the table above.
         th.order_item_select,
         td.order_item_select {
             width: 52px;
@@ -955,6 +1158,27 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         td.order_item_select label {
             display: block;
             margin: 0;
+        }
+
+        th.thumb,
+        td.thumb {
+            width: 60px;
+            padding-right: 16px;
+        }
+
+        td.thumb img {
+            display: block;
+            width: 44px;
+            height: 44px;
+            background-color: #f3f4f6;
+            border: 1px solid #e9e9e9;
+            border-radius: 3px;
+            object-fit: cover;
+        }
+
+        th.name,
+        td.name {
+            padding-left: 0;
         }
 
         th.quantity,
@@ -969,6 +1193,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             text-align: center;
         }
 
+        // The quantity is on screen from the start now, greyed until its row is ticked,
+        // so the column reads as "this row has a quantity" rather than as empty space.
+        // Pro marks the wrapper and disables the field together.
+        .shipping-tracking.is-disabled input {
+            background-color: #f9fafb;
+            border-color: #e9e9e9;
+            color: #a1a1aa;
+            cursor: not-allowed;
+        }
+
         // Backing out reads first, committing reads last — the same order as the refund
         // row, and the same 24px clearance from the last field.
         > .dokan-form-group:has(#add-tracking-status-details) {
@@ -981,6 +1215,58 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         #cancel-tracking-status-details {
             order: -1;
         }
+    }
+
+    // One step from a caption to the control it names, everywhere in both shipment forms.
+    // The tracking fields were sitting at 6px against the 8px the rest of the view uses.
+    // `:not(:has(input))` keeps the checkbox rows out of it — those wrap their own control
+    // and are handled as a row below.
+    .shippments-tracking-footer .dokan-control-label:not(:has(input)),
+    #add-shipping-tracking-status-form .dokan-control-label:not(:has(input)) {
+        display: block;
+        margin-bottom: 8px;
+    }
+
+    // `rows="4"` sets the height, but the theme's own row calculation lands short of the
+    // design's box — a floor keeps it a comment field rather than a two-line slot.
+    #tracking_status_comments,
+    .shipping-tracking-comments textarea {
+        min-height: 96px;
+        padding: 10px 12px;
+        resize: vertical;
+    }
+
+    // Chrome paints its own beige over an autofilled field, which is what turned the
+    // tracking number grey the moment it was focused — the rule below is the only way to
+    // repaint it, since the real background is untouchable. The inset shadow covers the
+    // control, and `text-fill` keeps the value legible on it.
+    input:-webkit-autofill,
+    input:-webkit-autofill:hover,
+    input:-webkit-autofill:focus,
+    input:-webkit-autofill:active,
+    textarea:-webkit-autofill,
+    textarea:-webkit-autofill:focus,
+    select:-webkit-autofill,
+    select:-webkit-autofill:focus {
+        -webkit-text-fill-color: $od-text;
+        box-shadow: 0 0 0 1000px #fff inset !important;
+        -webkit-box-shadow: 0 0 0 1000px #fff inset !important;
+        // Chrome repaints its own ground on focus and after any value change, and the
+        // only way to outlast that is to make the transition to it effectively never
+        // arrive. This is the documented workaround, not a hack of ours.
+        transition: background-color 5000s ease-in-out 0s;
+    }
+
+    // And the plain case, stated outright rather than left to whatever the theme happens
+    // to leave behind: a focused control in this view is white, whatever put it otherwise.
+    .dokan-form-control:focus,
+    input[type="text"]:focus,
+    input[type="number"]:focus,
+    input[type="email"]:focus,
+    input[type="url"]:focus,
+    textarea:focus,
+    select:focus {
+        background-color: #fff;
     }
 
     // A label wrapping its own checkbox is a row, not a field caption: the caption rule
@@ -1025,7 +1311,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // selector, so `!important` is the only way to sit it on the card's own inset.
     .shipping-status-tracking-top-info.info-not-shipment-yet {
         margin: 0 !important;
-        padding: 20px !important;
+        // No vertical padding of its own: the button's 16px margins are the whole gap.
+        // With 20px here as well the single action sat in ~76px of air, and the padding
+        // stayed behind as a sliver once the create form hid the button.
+        padding: 0 20px !important;
         border-top: 1px solid $od-border;
         text-align: left;
     }
@@ -1696,6 +1985,37 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin: 16px -20px 0;
         padding: 16px 20px 0;
         border-top: 1px solid $od-border;
+    }
+
+    // Store pickup is the one row in this list Pro wraps in a `div` around its `li`, so
+    // the `li + li` step that spaces every other row skips it entirely and it sat flush
+    // against Customer IP above. The wrapper takes the step instead.
+    .dokan-panel-body.general-details .vendor-store-pickup-location {
+        margin-top: 12px;
+
+        > li {
+            margin: 0;
+        }
+
+        // Treated as the customer note is, not as a field row: a pickup address carries a
+        // date, a time window, a hub name and a street address, and at three lines it
+        // wrapped raggedly around its own label. Block label, value beneath, so both read
+        // straight down the column.
+        > li > span {
+            display: block;
+            margin: 0 0 2px;
+            font-size: 14px;
+            font-weight: 600;
+            line-height: 22px;
+            color: $od-text;
+        }
+
+        > li > div {
+            display: block;
+            font-size: 14px;
+            line-height: 22px;
+            color: #6b6b6b;
+        }
     }
 
     // Inline actions carry a touch more weight than body text so they read as actions.

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -20,8 +20,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Legacy insets its content by 48px for a sidebar nav the panel does not have, which pushes the cards out of line with the page header; `!important` is required because that rule is ID-qualified and no class selector can outrank it.
     .dokan-dashboard-content {
         // The panel already leaves 16px under the header actions; 8px here makes it 24px.
-        padding-block: 8px 0;
-        padding-inline: !important 0;
+        padding-block: 8px 0 !important;
+        padding-inline: 0 !important;
         background: transparent !important;
     }
 
@@ -1619,11 +1619,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             color: #6b6b6b;
         }
 
-        // A pickup address is store data, so on an RTL store it is routinely still Latin; `plaintext` takes the direction from each line's own first strong character, or the browser reorders the time window and throws the label's colon to the wrong end.
-        > li > span,
-        > li > div {
-            unicode-bidi: plaintext;
-        }
+        // Deliberately no `unicode-bidi: plaintext`: it takes direction from the first strong character, so a Latin pickup address turned this row LTR and aligned it against the opposite edge from every other row in the list. Latin content reordering under RTL is how every label on this page already behaves, and an RTL store has these strings translated anyway.
     }
 
     // Inline actions carry a touch more weight than body text so they read as actions.

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -457,29 +457,577 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
+    // ── Shipments ──────────────────────────────────────────────────────────────
+    //
     // Pro's shipment card uses bare `h4`/`h5` tags, so they inherit the theme's heading
     // scale — "Shipment #1" rendered at 22.6px weight 300 inside a card whose own titles
     // are 14px semibold.
     .shippments-tracking-title {
-        font-size: 15px;
+        margin: 0;
+        font-size: 14px;
         font-weight: 600;
-        line-height: 22px;
+        line-height: 20px;
         color: $od-text;
     }
 
+    // The design puts the item count and the tracking link on one quiet line under the
+    // title, separated by a hairline.
     .shippments-tracking-via {
-        margin: 2px 0 0;
-        font-size: 13px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 4px 0 0;
+        font-size: 14px;
         line-height: 20px;
         color: $od-muted;
+
+        strong {
+            font-weight: 400;
+            color: $od-muted;
+        }
+
+        a {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-weight: 500;
+        }
     }
 
     .shipping-status-track-info-heading,
     .dokan-customer-shipment-notes-list-area h5 {
+        margin: 0 0 12px;
         font-size: 14px;
         font-weight: 600;
-        line-height: 22px;
+        line-height: 20px;
         color: $od-text;
+    }
+
+    // A little more room top and bottom than legacy's own margins leave.
+    .shipping-status-tracking-top-info {
+        padding: 4px 20px;
+    }
+
+    // Same voice as the other empty states in this view — "No shipping address set." and
+    // its billing twin — which run 14px on a 28px line in the body grey. Legacy had this
+    // one a shade lighter at #999 on a tighter line, so the two read as different kinds of
+    // message when they are the same kind.
+    .no-shipment-found-desc {
+        font-size: 14px;
+        line-height: 28px;
+        // Legacy sets #999 from a deeper selector; the other empty states in this view run
+        // the body grey, and a lighter one here made this message read as less important
+        // than "No shipping address set." beside it.
+        color: #6b6b6b !important;
+    }
+
+    // Empty state left as legacy renders it: centred, with the action as a filled button.
+    // The design has it left-aligned with the action as a `+` link, and that was built —
+    // but two theme rules repaint `.dokan-btn` on hover (`.dokan-btn-theme:hover` with a
+    // hard-coded fill, and a variable-driven `:is(…)` rule), and although the override
+    // ranked above both, it could not be demonstrated working. Reverted on request rather
+    // than shipped unverified.
+
+    // Each shipment is a row in the card, on the same full-bleed rules the item table and
+    // the downloadable list use.
+    .shipping-status-tracking-shippments-inner {
+        // Unlike the other cards, this one's body has no padding — Pro's markup supplies
+        // its own — so the row already spans the card and the inset belongs here. Pulling
+        // it out with a negative margin as the other sections do overhung the card by 20px
+        // on each side.
+        margin: 0;
+        padding: 20px;
+        // Legacy dresses each row as a little card of its own — a bottom border, a shadow
+        // and a 4px radius. Inside a card that already has all three it read as a second
+        // edge under the last shipment.
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
+
+        + .shipping-status-tracking-shippments-inner {
+            border-top: 1px solid $od-border;
+        }
+
+        // Legacy insets the header, the item list and the tracking form by a further 20px
+        // inside a row that is already inset, so the shipment title and its fields sat
+        // 40px in while the card heading above them sat at 20. Naming the row as well
+        // outranks it — a two-class selector alone ties and loses on source order.
+        > .shippments-tracking-header,
+        > .shippments-tracking-footer {
+            padding: 0;
+        }
+
+        // Same tie, and the reason the rules around the item list stayed at legacy's 2px
+        // #ddd while every other divider in the view is a 1px hairline.
+        > .shippments-tracking-items {
+            padding: 16px 20px;
+            border-top: 1px solid $od-border;
+            border-bottom: 1px solid $od-border;
+        }
+    }
+
+    // With every item shipped this holds nothing at all, and its own padding left an 8px
+    // sliver under the last shipment that read as one more edge.
+    .shipping-status-tracking-top-info:not(:has(*)) {
+        display: none;
+    }
+
+    .shippments-tracking-header {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px 12px;
+
+        > .clear {
+            display: none;
+        }
+    }
+
+    // Pro lays this row out with floats and percentage widths — the status block is
+    // `width: 63%; float: right` from a two-class selector. Naming the header as well
+    // outranks it so the flex row can take over.
+    .shippments-tracking-header .shippments-tracking-title {
+        flex: 1 1 auto;
+        order: 1;
+        width: auto;
+        float: none;
+        margin: 0;
+    }
+
+    // Status is a pill, matching the badges the page header and sidebar already use.
+    .shippments-tracking-header .shippments-statuses {
+        flex: 0 0 auto;
+        order: 2;
+        width: auto;
+        float: none;
+        margin: 0 0 0 auto;
+
+        // Flex rather than `font-size: 0`, which is what closed the whitespace gap
+        // between the badge and the toggle before. The toggle is an empty icon span, so
+        // zeroing the row's font size collapsed it to 0x0 — the chevron was in the DOM
+        // the whole time, unclickable, which is why the shipment could not be opened and
+        // its items, tracking form and update timeline all stayed hidden.
+        .shippments-tracking-status {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            margin: 0;
+        }
+
+        strong {
+            display: inline-flex;
+            align-items: center;
+            padding: 2px 10px;
+            border: 1px solid currentcolor;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 500;
+            line-height: 18px;
+        }
+    }
+
+    // The two expand controls — one on the shipment header, one on the update timeline.
+    // Legacy sizes them 20px with a text indent and leaves the glyph to whichever Font
+    // Awesome the site happens to load; drawn here instead, so the control does not
+    // depend on a font that a theme or another plugin can replace out from under it.
+    .shipment-item-details-tab-toggle,
+    .shipment-notes-details-tab-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        top: auto;
+        margin: 0;
+        border-radius: 6px;
+        color: #6b6b6b;
+        text-indent: 0;
+        cursor: pointer;
+
+        &:hover {
+            background-color: #f3f4f6;
+            color: $od-text;
+        }
+
+        // `currentcolor` through a mask, so the hover state comes for free.
+        &::after {
+            content: "";
+            width: 16px;
+            height: 16px;
+            background-color: currentcolor;
+            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") no-repeat center / 16px 16px;
+            transition: transform 0.15s ease;
+        }
+
+        // Pro's handler flips `dashicons-arrow-up-alt2` on and off in step with the panel
+        // it opens, so the class is a reliable "expanded" flag. The dashicon it names
+        // never renders — the markup ships a Font Awesome chevron — which is why the arrow
+        // never turned round.
+        &:has(.dashicons-arrow-up-alt2)::after {
+            transform: rotate(180deg);
+        }
+
+        // The glyph the markup ships. Hidden rather than restyled so only one chevron can
+        // ever appear, whichever icon font is present.
+        > span {
+            display: none;
+        }
+    }
+
+    // Pro pins this one to the corner of the block. Kept there rather than turned into a
+    // flex row: the block is opened by toggling an inline `display`, and any `display` of
+    // ours on the container would either outrank `.dokan-hide` while it is closed or be
+    // outranked by the inline value once it opens.
+    .dokan-customer-shipment-notes-list-area .shipment-notes-details-tab-toggle {
+        top: 14px;
+        right: 20px;
+    }
+
+    .shippments-tracking-header .shippments-tracking-via {
+        flex: 1 1 100%;
+        order: 3;
+        width: auto;
+        float: none;
+    }
+
+    // The shipment's own item list follows the order table's shape rather than the
+    // theme's default table styling.
+    .shippments-tracking-items {
+        // Pulled out over the row's 20px inset so the rules above and below it run to the
+        // card edges, and the inset put back as padding so the content does not move.
+        // Legacy rules this block off with 2px of #ddd, twice the weight of every other
+        // divider in the view.
+        margin: 20px -20px;
+        padding: 16px 20px;
+        border-top: 1px solid $od-border;
+        border-bottom: 1px solid $od-border;
+
+        table {
+            width: 100%;
+            margin: 0;
+            border-collapse: collapse;
+        }
+
+        td {
+            padding: 10px 12px 10px 0;
+            background-color: transparent !important;
+            border: 0;
+            font-size: 14px;
+            line-height: 20px;
+            color: $od-text;
+            vertical-align: middle;
+        }
+
+        tr + tr td {
+            border-top: 1px solid $od-border;
+        }
+
+        // `.shippments-tracking-items td.thumb img { width: 100% }` ships with Pro and is
+        // one element deeper than a plain descendant selector, so the cell has to be named
+        // or the thumbnail fills its column at 163px.
+        td.thumb {
+            width: 56px;
+        }
+
+        td.thumb img {
+            display: block;
+            width: 36px;
+            height: 36px;
+            background-color: #f3f4f6;
+            border: 1px solid #e9e9e9;
+            border-radius: 3px;
+            object-fit: cover;
+        }
+
+        // The product names the row, so it takes the body colour rather than the theme's
+        // link colour, like the order items table above.
+        a {
+            color: $od-text !important;
+
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
+        }
+
+        strong {
+            font-size: 14px;
+            font-weight: 400;
+            color: $od-muted;
+        }
+    }
+
+    .shippments-tracking-footer {
+        margin-top: 0;
+
+        > .clear {
+            display: none;
+        }
+    }
+
+    // Full-bleed like the rules above and below the item list, rather than a rule floating
+    // inside the row's inset.
+    .shippments-tracking-footer hr,
+    #add-shipping-tracking-status-form > hr {
+        margin: 20px -20px;
+        border: 0;
+        border-top: 1px solid $od-border;
+    }
+
+    // Field rows in the tracking form share the card's rhythm.
+    .shippments-tracking-footer .dokan-form-group,
+    #add-shipping-tracking-status-form > .dokan-form-group {
+        margin-bottom: 16px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    // Pro floats the three tracking fields at 33% with a 2% gutter, which leaves the last
+    // one 35px short of the other two. Equal thirds on a real gap instead.
+    .shipping-status-provider,
+    .shipped-status-date,
+    .shipped-tracking-number {
+        float: left;
+        width: calc((100% - 32px) / 3);
+        margin-right: 16px;
+        overflow: visible;
+    }
+
+    .shipped-tracking-number {
+        margin-right: 0;
+    }
+
+    // Pro pins this field to 98% from an id selector, so it came out a hair narrower than
+    // the two beside it even once the columns matched.
+    input#tracking_status_number {
+        width: 100%;
+    }
+
+    // Everything after the floated row starts a line of its own.
+    .tracking-status-other-url,
+    .shipping-tracking-comments,
+    .shipped-status-is-notify,
+    .shipped-status-update-is-notify,
+    .shippments-tracking-footer-button,
+    #add-shipping-tracking-status-form > .dokan-form-group:has(#add-tracking-status-details) {
+        clear: both;
+    }
+
+    // Update sits where Submit Refund and Add Note sit: on the right, clearing the last
+    // field by the same 24px step.
+    .shippments-tracking-footer-button {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        margin-top: 24px;
+        text-align: right;
+
+        input {
+            margin: 0;
+        }
+    }
+
+    // The template leaves these holding nothing until a response lands in them.
+    #shipment-update-response-area,
+    .shipment-update-response-box {
+        margin: 12px 0 0;
+        font-size: 13px;
+        line-height: 18px;
+
+        &:empty {
+            display: none;
+        }
+    }
+
+    // The update timeline: a marker column with a connecting line, then the entry. Legacy
+    // paints the whole block on a grey band; here it is a plain closing section of the
+    // row, on the same hairline as the rest.
+    .shipping-status-tracking-shippments-inner .dokan-customer-shipment-notes-list-area {
+        margin: 20px -20px -20px;
+        padding: 16px 20px;
+        background-color: transparent;
+        border-top: 1px solid $od-border;
+    }
+
+    .dokan-customer-shipment-notes-list-area {
+        h5 {
+            // Room for the toggle in the corner, so a long heading cannot run under it.
+            margin: 0;
+            padding-right: 32px;
+        }
+
+        .customer-shipment-list-notes-inner-area {
+            margin-top: 16px;
+        }
+
+        // Legacy indents the list another 15px inside an already-inset block.
+        .dokan-order-updates {
+            margin: 0;
+            padding: 0;
+        }
+
+        li {
+            margin: 0;
+            // The left inset is what clears the marker column. A `padding` shorthand here
+            // zeroed it and dropped the bullet on top of the date.
+            padding: 0 0 20px 24px;
+            font-size: 14px;
+            line-height: 22px;
+            color: #6b6b6b;
+
+            &:last-child {
+                padding-bottom: 0;
+            }
+
+            // The line joining one entry to the next, hanging from the dot rather than
+            // running the full height of the entry.
+            &::before {
+                top: 10px;
+                left: 4px;
+                width: 1px;
+                // A shade darker than the card's dividers: at 1px the divider grey read as
+                // nothing at all and the entries lost the thread joining them.
+                background-color: #d9d9d9;
+            }
+
+            &:last-child::before {
+                content: none;
+            }
+
+            &::after {
+                top: 5px;
+                left: 0;
+                width: 9px;
+                height: 9px;
+                background-color: #c4c4c4;
+            }
+        }
+
+        .dokan-order-update-meta {
+            margin: 0;
+            font-size: 13px;
+            line-height: 18px;
+            color: $od-muted;
+        }
+
+        .dokan-order-update-description p {
+            margin: 4px 0 0;
+        }
+
+        .clear {
+            display: none;
+        }
+    }
+
+    // ── Create shipment ────────────────────────────────────────────────────────
+    //
+    // The form Pro reveals under "Create New Shipment". It borrows the order items table's
+    // class names so it inherits that table's shape, but its own chrome came straight from
+    // legacy: a 15px inset pinned inline, a rule that stopped short of the card, and two
+    // native buttons.
+
+    // Only when shipments are already listed above it — otherwise this doubles up with the
+    // card heading's own rule.
+    #dokan-order-shipping-status-tracking-shippments:has(.shipping-status-tracking-shippments-inner)
+        + #dokan-order-shipping-status-tracking {
+        border-top: 1px solid $od-border;
+    }
+
+    #add-shipping-tracking-status-form {
+        // The template pins 15px inline, which no selector can outrank.
+        padding: 20px !important;
+
+        // The item picker leads the form, so it closes on the same step the fields use.
+        .woocommerce_order_items_wrapper {
+            margin-bottom: 20px;
+        }
+
+        // Four columns, one per cell the rows render. The checkbox and the quantity are
+        // fixed; the thumbnail takes its width from the order items table above.
+        th.order_item_select,
+        td.order_item_select {
+            width: 52px;
+            padding-right: 0;
+        }
+
+        td.order_item_select label {
+            display: block;
+            margin: 0;
+        }
+
+        th.quantity,
+        td.quantity {
+            width: 96px;
+        }
+
+        // The template pins 60px inline, which leaves ~34px for the number once the
+        // control's own padding is taken out.
+        td.quantity input {
+            width: 72px !important;
+            text-align: center;
+        }
+
+        // Backing out reads first, committing reads last — the same order as the refund
+        // row, and the same 24px clearance from the last field.
+        > .dokan-form-group:has(#add-tracking-status-details) {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+            margin: 24px 0 0;
+        }
+
+        #cancel-tracking-status-details {
+            order: -1;
+        }
+    }
+
+    // A label wrapping its own checkbox is a row, not a field caption: the caption rule
+    // stacks the text under the box and bolds it.
+    .dokan-form-group > label:has(input[type="checkbox"]) {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin: 0;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 20px;
+        color: $od-text;
+        cursor: pointer;
+    }
+
+    // The browser accent is blue here, and blue appears nowhere else on the page.
+    // Tailwind's form reset paints the checked state with `background-color` rather than
+    // the accent, so both have to be set.
+    input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--color-dokan-btn, #7047eb);
+        cursor: pointer;
+
+        &:checked {
+            background-color: var(--color-dokan-btn, #7047eb);
+            border-color: var(--color-dokan-btn, #7047eb);
+        }
+    }
+
+    // Only where something else owns the gap — the label's own `gap` above, and the
+    // table cell's padding. Left global, this would close up the theme's spacing around
+    // checkboxes that sit loose in their row, such as the refund restock box.
+    .dokan-form-group > label > input[type="checkbox"],
+    td.order_item_select input[type="checkbox"] {
+        margin: 0;
+    }
+
+    // With shipments already listed, this holds the "Create New Shipment" action alone and
+    // reads as the card's closing row. Legacy nudges it with stray margins from an id
+    // selector, so `!important` is the only way to sit it on the card's own inset.
+    .shipping-status-tracking-top-info.info-not-shipment-yet {
+        margin: 0 !important;
+        padding: 20px !important;
+        border-top: 1px solid $od-border;
+        text-align: left;
     }
 
     // Nested panels — one per downloadable file — are rows inside a card, not cards of
@@ -572,7 +1120,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Column headings are labels, not a ruled header band: Inter 12/16 uppercase in the
     // muted grey, with a single rule under the row.
     .woocommerce_order_items thead th {
-        padding: 0 12px 12px 0;
+        // 19px, not 20: the line box adds a pixel below the cap height, so this is what
+        // puts the same 20px of visible air under the labels as the card's inset puts
+        // above them.
+        padding: 0 12px 19px 0;
         border: 0;
         font-size: 12px;
         font-weight: 400;
@@ -592,17 +1143,29 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         vertical-align: middle;
     }
 
-    // The rule belongs to the row, not to its cells. Line items render six cells while a
-    // shipping row renders seven, so a cell-level border stopped 27px short on some rows
-    // and ran to the edge on others — a ragged right edge down the table.
-    .woocommerce_order_items thead tr,
-    .woocommerce_order_items tbody tr {
-        border-bottom: 1px solid $od-border;
+    // Shipping, fee and refund rows render a trailing actions cell that line items do not,
+    // and whose contents Pro has commented out — 34px of nothing. It made the table seven
+    // columns wide with only some rows reaching the last one, so an item row's cells ended
+    // at 1494 while the others reached 1528. A row background paints only under its cells,
+    // so that is where the rule stopped too. Dropping the empty column makes every row the
+    // same six cells. The `:has` guard keeps it if Pro ever puts real actions back.
+    .woocommerce_order_items th.wc-order-edit-line-item,
+    .woocommerce_order_items td.wc-order-edit-line-item:not(:has(a, button, input, select)) {
+        display: none;
     }
 
-    // Last row closes on the totals block's own rule instead of doubling up.
-    .woocommerce_order_items tbody:last-of-type tr:last-child {
+    // Line items render six cells while shipping, fee and refund rows render seven, so
+    // the separator has to be independent of how many cells a row happens to have.
+    //
+    // A `border` cannot do that here. Under `border-collapse: collapse` the edge is
+    // resolved and painted per cell, so a border declared on the row still stops with its
+    // last cell: item rows ended at 1494 and the rest reached 1528, a 34px stub down the
+    // table. Painting the rule as a background instead follows the row box, which spans
+    // the full width whatever the cell count.
+    .woocommerce_order_items thead tr,
+    .woocommerce_order_items tbody tr {
         border-bottom: 0;
+        background: linear-gradient($od-border, $od-border) bottom left / 100% 1px no-repeat;
     }
 
     // Shipping, fee and refund rows carry a Font Awesome glyph where a product has its
@@ -656,10 +1219,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        .order-product-variation {
-            margin: 4px 0 0;
+        .order-product-variation,
+        p.description {
+            margin: 2px 0 0;
             font-size: 13px;
             line-height: 18px;
+            color: $od-muted;
         }
     }
 
@@ -709,7 +1274,9 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Totals: label left, amount right, on the same 14px body scale as the rows above.
     .wc-order-data-row.wc-order-totals-items {
-        margin-top: 20px;
+        // 16px of box puts the first line's ink 20px clear of the rule above it — the
+        // difference is the half-leading the line box adds over the cap height.
+        margin-top: 16px;
         overflow: hidden;
 
         &::before,
@@ -719,7 +1286,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .wc-order-totals td {
-        padding: 9px 0;
+        // 12px gives the list a 44px pitch. The design measures 38, but its rows are a
+        // plain label and figure; ours carry the tips icon and longer localised labels,
+        // which need the extra air to keep from reading as a solid block.
+        padding: 12px 0;
         border: 0;
         font-size: 14px;
         line-height: 20px;
@@ -735,9 +1305,21 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Order Total is the figure the row exists for. It has no class of its own, but it is
     // always the row directly above the refunded one, which does.
     .wc-order-totals tr:has(+ tr .refunded-total) td {
-        padding-top: 16px;
+        padding-top: 18px;
         border-top: 1px solid $od-border;
         font-weight: 600;
+    }
+
+    // Matching air on the other side of that rule — it had the rows' default 9px above
+    // and 16px below, which read as the total leaning away from the list.
+    .wc-order-totals tr:has(+ tr + tr .refunded-total) td {
+        padding-bottom: 18px;
+    }
+
+    // The card body already provides the 20px floor every other section closes on, so the
+    // last row adds nothing of its own.
+    .wc-order-totals tr:last-child td {
+        padding-bottom: 0;
     }
 
     // A refund is money going out, so it reads in the danger colour.
@@ -753,7 +1335,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Coupon codes are chips in the design, not a bulleted list.
     .wc-used-coupons {
-        margin: 20px 0 12px;
+        // The block is a sibling of the totals table inside a full-bleed row, so it needs
+        // the inset the table gets from its own cells or it starts 20px to their left.
+        // No top margin: the row it sits in already carries one, and the two stacked to
+        // 40px below the item table.
+        padding: 0 20px;
+        margin: 0 0 12px;
 
         .wc_coupon_list {
             display: flex;
@@ -765,22 +1352,27 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             list-style: none;
         }
 
+        // The label reads as one of the totals rows it sits with, not as a caption.
         li {
             margin: 0;
-            font-size: 13px;
-            line-height: 18px;
-            color: $od-muted;
+            font-size: 14px;
+            line-height: 20px;
+            color: $od-text;
         }
 
         li.code {
-            padding: 2px 10px;
+            padding: 3px 10px;
             background: #f3f4f6;
+            border: 1px solid $od-border;
             border-radius: 4px;
+            font-size: 13px;
             font-weight: 500;
+            line-height: 18px;
             color: $od-text;
 
             a {
                 color: inherit !important;
+                text-decoration: none;
             }
         }
     }
@@ -822,35 +1414,9 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         box-shadow: none;
     }
 
-    // The design puts the currency on the amount fields as an attached affix, so a bare
-    // number is never mistaken for one. The templates that render these inputs are not
-    // ours to change, so the symbol comes from a custom property the plugin publishes
-    // with the rest of its styles, and the affix is drawn rather than inserted.
-    .woocommerce_order_items td.line_cost .refund,
-    .woocommerce_order_items td.line_tax .refund {
-        display: inline-flex;
-        align-items: stretch;
-
-        &::before {
-            display: flex;
-            align-items: center;
-            padding: 0 9px;
-            background: #f3f4f6;
-            border: 1px solid $od-border;
-            border-right: 0;
-            border-radius: 6px 0 0 6px;
-            font-size: 13px;
-            line-height: 20px;
-            color: #6b6b6b;
-            white-space: nowrap;
-            content: var(--dokan-currency-symbol, "");
-        }
-
-        input {
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
-        }
-    }
+    // No drawn currency affix on these. A grey chip butted against a field reads as a
+    // detached box rather than part of the control, at every width it was tried at. The
+    // currency states itself in the placeholder, which cannot come apart.
 
     .wc-order-data-row.wc-order-refund-items {
         margin-left: -20px;
@@ -863,58 +1429,35 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Label and field belong on the same line. Left alone the label sat at the top of a
     // 56px row while its 38px field centred below it.
+    //
+    // 12px vertical matches the totals list this panel sits under, so the two read as one
+    // rhythm rather than the panel being noticeably tighter. The 20px right is not
+    // optional: this rule is a class deeper than the general `td:last-child` inset, so
+    // without it the values and the restock checkbox sat flush on the card edge.
     .wc-order-refund-items .wc-order-totals td {
-        padding: 8px 0 8px 20px;
+        padding: 12px 20px;
         vertical-align: middle;
     }
 
-    // The value side is laid out rather than merely right-aligned, so the currency affix
-    // can sit against its field the way it does on the line items.
+    // No currency affix on these two. The chip works on the line items, where the field is
+    // 76px and it reads as part of the control, but this field is 411px wide and the chip
+    // just floated at the far end of an empty box. The panel reads as the totals list it
+    // sits under — plain label, plain value — and the field states its currency in the
+    // placeholder instead.
     .wc-order-refund-items .wc-order-totals td.total {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        gap: 0;
-
-        // A float clearer has no job inside a flex row.
+        // A float clearer has no job here.
         > .clear {
             display: none;
         }
-
-        > input[type="text"],
-        > input.wc_input_price {
-            flex: 1 1 auto;
-            min-width: 0;
-            width: auto;
-        }
-    }
-
-    .wc-order-refund-items .wc-order-totals td.total:has(> input.wc_input_price)::before {
-        flex: 0 0 auto;
-        align-self: stretch;
-        display: flex;
-        align-items: center;
-        padding: 0 10px;
-        background: #f3f4f6;
-        border: 1px solid $od-border;
-        border-right: 0;
-        border-radius: 6px 0 0 6px;
-        font-size: 14px;
-        color: #6b6b6b;
-        white-space: nowrap;
-        content: var(--dokan-currency-symbol, "");
-    }
-
-    .wc-order-refund-items .wc-order-totals td.total:has(> input.wc_input_price) > input {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
     }
 
     // The amount field stays disabled until a quantity or line amount is entered, so it
-    // should read that way rather than inviting a value it will not accept.
+    // should read that way rather than inviting a value it will not accept. Fading it
+    // rather than filling it grey keeps the field looking like the one it becomes when it
+    // is enabled — the change is in weight, not in kind.
     .wc-order-refund-items input:disabled {
-        background: #f3f4f6;
-        color: $od-muted;
+        background: #fff;
+        opacity: 0.5;
         cursor: not-allowed;
     }
 
@@ -961,13 +1504,23 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         align-items: center;
         justify-content: flex-end;
         gap: 8px;
-        margin-top: 16px;
-        padding: 0 20px 4px;
+        // 24px clears the last field by the same step the fields clear each other. Nothing
+        // below: the card body already provides the 20px floor, and adding to it closed
+        // this section on 40px where every other one closes on 20.
+        margin-top: 24px;
+        padding: 0 20px;
 
-        // Legacy button margins pushed the pair 8px off the right edge the fields above
-        // them sit on.
+        // Legacy button margins pushed the pair off the right edge the fields above them
+        // sit on.
         button {
             margin: 0 !important;
+        }
+
+        // The template closes this row with a float clearer. As a flex item it takes a
+        // slot of its own after Submit, and the row's 8px gap with it — which is exactly
+        // how far short of the fields the buttons were landing.
+        > .clear {
+            display: none;
         }
 
         // Backing out reads first, committing reads last.
@@ -976,17 +1529,45 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Cancel backs out of the flow; it should not carry the same weight as the action
-    // that submits money.
-    .wc-order-refund-items .cancel-action {
-        background: #fff !important;
-        border: 1px solid $od-border !important;
-        color: $od-text !important;
-        text-shadow: none;
+    // Two button weights in this view, and both need stating because the theme paints
+    // `.dokan-btn` and `.dokan-btn:hover` the same regardless of role.
+    //
+    // Secondary — the two Cancels — take the treatment the panel's own Back button sets:
+    // white ground, brand border, brand label, tinting rather than filling on hover. Left
+    // to the theme they turn into a second primary the moment the pointer touches them.
+    .cancel-action,
+    .dokan-cancel-status {
+        // The hover state is handed over rather than fought for. The colour module paints
+        // `.dokan-btn:hover` from three custom properties, as `!important` and from a
+        // selector no rule reachable from here can outrank — competing with it on
+        // specificity failed, and an inline `!important` was the only thing that ever won.
+        // Redefining the properties on the button lets the module's own rule paint the
+        // secondary treatment: a tint rather than a fill, with the brand kept for the
+        // border and the label.
+        //
+        // `--color-dokan-btn` itself is deliberately not shadowed here — the values below
+        // read it, and the resting rule underneath needs it to still mean the brand.
+        --color-dokan-btn-hover: #{"color-mix(in srgb, var(--color-dokan-btn, #7047eb) 10%, #fff)"};
+        --color-dokan-btn-border-hover: var(--color-dokan-btn, #7047eb);
+        --color-dokan-btn-text-hover: var(--color-dokan-btn, #7047eb);
 
+        background: #fff !important;
+        border: 1px solid var(--color-dokan-btn, #7047eb) !important;
+        color: var(--color-dokan-btn, #7047eb) !important;
+        text-shadow: none;
+    }
+
+    // Primary — everything else — darkens. The theme's hover reached the `<button>`s
+    // carrying `.dokan-btn-default` but not Update, which is an `<input>` on
+    // `.dokan-btn-success`, so identical-looking buttons behaved differently under the
+    // pointer.
+    .dokan-btn:not(.cancel-action):not(.dokan-cancel-status),
+    input[type="submit"].dokan-btn {
         &:hover,
         &:focus {
-            background: #f9fafb !important;
+            background: color-mix(in srgb, var(--color-dokan-btn, #7047eb) 86%, #000) !important;
+            border-color: color-mix(in srgb, var(--color-dokan-btn, #7047eb) 86%, #000) !important;
+            color: #fff !important;
         }
     }
 }
@@ -1117,6 +1698,11 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border-top: 1px solid $od-border;
     }
 
+    // Inline actions carry a touch more weight than body text so they read as actions.
+    .dokan-edit-status {
+        font-weight: 600;
+    }
+
     // Status reads as a pill rather than a legacy square badge.
     .dokan-label {
         display: inline-flex;
@@ -1158,13 +1744,6 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 &:last-child {
                     border-bottom: 0;
                 }
-            }
-
-            // Customer-visible notes keep a marker: the design tells them apart by a
-            // text label, which CSS cannot add without hardcoding an untranslatable
-            // string.
-            li.customer-note {
-                border-left: 2px solid var(--color-dokan-btn, #7047eb);
             }
 
             .note_content {
@@ -1264,37 +1843,6 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Shared control styling across the sidebar (notes, delivery time).
-    input[type="text"],
-    input[type="number"],
-    input[type="email"],
-    select,
-    textarea,
-    .dokan-form-control,
-    .form-control {
-        width: 100%;
-        padding: 8px 12px;
-        background: #fff;
-        border: 1px solid $od-border;
-        border-radius: 6px;
-        font-size: 14px;
-        line-height: 20px;
-        color: $od-text;
-        box-shadow: none;
-
-        &::placeholder {
-            color: $od-muted;
-        }
-    }
-
-    // Legacy pins selects to 35px while the button sits at 43px, leaving the note row
-    // visibly uneven. One height for both settles it.
-    input[type="text"],
-    input[type="number"],
-    input[type="email"],
-    select {
-        height: 38px;
-    }
 
     // Delivery / Store Pickup choice row.
     #vendor-delivery-type {
@@ -1401,6 +1949,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         resize: vertical;
     }
 
+}
+
+// ── Buttons ────────────────────────────────────────────────────────────────────
+//
+// One button standard for the whole view, for the same reason as the controls below: this
+// lived under `.dokan-order-right-content` and reached only the sidebar, so the sidebar's
+// buttons sat at 38px on a 6px radius while Request Refund and Create New Shipment in the
+// main column kept legacy's 3px.
+
+.dokan-order-details-fragment {
     a.dokan-btn {
         display: inline-flex;
         align-items: center;
@@ -1417,6 +1975,78 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         font-weight: 500;
         text-shadow: none;
         box-shadow: none;
+    }
+
+    // `.dokan-dashboard-wrap .dokan-btn.dokan-btn-theme` pins 3px as `!important`, which
+    // left Create New Shipment and the delivery-time Update on a different corner from
+    // every other button in the view. Naming the modifier as well outranks it.
+    &#{&} {
+        .dokan-btn,
+        .dokan-btn.dokan-btn-theme,
+        .dokan-btn.dokan-btn-default,
+        input[type="submit"].dokan-btn {
+            border-radius: 6px !important;
+        }
+    }
+}
+
+// ── Form controls ──────────────────────────────────────────────────────────────
+//
+// One control standard for the whole view. This lived under `.dokan-order-right-content`
+// and so only ever reached the sidebar, which is why the Shipments card's selects came
+// out 35px with square corners and its inputs 37px while the notes and delivery-time
+// fields beside them were 38px on a 6px radius.
+
+.dokan-order-details-fragment {
+    input[type="text"],
+    input[type="number"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    select,
+    textarea,
+    .dokan-form-control,
+    .form-control {
+        width: 100%;
+        padding: 8px 12px;
+        background: #fff;
+        border: 1px solid $od-border;
+        border-radius: 6px;
+        font-size: 14px;
+        line-height: 20px;
+        color: $od-text;
+        box-shadow: none;
+
+        &::placeholder {
+            color: $od-muted;
+        }
+    }
+
+    // Legacy pins selects to 35px while the button beside them sits at 43px, leaving a
+    // row visibly uneven. One height for all of them settles it.
+    input[type="text"],
+    input[type="number"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    select,
+    select.dokan-form-control,
+    select.form-control {
+        // `select.dokan-form-control` pins 35px at the same specificity as a bare `select`
+        // here and wins on source order, so the class has to be named explicitly or the
+        // selects sit 3px shorter than the inputs beside them.
+        height: 38px;
+    }
+
+    // Field labels: the design's small dark caption, not the theme's 16px body text.
+    .dokan-form-group > label,
+    .shippments-tracking-footer label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        line-height: 18px;
+        color: $od-text;
     }
 }
 
@@ -1440,6 +2070,21 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         border-color: var(--color-dokan-btn, #7047eb) !important;
         outline: none !important;
         box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-dokan-btn, #7047eb) 18%, transparent) !important;
+    }
+}
+
+// ── Panel header ───────────────────────────────────────────────────────────────
+//
+// The header is React, outside the fragment, so it is reached through the page — the
+// same `:has()` guard the grey canvas and the date picker use. Its buttons come from the
+// shared component library at Tailwind's 4px `rounded`, while every control and button
+// inside the view sits at 6px, which put the two buttons closest to the card on a
+// different corner radius from everything they sit above.
+body:has(.dokan-order-details-fragment) {
+    .dokan-header-actions button,
+    .dokan-header-actions a {
+        // Tailwind's `rounded` is emitted `!important` in this build.
+        border-radius: 6px !important;
     }
 }
 

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -20,7 +20,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Legacy insets its content by 48px for a sidebar nav the panel does not have, which pushes the cards out of line with the page header; `!important` is required because that rule is ID-qualified and no class selector can outrank it.
     .dokan-dashboard-content {
         // The panel already leaves 16px under the header actions; 8px here makes it 24px.
-        padding: 8px 0 0 !important;
+        padding-block: 8px 0;
+        padding-inline: !important 0;
         background: transparent !important;
     }
 
@@ -261,7 +262,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // Height, not min-height: the inner search input grows the box, and pushed this to 46px next to the two 40px fields above it.
         height: 40px;
         min-height: 40px;
-        padding: 3px 12px 3px 36px;
+        padding-block: 3px 3px;
+        padding-inline: 36px 12px;
         background-color: #fff;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
         background-repeat: no-repeat;
@@ -377,7 +379,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         // Calendar affordance on the expiry field; `!important` to match the shared padding, which needs it to beat Tailwind's `.form-input` and would otherwise pull the text back under the icon.
         input.datepicker {
-            padding-left: 38px !important;
+            padding-inline-start: 38px !important;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E");
             background-repeat: no-repeat;
             background-position: left 12px center;
@@ -608,7 +610,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // Kept pinned to the corner rather than made a flex row: the block opens by toggling an inline `display`, so any `display` of ours would either outrank `.dokan-hide` while closed or lose to the inline value once open.
     .dokan-customer-shipment-notes-list-area .shipment-notes-details-tab-toggle {
         top: 12px;
-        right: 16px;
+        inset-inline-end: 16px;
     }
 
     .shippments-tracking-header .shippments-tracking-via {
@@ -632,7 +634,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
 
         td {
-            padding: 12px 12px 12px 0;
+            padding-block: 12px 12px;
+            padding-inline: 0 12px;
             background-color: transparent !important;
             border: 0;
             font-size: 14px;
@@ -642,8 +645,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
 
         td:last-child {
-            padding-right: 20px;
-            text-align: right;
+            padding-inline-end: 20px;
+            text-align: end;
             white-space: nowrap;
         }
 
@@ -660,7 +663,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         td.thumb {
             width: 68px;
             min-width: 68px;
-            padding-left: 20px;
+            padding-inline-start: 20px;
         }
 
         td.thumb img {
@@ -732,7 +735,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .shipped-tracking-number {
         float: left;
         width: calc((100% - 32px) / 3);
-        margin-right: 16px;
+        margin-inline-end: 16px;
         margin-bottom: 0;
         overflow: visible;
     }
@@ -749,7 +752,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .shipped-tracking-number {
-        margin-right: 0;
+        margin-inline-end: 0;
     }
 
     // Pro pins this field to 98% from an id selector, so it stayed a hair narrower than the two beside it even once the columns matched.
@@ -773,7 +776,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         flex-direction: column;
         align-items: flex-end;
         margin-top: 24px;
-        text-align: right;
+        text-align: end;
 
         input {
             margin: 0;
@@ -813,7 +816,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // The heading is the section's header band, on the same grey as the card headings, with right padding keeping a long title clear of the toggle.
         h5 {
             margin: 0;
-            padding: 16px 56px 16px 20px;
+            padding-block: 16px 16px;
+            padding-inline: 20px 56px;
             background-color: #f9fafb;
         }
 
@@ -835,7 +839,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         li {
             margin: 0;
             // The left inset is what clears the marker column; a `padding` shorthand zeroed it and dropped the bullet on top of the date.
-            padding: 0 0 24px 44px;
+            padding-block: 0 24px;
+            padding-inline: 44px 0;
             font-size: 14px;
             line-height: 22px;
             color: #6b6b6b;
@@ -847,7 +852,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             // The line joining one entry to the next hangs just below the marker rather than running the entry's full height, with 2px of breath so it reads as connected rather than welded to it.
             &::before {
                 top: 26px;
-                left: 14px;
+                inset-inline-start: 14px;
                 width: 1px;
                 // A shade darker than the card's dividers, which at 1px read as nothing at all and lost the thread joining the entries.
                 background-color: #d9d9d9;
@@ -860,7 +865,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             // The design's delivery badge, drawn entirely here so the markup keeps its bare `li`; `-4px` puts the 28px marker on the 20px date line's midline.
             &::after {
                 top: -4px;
-                left: 0;
+                inset-inline-start: 0;
                 width: 28px;
                 height: 28px;
                 box-sizing: border-box;
@@ -924,7 +929,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         th.order_item_select,
         td.order_item_select {
             width: 52px;
-            padding-right: 0;
+            padding-inline-end: 0;
         }
 
         td.order_item_select label {
@@ -936,12 +941,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         th.thumb,
         td.thumb {
             width: 60px;
-            padding-right: 16px;
+            padding-inline-end: 16px;
         }
 
         th.name,
         td.name {
-            padding-left: 0;
+            padding-inline-start: 0;
         }
 
         th.quantity,
@@ -1056,7 +1061,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // No vertical padding of its own: the button's 16px margins are the whole gap, and 20px here left the single action in ~76px of air and a leftover sliver once the create form hid the button.
         padding: 0 20px !important;
         border-top: 1px solid $od-border;
-        text-align: left;
+        text-align: start;
     }
 
     // Nested panels — one per downloadable file — are rows inside a card, not cards of their own, so they are flattened onto the card's single 20px inset.
@@ -1113,26 +1118,27 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // The table is pulled out over the body's 20px inset and the edge cells put it back, so the rules between rows run to the card edges while the content stays aligned with the heading above.
     .woocommerce_order_items_wrapper,
     .wc-order-data-row.wc-order-totals-items {
-        margin-left: -20px;
-        margin-right: -20px;
+        margin-inline-start: -20px;
+        margin-inline-end: -20px;
     }
 
     .woocommerce_order_items th:first-child,
     .woocommerce_order_items td:first-child,
     .wc-order-totals td:first-child {
-        padding-left: 20px;
+        padding-inline-start: 20px;
     }
 
     .woocommerce_order_items th:last-child,
     .woocommerce_order_items td:last-child,
     .wc-order-totals td:last-child {
-        padding-right: 20px;
+        padding-inline-end: 20px;
     }
 
     // Column headings are labels, not a ruled header band: 12/16 uppercase in the muted grey, with a single rule under the row.
     .woocommerce_order_items thead th {
         // 19px, not 20: the line box adds a pixel below the cap height, so this puts the same 20px of visible air under the labels as the card's inset puts above them.
-        padding: 0 12px 19px 0;
+        padding-block: 0 19px;
+        padding-inline: 0 12px;
         border: 0;
         font-size: 12px;
         font-weight: 400;
@@ -1144,7 +1150,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .woocommerce_order_items tbody td {
-        padding: 16px 12px 16px 0;
+        padding-block: 16px 16px;
+        padding-inline: 0 12px;
         border: 0;
         font-size: 14px;
         line-height: 20px;
@@ -1183,7 +1190,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .woocommerce_order_items td.thumb {
         // Border-box, so this carries the card inset and the gap as well as the image (20 + 44 + 16); at 60 the padding ate it and the image rendered 24px wide.
         width: 80px;
-        padding-right: 16px;
+        padding-inline-end: 16px;
 
         img {
             display: block;
@@ -1248,7 +1255,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .woocommerce_order_items td.line_cost,
     .woocommerce_order_items th.line_tax,
     .woocommerce_order_items td.line_tax {
-        text-align: left;
+        text-align: start;
         white-space: nowrap;
     }
 
@@ -1283,7 +1290,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     .wc-order-totals td.total {
         width: 35%;
-        text-align: right;
+        text-align: end;
         white-space: nowrap;
     }
 
@@ -1391,8 +1398,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     // No drawn currency affix on these: a grey chip butted against a field read as a detached box at every width it was tried at, and the placeholder states the currency without coming apart.
 
     .wc-order-data-row.wc-order-refund-items {
-        margin-left: -20px;
-        margin-right: -20px;
+        margin-inline-start: -20px;
+        margin-inline-end: -20px;
         padding: 20px 0 0;
         // No rule of its own: the item table's last row already draws one directly above, and the two sat 1px apart and read as a single thick stripe.
         border-top: 0;
@@ -1495,7 +1502,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
             // Figma labels the value, not the other way round: dark semibold label, grey value.
             > span:first-child {
-                margin-right: 6px;
+                margin-inline-end: 6px;
                 font-size: 14px;
                 font-weight: 600;
                 color: $od-text;
@@ -1597,8 +1604,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             display: block;
             margin: 0 0 2px;
             // Both sides stated outright: a longhand elsewhere leaves 6px on this label's inline end, which reads as nothing in LTR but pushes the label off the rail the rest of the list sits on once the column is mirrored.
-            margin-right: 0;
-            margin-left: 0;
+            margin-inline-end: 0;
+            margin-inline-start: 0;
             font-size: 14px;
             font-weight: 600;
             line-height: 22px;
@@ -1693,7 +1700,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
             // "Delete note" is an action, so it reads in the action colour.
             .delete_note {
-                margin-left: 10px;
+                margin-inline-start: 10px;
                 font-weight: 500;
                 color: var(--color-dokan-btn, #7047eb);
 
@@ -1755,7 +1762,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         input[type="submit"] {
             flex: 0 0 auto;
-            margin-left: auto;
+            margin-inline-start: auto;
             width: auto;
         }
     }
@@ -1815,7 +1822,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             cursor: pointer;
 
             &:last-of-type {
-                margin-right: 0;
+                margin-inline-end: 0;
             }
         }
     }
@@ -1828,7 +1835,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: #6b6b6b;
 
         > span:first-child {
-            margin-right: 4px;
+            margin-inline-end: 4px;
             font-size: 14px;
             font-weight: 600;
             color: $od-text;
@@ -1839,7 +1846,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     select,
     select.dokan-form-control,
     select.form-control {
-        padding-right: 34px;
+        padding-inline-end: 34px;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
         background-repeat: no-repeat;
         background-position: right 12px center;

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -1,15 +1,4 @@
-// Vendor panel look and feel for the server-rendered order details fragment.
-//
-// Scoped to `.dokan-order-details-fragment`, a wrapper only the panel adds (see
-// DetailsFragment::wrap()). The legacy order details page never carries it and never
-// loads this bundle, so its appearance is untouched.
-//
-// Tokens follow the panel's own React screens rather than the legacy stylesheet — the
-// RFQ edit-quote screen is the reference: 8px radius, shadow instead of a border,
-// gray-200 dividers, 20px section padding, a 320px sidebar and a 24px column gap.
-//
-// Plain CSS on purpose: module SCSS compiles outside the `dokan-tailwind` bundle, so
-// `@apply` has no theme to resolve against here.
+// Vendor panel look and feel for the server-rendered order details fragment: scoped to `.dokan-order-details-fragment`, a wrapper only the panel adds, so the legacy page is untouched; tokens follow the panel's own React screens (the RFQ edit-quote screen) rather than the legacy stylesheet, and it stays plain CSS because module SCSS compiles outside the `dokan-tailwind` bundle, where `@apply` has no theme to resolve against.
 
 $od-text: #25252d;
 $od-muted: #828282;
@@ -21,21 +10,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 .dokan-dashboard-content:has(.dokan-order-details-fragment) {
     background-color: #f0f0f1;
 
-    // The page-header status badge already shares the sidebar badge's colours through
-    // its `dokan-badge-*` class; `currentcolor` gives it the matching outline for free,
-    // whatever the status.
+    // The header badge already carries the status colours through its `dokan-badge-*` class, so `currentcolor` gives it a matching outline whatever the status.
     .dokan-header-title [class*="dokan-badge-"] {
         border: 1px solid currentcolor;
     }
 }
 
 .dokan-order-details-fragment {
-    // The legacy page insets its content by 48px because it sits beside a sidebar nav.
-    // In the panel that pushes the cards out of line with the page header on both edges.
-    //
-    // `!important` is required, not lazy: the legacy rule is
-    // `.dokan-dashboard #dokan-dashboard-fullwidth-wrapper .dokan-dashboard-wrap
-    // .dokan-dashboard-content`, whose ID no class selector can outrank.
+    // Legacy insets its content by 48px for a sidebar nav the panel does not have, which pushes the cards out of line with the page header; `!important` is required because that rule is ID-qualified and no class selector can outrank it.
     .dokan-dashboard-content {
         // The panel already leaves 16px under the header actions; 8px here makes it 24px.
         padding: 8px 0 0 !important;
@@ -46,8 +28,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background: transparent;
     }
 
-    // Legacy floats leave slack and a percentage gutter, so the row neither fills the
-    // width nor honours a fixed gap. Flex does both without moving either column.
+    // Legacy floats with a percentage gutter neither fill the width nor honour a fixed gap; flex does both without moving either column.
     .dokan-order-details-wrap {
         display: flex;
         align-items: flex-start;
@@ -60,8 +41,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Same story for the gutter: `.dokan-orders-content .dokan-orders-area
-    // .dokan-order-left-content { margin: 3% }` outranks a two-class selector.
+    // Same story for the gutter: legacy's three-class `.dokan-order-left-content { margin: 3% }` outranks a two-class selector.
     .dokan-order-left-content,
     .dokan-order-right-content {
         float: none;
@@ -104,8 +84,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         box-shadow: $od-shadow;
     }
 
-    // Qualified with `.dokan-panel-default >`: the legacy grey-heading rule has the
-    // same specificity as a two-class selector and wins on source order.
+    // Qualified with `.dokan-panel-default >` because the legacy grey-heading rule ties a two-class selector and wins on source order.
     .dokan-panel-default > .dokan-panel-heading,
     .dokan-panel-heading {
         padding: 16px 20px;
@@ -127,9 +106,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 }
 
-// The main column mixes full-width cards with a two-up address row. Legacy floats them,
-// which cannot equalise the pair's height, so the shorter card stopped short of its
-// neighbour. Flex does, and keeps the same order and widths.
+// Flex rather than legacy's floats, which cannot equalise the address pair's height, so the shorter card stopped short of its neighbour.
 .dokan-order-details-fragment .dokan-order-left-content > .dokan-clearfix {
     display: flex;
     flex-wrap: wrap;
@@ -140,23 +117,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         content: none;
     }
 
-    // `gap` owns the spacing; the legacy percentage margins would push the address pair
-    // past 100% of the row and wrap it.
-    //
-    // `min-width` needs `!important` for the same reason, from a rule one class deeper:
-    // legacy pins the address columns to `min-width: 49%`, which only leaves room for the
-    // pair plus the 24px gap while the row is at least 1200px wide. Below that the minimum
-    // outgrows the basis and the second address drops to its own line — so the layout
-    // silently changed with the window rather than staying a two-column pair.
+    // `gap` owns the spacing, and `min-width` needs `!important` to beat legacy's `min-width: 49%` — which outgrows the basis below ~1200px and silently drops the second address onto its own line.
     > * {
         flex: 0 0 100%;
         min-width: 0 !important;
         margin: 0 !important;
     }
 
-    // The address pair shares the row, splitting it around the 24px gap. Sized from a
-    // width rather than a percentage so the pair stacks when there is genuinely no room
-    // for two columns — a 50% basis would hold two 150px columns on a phone.
+    // Sized from a width rather than a 50% basis so the pair stacks when there is genuinely no room for two columns, instead of holding two 150px columns on a phone.
     > .dokan-left {
         flex: 1 1 320px;
     }
@@ -181,18 +149,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 .dokan-order-details-fragment {
     .dokan-order-billing-address .dokan-panel-body,
     .dokan-order-shipping-address .dokan-panel-body {
-        // A 28px line box around 14px text carries ~7px of half-leading above the first
-        // line and below the last, so a flat 20px pad reads as ~27px vertically against
-        // a true 20px on the sides. Trimming the vertical pad evens the optical inset.
+        // Trimmed vertically because a 28px line box around 14px text adds half-leading above the first line and below the last, so a flat 20px pad reads wider than the true 20px on the sides.
         padding: 13px 20px;
         font-size: 14px;
-        // Addresses run to many short lines with no separators between fields, so they
-        // need noticeably more leading than the single-line rows elsewhere to stay
-        // readable as distinct lines.
+        // Addresses run to many short lines with no separators between fields, so they need more leading than the single-line rows elsewhere to read as distinct lines.
         line-height: 28px;
         color: #6b6b6b;
-        // Addresses are free text and can carry long unbroken tokens; wrap rather than
-        // push the card wider than its column.
+        // Addresses are free text and can carry long unbroken tokens; wrap rather than push the card wider than its column.
         overflow-wrap: anywhere;
 
         address,
@@ -202,19 +165,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The download permission details live in a Bootstrap `.panel-collapse.collapse`,
-    // and the panel's own Tailwind bundle defines `.dokan-layout .collapse` as the
-    // `visibility: collapse` utility — same class name, opposite meaning. That collision
-    // hid Downloads Remaining, Access Expires and the download count, which the legacy
-    // page shows because it never loads Tailwind. The design has them always visible.
-    // `!important` is required: the utility is emitted important, so no specificity wins.
+    // Bootstrap's `.panel-collapse.collapse` collides with the panel's Tailwind `visibility: collapse` utility and hid the permission details the legacy page shows; the utility is emitted `!important`, so no specificity wins.
     .panel-collapse.collapse {
         visibility: visible !important;
         height: auto;
     }
 
-    // Title and Revoke share one row, pushed apart — the design's justify-between.
-    // The legacy markup floats the button, which the flex row makes redundant.
+    // Title and Revoke share one justified row, which makes legacy's float on the button redundant.
     .order_download_permissions .dokan-panel-heading {
         display: flex;
         align-items: center;
@@ -222,11 +179,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         gap: 16px;
     }
 
-    // Headings/H4 in the design: 14px semibold at the body text colour. The markup makes
-    // it an `<a>` (it toggles the collapse), so it arrives as a brand-coloured link.
-    // Two of the three parts are links — the product, and the file the permission grants
-    // access to — so those keep the link colour while the connective text stays body
-    // coloured. That contrast is what makes it readable as "these bits are clickable".
+    // The heading is an `<a>` because it toggles the collapse, so it arrives brand-coloured; keeping the link colour on the product and the file while the connective text stays body-coloured is what shows which bits are clickable.
     .order_download_permissions .dokan-panel-heading .title {
         flex: 1 1 auto;
         min-width: 0;
@@ -246,8 +199,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         flex: 0 0 auto;
         float: none;
         height: auto;
-        // `!important`: legacy's `.btn-sm` keeps 10px of side padding, which stopped the
-        // label 10px short of the counter beneath it on the same right edge.
+        // `!important` because legacy's `.btn-sm` side padding stopped the label 10px short of the counter beneath it on the same right edge.
         padding: 0 !important;
         background: transparent !important;
         border: 0 !important;
@@ -258,16 +210,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: var(--color-dokan-btn, #7047eb) !important;
     }
 
-    // Product search: the design's bordered field with a magnifier, and a real gap
-    // before Grant Access. The legacy toolbar relies on a grid that collapses here.
+    // The design's bordered field with a magnifier and a real gap before Grant Access; the legacy toolbar relies on a grid that collapses here.
     .order_download_permissions .toolbar {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
         gap: 16px;
-        // `!important` because legacy sets `margin-top: 15px` from a four-class selector,
-        // which stacked on the last row's 30px and left a wider gap above the rule here
-        // than between the file rows.
+        // `!important` because legacy's four-class `margin-top: 15px` stacked on the last row's spacing and left a wider gap above this rule than between the file rows.
         margin: 0 -20px !important;
         padding: 0 20px;
 
@@ -283,8 +232,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             float: none;
         }
 
-        // select2 mounts its dropdown as a sibling of the field inside this flex column,
-        // so without this it becomes a flex item and pushes Grant Access down.
+        // select2 mounts its dropdown as a sibling of the field inside this flex column, where it would otherwise become a flex item and push Grant Access down.
         > .select2-container--open .select2-dropdown {
             width: 100% !important;
         }
@@ -294,11 +242,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // A rule above the add-product toolbar, on the same full-bleed line as the dividers
-    // between files, so the list reads as separate from the control that adds to it —
-    // including when there is a single permission and no between-file rules at all.
-    // Conditional on the list actually having rows: with none, a lone rule hanging under
-    // the card header separates nothing.
+    // A full-bleed rule above the add-product toolbar so the list reads as separate from the control that adds to it, conditional on the list having rows — under an empty list a lone rule separates nothing.
     .order_download_permissions .panel-group {
         margin-bottom: 0;
     }
@@ -314,8 +258,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .order_download_permissions .select2-container .select2-selection {
-        // Height, not min-height: the inner search input is what grows the box, and it
-        // pushed this to 46px next to the two 40px fields above it.
+        // Height, not min-height: the inner search input grows the box, and pushed this to 46px next to the two 40px fields above it.
         height: 40px;
         min-height: 40px;
         padding: 3px 12px 3px 36px;
@@ -342,9 +285,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The permission fields are a fixed-layout table whose first row has one cell and
-    // second has two, so the meta line only ever filled the left 60%. Laid out as blocks
-    // they stack full width, the way the design shows them.
+    // The permission fields are a fixed-layout table whose meta line only ever filled the left 60%, so the cells are laid out as blocks to stack full width.
     .wc-metabox-content {
         display: block;
         width: 100%;
@@ -361,11 +302,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             width: auto !important;
             // 20px from a field to the label under it, per the design's row rhythm.
             padding: 0 0 20px;
-            // The theme zebra-stripes tables — `table:not(.has-background) tbody td` plus a
-            // `tr:nth-child(2n) td` override — which, once the table is laid out as blocks,
-            // reads as grey bands running the width of the card behind the labels. The
-            // striping selector is four element-selectors deep, so it cannot be outranked
-            // from here on specificity alone.
+            // The theme's zebra striping is four element-selectors deep and cannot be outranked on specificity, and once the table is laid out as blocks it read as grey bands running behind the labels.
             background-color: transparent !important;
             border: 0;
             font-size: 14px;
@@ -377,8 +314,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             padding-bottom: 0;
         }
 
-        // Headings/H6: 12px semibold, 130%. 27px from the top of the label to the top of
-        // its field is the design's measured gap.
+        // Headings/H6 at the design's measured 27px from the top of the label to the top of its field.
         label {
             display: block;
             margin-bottom: 11px;
@@ -389,11 +325,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             color: $od-text;
         }
 
-        // The design pairs each field label with its counter on one row — label left,
-        // counter right. The counter lives in its own leading row in this markup, so it
-        // is lifted by exactly its own height onto the following row's line, which lands
-        // the two on a shared baseline without either one moving the fields below.
-        // Paragraphs/Small: 12px regular, 140%.
+        // The design pairs each label with its counter on one row, but the counter has a leading row of its own here, so it is lifted by exactly its own height onto the following row's line without moving the fields below.
         tr:first-child td {
             display: flex;
             justify-content: flex-end;
@@ -414,10 +346,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        // Beats the inline `width: 150px` on both fields. The `!important` run is for the
-        // number field only in practice: it carries Tailwind's `.form-input`, which this
-        // build emits with `!important`, so specificity alone left it square-cornered,
-        // 16px and grey-bordered next to an identically-sized sibling.
+        // Beats the inline `width: 150px`; the `!important` run is for the number field, which carries Tailwind's `.form-input` — emitted `!important` in this build, so specificity alone left it square-cornered and grey-bordered beside an identical sibling.
         input[type="number"],
         input[type="text"] {
             width: 100% !important;
@@ -446,9 +375,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        // Calendar affordance on the expiry field, matching the design. `!important` to
-        // match the shared padding above, which needs it to beat Tailwind's `.form-input`
-        // and would otherwise pull the text back under the icon.
+        // Calendar affordance on the expiry field; `!important` to match the shared padding, which needs it to beat Tailwind's `.form-input` and would otherwise pull the text back under the icon.
         input.datepicker {
             padding-left: 38px !important;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E");
@@ -459,10 +386,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // ── Shipments ──────────────────────────────────────────────────────────────
-    //
-    // Pro's shipment card uses bare `h4`/`h5` tags, so they inherit the theme's heading
-    // scale — "Shipment #1" rendered at 22.6px weight 300 inside a card whose own titles
-    // are 14px semibold.
+    // Pro's shipment card uses bare `h4`/`h5` tags, so they inherit the theme's heading scale — "Shipment #1" rendered at 22.6px weight 300 inside a card whose own titles are 14px semibold.
     .shippments-tracking-title {
         margin: 0;
         font-size: 14px;
@@ -471,13 +395,11 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: $od-text;
     }
 
-    // The design puts the item count and the tracking link on one quiet line under the
-    // title, separated by a hairline tick.
+    // The item count and the tracking link share one quiet line under the title, separated by a hairline tick.
     .shippments-tracking-via {
         display: flex;
         align-items: center;
-        // Word-sized, not 10px: "via" and the provider are one phrase, and the flex gap
-        // sits between them too, which read as a stray double space.
+        // Word-sized, not 10px: the flex gap also falls inside the "via <provider>" phrase, where a wider gap read as a stray double space.
         gap: 4px;
         margin: 4px 0 0;
         font-size: 14px;
@@ -496,8 +418,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             font-weight: 500;
         }
 
-        // The tick between the provider phrase and the tracking link, drawn rather than
-        // typed so it cannot inherit the link colour or stretch to the line height.
+        // The tick is drawn rather than typed so it cannot inherit the link colour or stretch to the line height.
         a:first-of-type::before {
             content: "";
             align-self: center;
@@ -517,107 +438,65 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: $od-text;
     }
 
-    // "Tracking Information" heads a group of fields, but it lands 14px/600 against
-    // labels that are 13px/600 in the same colour — one pixel apart, so it read as one
-    // more label rather than the heading over them. Size cannot carry the difference:
-    // the card's own heading is 14px too, and an inner heading has no business being
-    // larger than the card it sits in. Air does it instead — 20px below, the same step
-    // the card leaves under its heading, against the 8px each label leaves under itself.
+    // Air, not size, separates this heading from the 13px/600 labels under it — the card's own heading is 14px too, and an inner heading has no business being larger — so it takes the same 20px step the card leaves under its heading.
     .shipping-status-track-info-heading {
         margin-bottom: 20px;
     }
 
-    // The strip holding Create New Shipment. Named through the card body because Pro
-    // styles it from a two-class selector too, and a tie there goes to `orders.less` on
-    // source order — the strip kept Pro's 20px padding either side of a button that
-    // already carried its own 20px margin, so the action sat in ~76px of air.
-    //
-    // The padding is dropped to nothing while the button is hidden (the create form
-    // replaces it, and jQuery hides it with an inline `display`), so the strip cannot
-    // leave a sliver behind under the form.
+    // The strip holding Create New Shipment, named through the card body because Pro's two-class rule ties and `orders.less` wins on source order; the padding drops to nothing while the button is hidden so the strip cannot leave a sliver under the create form.
     .dokan-panel-body .shipping-status-tracking-top-info {
         padding: 0 20px;
 
-        // 16px either side of the action, so the strip closes on the same step the rest of
-        // the card uses. `!important` is the only lever here: Pro sets the bottom margin
-        // from `#dokan-order-shipping-status-tracking-panel … #create-tracking-status-action`,
-        // which carries two ids — no selector built from classes can outrank that.
+        // `!important` is the only lever here: Pro sets the bottom margin from a selector carrying two ids, which nothing built from classes can outrank.
         #create-tracking-status-action {
             margin: 16px 0 !important;
         }
 
-        // The empty state is centred, and Pro's paragraph margin left the button adrift
-        // below the message.
+        // Pro's paragraph margin left the button adrift below the centred empty-state message.
         .no-shipment-found-desc {
             margin: 16px 0 0;
         }
 
-        // With the message present the button follows it, so its own top margin would
-        // double the gap between the two.
+        // With the message present the button follows it, so its own top margin would double the gap between the two.
         .no-shipment-found-desc + #create-tracking-status-action {
             margin-top: 12px;
         }
     }
 
-    // Same voice as the other empty states in this view — "No shipping address set." and
-    // its billing twin — which run 14px on a 28px line in the body grey. Legacy had this
-    // one a shade lighter at #999 on a tighter line, so the two read as different kinds of
-    // message when they are the same kind.
+    // Legacy runs this empty state lighter and tighter than the view's others, so the same kind of message read as a different kind.
     .no-shipment-found-desc {
         font-size: 14px;
         line-height: 28px;
-        // Legacy sets #999 from a deeper selector; the other empty states in this view run
-        // the body grey, and a lighter one here made this message read as less important
-        // than "No shipping address set." beside it.
+        // Legacy sets #999 from a deeper selector, which made this message read as less important than the empty state beside it.
         color: #6b6b6b !important;
     }
 
-    // Empty state left as legacy renders it: centred, with the action as a filled button.
-    // The design has it left-aligned with the action as a `+` link, and that was built —
-    // but two theme rules repaint `.dokan-btn` on hover (`.dokan-btn-theme:hover` with a
-    // hard-coded fill, and a variable-driven `:is(…)` rule), and although the override
-    // ranked above both, it could not be demonstrated working. Reverted on request rather
-    // than shipped unverified.
+    // Empty state left as legacy renders it: the design's left-aligned `+` link was built, but two theme rules repaint `.dokan-btn` on hover and the override could not be demonstrated working, so it was reverted on request rather than shipped unverified.
 
-    // Each shipment is a row in the card, on the same full-bleed rules the item table and
-    // the downloadable list use.
+    // Each shipment is a row in the card, on the same full-bleed rules the item table and the downloadable list use.
     .shipping-status-tracking-shippments-inner {
-        // Unlike the other cards, this one's body has no padding — Pro's markup supplies
-        // its own — so the row already spans the card and the inset belongs here. Pulling
-        // it out with a negative margin as the other sections do overhung the card by 20px
-        // on each side.
+        // Pro's markup supplies this card body's padding, so the inset belongs on the row itself — the negative-margin trick the other sections use overhung the card by 20px a side.
         margin: 0;
         padding: 20px;
-        // Legacy dresses each row as a little card of its own — a bottom border, a shadow
-        // and a 4px radius. Inside a card that already has all three it read as a second
-        // edge under the last shipment.
+        // Legacy dresses each row as a little card of its own, which inside a card that already has border, shadow and radius read as a second edge under the last shipment.
         border: 0;
         border-radius: 0;
         box-shadow: none;
 
-        // Every shipment rules off from the one above it. This was written as
-        // `+ .shipping-status-tracking-shippments-inner` and drew nothing, because the
-        // template closes each shipment with a `<div class="clear">` — so no two
-        // shipments are ever adjacent siblings and the combinator never matched. Drawn on
-        // all of them and lifted from the first instead, which does not care what sits
-        // between.
+        // Drawn on every row and lifted from the first rather than with `+`, because the template closes each shipment with a `<div class="clear">` so no two shipments are ever adjacent siblings.
         border-top: 1px solid $od-border;
 
         &:first-child {
             border-top: 0;
         }
 
-        // Legacy insets the header, the item list and the tracking form by a further 20px
-        // inside a row that is already inset, so the shipment title and its fields sat
-        // 40px in while the card heading above them sat at 20. Naming the row as well
-        // outranks it — a two-class selector alone ties and loses on source order.
+        // Legacy insets these a further 20px inside an already-inset row; naming the row as well outranks it, since a two-class selector ties and loses on source order.
         > .shippments-tracking-header,
         > .shippments-tracking-footer {
             padding: 0;
         }
 
-        // Same tie, and the reason the rules around the item list stayed at legacy's 2px
-        // #ddd while every other divider in the view is a 1px hairline.
+        // Same tie, and the reason the rules around the item list stayed at legacy's 2px #ddd while every other divider in the view is a 1px hairline.
         > .shippments-tracking-items {
             padding: 8px 20px;
             border-top: 1px solid $od-border;
@@ -625,15 +504,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // With every item shipped this holds nothing at all, and its own padding left an 8px
-    // sliver under the last shipment that read as one more edge.
+    // With every item shipped this holds nothing at all, and its own padding left an 8px sliver that read as one more edge.
     .shipping-status-tracking-top-info:not(:has(*)) {
         display: none;
     }
 
-    // Grid rather than a wrapped flex row: the badge and its toggle centre against the
-    // full two-line title block (title over the via line), which flex cannot do once
-    // the via line wraps onto a row of its own.
+    // Grid rather than a wrapped flex row: the badge and its toggle must centre against the whole two-line title block, which flex cannot do once the via line wraps.
     .shippments-tracking-header {
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
@@ -646,9 +522,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Pro lays this row out with floats and percentage widths — the status block is
-    // `width: 63%; float: right` from a two-class selector. Naming the header as well
-    // outranks it so the grid can take over.
+    // Pro floats this row's status block at 63% from a two-class selector, so naming the header as well outranks it and lets the grid take over.
     .shippments-tracking-header .shippments-tracking-title {
         grid-column: 1;
         grid-row: 1;
@@ -657,8 +531,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin: 0;
     }
 
-    // Status is a pill, matching the badges the page header and sidebar already use.
-    // Spanning both title rows so the pill and the toggle sit on the block's midline.
+    // A pill matching the badges the page header and sidebar use, spanning both title rows so it and the toggle sit on the block's midline.
     .shippments-tracking-header .shippments-statuses {
         display: inline-flex;
         align-items: center;
@@ -670,11 +543,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         float: none;
         margin: 0;
 
-        // Flex rather than `font-size: 0`, which is what closed the whitespace gap
-        // between the badge and the toggle before. The toggle is an empty icon span, so
-        // zeroing the row's font size collapsed it to 0x0 — the chevron was in the DOM
-        // the whole time, unclickable, which is why the shipment could not be opened and
-        // its items, tracking form and update timeline all stayed hidden.
+        // Flex, not `font-size: 0` — that collapsed the empty icon span to 0x0 and made the chevron unclickable, so the shipment could not be opened at all.
         .shippments-tracking-status {
             display: inline-flex;
             align-items: center;
@@ -695,10 +564,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The two expand controls — one on the shipment header, one on the update timeline.
-    // Legacy sizes them 20px with a text indent and leaves the glyph to whichever Font
-    // Awesome the site happens to load; drawn here instead, so the control does not
-    // depend on a font that a theme or another plugin can replace out from under it.
+    // The chevron is drawn here rather than left to whichever Font Awesome the site happens to load, so the control cannot depend on a font a theme or another plugin replaces.
     .shipment-item-details-tab-toggle,
     .shipment-notes-details-tab-toggle {
         display: inline-flex;
@@ -728,25 +594,18 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             transition: transform 0.15s ease;
         }
 
-        // Pro's handler flips `dashicons-arrow-up-alt2` on and off in step with the panel
-        // it opens, so the class is a reliable "expanded" flag. The dashicon it names
-        // never renders — the markup ships a Font Awesome chevron — which is why the arrow
-        // never turned round.
+        // Pro's handler flips `dashicons-arrow-up-alt2` in step with the panel it opens, so it is a reliable expanded flag — the dashicon it names never renders, which is why the arrow never turned round.
         &:has(.dashicons-arrow-up-alt2)::after {
             transform: rotate(180deg);
         }
 
-        // The glyph the markup ships. Hidden rather than restyled so only one chevron can
-        // ever appear, whichever icon font is present.
+        // The glyph the markup ships, hidden rather than restyled so only one chevron can ever appear whichever icon font is present.
         > span {
             display: none;
         }
     }
 
-    // Pro pins this one to the corner of the block. Kept there rather than turned into a
-    // flex row: the block is opened by toggling an inline `display`, and any `display` of
-    // ours on the container would either outrank `.dokan-hide` while it is closed or be
-    // outranked by the inline value once it opens. Centred in the 52px header band.
+    // Kept pinned to the corner rather than made a flex row: the block opens by toggling an inline `display`, so any `display` of ours would either outrank `.dokan-hide` while closed or lose to the inline value once open.
     .dokan-customer-shipment-notes-list-area .shipment-notes-details-tab-toggle {
         top: 12px;
         right: 16px;
@@ -760,21 +619,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin: 0;
     }
 
-    // The shipment's own item list follows the order table's shape rather than the
-    // theme's default table styling.
+    // The shipment's own item list follows the order table's shape rather than the theme's default table styling.
     .shippments-tracking-items {
-        // Pulled out over the row's 20px inset so the rules above and below it run to the
-        // card edges, and the inset put back as padding so the content does not move.
-        // Legacy rules this block off with 2px of #ddd, twice the weight of every other
-        // divider in the view.
+        // Only the margin lands here — Pro ties on the padding and borders and wins on source order, so those are set on the row-qualified rule above.
         margin: 20px -20px;
-        padding: 8px 20px;
-        border-top: 1px solid $od-border;
-        border-bottom: 1px solid $od-border;
 
-        // The table hangs over the block's inset and the edge cells put it back, the
-        // same trick as the order items table — otherwise every row separator stops
-        // 20px short of the card edge at both ends.
+        // The table hangs over the block's inset and the edge cells put it back, the same trick as the order items table — otherwise every row separator stops 20px short of the card edge.
         table {
             width: calc(100% + 40px);
             margin: 0 -20px;
@@ -797,8 +647,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             white-space: nowrap;
         }
 
-        // The name column absorbs the leftover, so the quantity sits against the right
-        // edge instead of drifting to wherever auto layout leaves it.
+        // The name column absorbs the leftover so the quantity sits against the right edge instead of wherever auto layout leaves it.
         td:nth-child(2) {
             width: 100%;
         }
@@ -807,12 +656,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             border-top: 1px solid $od-border;
         }
 
-        // `.shippments-tracking-items td.thumb img { width: 100% }` ships with Pro and is
-        // one element deeper than a plain descendant selector, so the cell has to be named
-        // or the thumbnail fills its column at 163px. `min-width`, because the name
-        // column's `width: 100%` squeezes this one to its min-content — and Tailwind's
-        // `img { max-width: 100% }` makes the image's min-content zero, so the plain
-        // `width` hint was crushed to a 6px sliver.
+        // Pro's `td.thumb img { width: 100% }` is one element deeper than a plain descendant selector, so the cell has to be named; `min-width`, because the name column's `width: 100%` and Tailwind's `img { max-width: 100% }` crushed the plain width hint to a 6px sliver.
         td.thumb {
             width: 68px;
             min-width: 68px;
@@ -830,8 +674,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             object-fit: cover;
         }
 
-        // The product names the row, so it takes the body colour rather than the theme's
-        // link colour, like the order items table above.
+        // The product names the row, so it takes the body colour rather than the theme's link colour, like the order items table above.
         a {
             color: $od-text !important;
 
@@ -841,9 +684,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        // The quantity is metadata, not a second name — one step down from the row and
-        // muted, like the counters in the downloadable section, but weighted so the
-        // number still registers at a glance.
+        // The quantity is metadata, not a second name — muted like the counters in the downloadable section, but weighted so the number still registers at a glance.
         strong {
             font-size: 13px;
             font-weight: 500;
@@ -860,8 +701,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Full-bleed like the rules above and below the item list, rather than a rule floating
-    // inside the row's inset.
+    // Full-bleed like the rules above and below the item list, rather than a rule floating inside the row's inset.
     .shippments-tracking-footer hr,
     #add-shipping-tracking-status-form > hr {
         margin: 20px -20px;
@@ -878,9 +718,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin-bottom: 0;
         }
 
-        // The floated tracking row gives its trailing margin up — see the float rule
-        // below for why. Declared here rather than there because this selector is one
-        // class deeper and would otherwise win the point back.
+        // Declared here rather than on the float rule below, because this selector is one class deeper and would otherwise win the point back.
         &.shipping-status-provider,
         &.shipped-status-date,
         &.shipped-tracking-number {
@@ -888,15 +726,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Pro floats the three tracking fields at 33% with a 2% gutter, which leaves the last
-    // one 35px short of the other two. Equal thirds on a real gap instead.
-    //
-    // `margin-bottom: 0` is the important part: because these are floats, the 16px every
-    // field row carries extends the row box and pushes whatever clears it down by that
-    // much *on top of* that element's own top spacing. It read as 36px before the
-    // timeline where this card steps by 20, and would be 40px before the Update button
-    // where it should step by 24. The row gives up its trailing margin; the blocks that
-    // clear it own the gap.
+    // Equal thirds on a real gap instead of Pro's 33% with a 2% gutter, which left the last field 35px short; `margin-bottom: 0` is the important part, because a float's trailing margin extends the row box and pushes whatever clears it down on top of that element's own spacing.
     .shipping-status-provider,
     .shipped-status-date,
     .shipped-tracking-number {
@@ -907,25 +737,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         overflow: visible;
     }
 
-    // Whichever of those blocks lands under the row needs its own step down from it — the
-    // other-provider pair when the provider is "Other", the comment field either way.
-    //
-    // `padding`, not `margin`: these carry `clear: both`, and when clearance is introduced
-    // the top margin is absorbed into it rather than drawn. A `margin-top: 16px` here
-    // computed correctly and rendered as nothing.
-    //
-    // Stated unconditionally, not behind `:not(.dokan-hide)`: jQuery reveals the pair with
-    // `.show()`, which writes an inline `display` and leaves `dokan-hide` sitting on the
-    // element — so that test never matched and the block got no spacing at all. While it
-    // is genuinely hidden the padding cannot be seen anyway.
+    // `padding`, not `margin`, because these blocks carry `clear: both` and a top margin is absorbed into the clearance and rendered as nothing; stated unconditionally rather than behind `:not(.dokan-hide)`, since jQuery's `.show()` leaves `dokan-hide` sitting on the element and that test never matched.
     .tracking-status-other-url,
     .shipping-tracking-comments {
         padding-top: 16px;
     }
 
-    // Pro floats the two fields inside this block and nothing contained them, so it
-    // measured no height of its own and the comment field below landed ~95px adrift.
-    // `overflow` contains them without touching `display`, which jQuery owns here.
+    // Pro floats the two fields inside this block and nothing contained them, so it measured no height and the comment field landed adrift; `overflow` contains them without touching `display`, which jQuery owns here.
     .tracking-status-other-url {
         overflow: hidden;
     }
@@ -934,8 +752,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         margin-right: 0;
     }
 
-    // Pro pins this field to 98% from an id selector, so it came out a hair narrower than
-    // the two beside it even once the columns matched.
+    // Pro pins this field to 98% from an id selector, so it stayed a hair narrower than the two beside it even once the columns matched.
     input#tracking_status_number {
         width: 100%;
     }
@@ -950,8 +767,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         clear: both;
     }
 
-    // Update sits where Submit Refund and Add Note sit: on the right, clearing the last
-    // field by the same 24px step.
+    // Update sits where Submit Refund and Add Note sit: on the right, clearing the last field by the same 24px step.
     .shippments-tracking-footer-button {
         display: flex;
         flex-direction: column;
@@ -976,10 +792,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // A delivered or cancelled shipment keeps its form on screen but locked — Pro marks
-    // the selects `disabled` and the inputs `readonly`, yet legacy leaves both looking
-    // live. Painted inert, and mouse-blocked so the date picker cannot open a calendar
-    // over a field the handler will refuse to save anyway.
+    // A delivered or cancelled shipment keeps a locked form that legacy still paints as live, so it is painted inert and mouse-blocked, or the date picker opens a calendar over a field the handler will refuse to save.
     .shippments-tracking-footer select:disabled,
     .shippments-tracking-footer input[readonly] {
         background-color: #f9fafb !important;
@@ -988,11 +801,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         pointer-events: none;
     }
 
-    // The update timeline is a full-width section closing the shipment row: a header band
-    // on the section grey, flush to the card edges, with its entries below on white. A
-    // nested-card and a painted-gap variant were both tried; this full-width section read
-    // cleanest. Full-bleed over the row's 20px inset, with the bottom margin cancelling
-    // the row's bottom padding so the section reaches the card edge.
+    // Full-bleed over the row's 20px inset, with the bottom margin cancelling the row's bottom padding so the section reaches the card edge.
     .shipping-status-tracking-shippments-inner .dokan-customer-shipment-notes-list-area {
         margin: 20px -20px -20px;
         padding: 0;
@@ -1001,17 +810,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .dokan-customer-shipment-notes-list-area {
-        // The heading is the section's header band, full width on the same grey as the
-        // card headings. The right padding keeps a long title clear of the toggle.
+        // The heading is the section's header band, on the same grey as the card headings, with right padding keeping a long title clear of the toggle.
         h5 {
             margin: 0;
             padding: 16px 56px 16px 20px;
             background-color: #f9fafb;
         }
 
-        // Toggled by jQuery, so no `display` here — padding and the rule above are safe.
-        // The bottom rule closes the section once it is open: the band above it is the
-        // header, and without this the entries ran straight into whatever followed.
+        // No `display` here because jQuery toggles it; the bottom rule closes the section, without which the entries ran straight into whatever followed.
         .customer-shipment-list-notes-inner-area {
             margin: 0;
             padding: 20px;
@@ -1019,27 +825,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             border-bottom: 1px solid $od-border;
         }
 
-        // Pro sets `margin: 15px` on this list from a three-class selector nested inside
-        // `.customer-shipment-list-notes-inner-area`. A three-class rule here only ties,
-        // and Pro's `orders.less` is emitted after this bundle, so it won on source order
-        // and pushed every entry 15px right of the 20px inset the rest of the card sits
-        // on — the marker column never lined up with anything above it. Naming the
-        // element as well outranks it.
+        // Pro's three-class `margin: 15px` ties a three-class rule here and wins on source order, pushing every entry 15px off the 20px inset the rest of the card sits on — naming the element as well outranks it.
         ol.dokan-order-updates {
             margin: 0;
             padding: 0;
         }
 
-        // Every value below is derived from one number — the 28px marker — so the column
-        // stays true if it ever changes: inset = marker + 16px gutter, the line sits on
-        // the marker's centre (28 / 2), and the marker is lifted half its height above the
-        // date's 20px line box so the two share a midline. The design's proportion is a
-        // glyph with clear air inside the ring; at 20px in a 32px circle it crowded the
-        // border, so both are back to the 28 / 15 pairing.
+        // Every value below derives from the 28px marker so the column stays true if it changes: inset = marker + 16px gutter, the line sits on the marker's centre, and the marker is lifted half its height to share the date's midline.
         li {
             margin: 0;
-            // The left inset is what clears the marker column. A `padding` shorthand here
-            // zeroed it and dropped the bullet on top of the date.
+            // The left inset is what clears the marker column; a `padding` shorthand zeroed it and dropped the bullet on top of the date.
             padding: 0 0 24px 44px;
             font-size: 14px;
             line-height: 22px;
@@ -1049,16 +844,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 padding-bottom: 0;
             }
 
-            // The line joining one entry to the next, hanging just below the marker rather
-            // than running the full height of the entry. The marker bottoms out at 24px
-            // (-4 + 28), so 26px leaves the 2px breath that reads as connected rather than
-            // welded to it.
+            // The line joining one entry to the next hangs just below the marker rather than running the entry's full height, with 2px of breath so it reads as connected rather than welded to it.
             &::before {
                 top: 26px;
                 left: 14px;
                 width: 1px;
-                // A shade darker than the card's dividers: at 1px the divider grey read as
-                // nothing at all and the entries lost the thread joining them.
+                // A shade darker than the card's dividers, which at 1px read as nothing at all and lost the thread joining the entries.
                 background-color: #d9d9d9;
             }
 
@@ -1066,9 +857,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 content: none;
             }
 
-            // The marker is the design's delivery badge — a bordered circle with the truck
-            // glyph — drawn entirely here so the markup keeps its bare `li`. `-4px` is
-            // `(20px date line ÷ 2) − (28px marker ÷ 2)`, which puts the two on one midline.
+            // The design's delivery badge, drawn entirely here so the markup keeps its bare `li`; `-4px` puts the 28px marker on the 20px date line's midline.
             &::after {
                 top: -4px;
                 left: 0;
@@ -1084,8 +873,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        // The date leads each entry, so it carries the entry's weight; the detail lines
-        // below stay quiet.
+        // The date leads each entry, so it carries the entry's weight; the detail lines below stay quiet.
         .dokan-order-update-meta {
             margin: 0;
             font-size: 14px;
@@ -1094,10 +882,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             color: $od-text;
         }
 
-        // `wpautop` splits the note on its blank line, so the detail lines arrive as one
-        // paragraph and the comment as another. 8px sets the detail block under the date;
-        // 12px between blocks is what makes the comment read as a separate remark rather
-        // than a fifth detail line — at the 6px both shared, the two blocks ran together.
+        // `wpautop` splits the note on its blank line into a details paragraph and a comment, and 12px between them is what makes the comment read as a separate remark rather than a fifth detail line.
         .dokan-order-update-description p {
             margin: 12px 0 0;
             font-size: 13px;
@@ -1115,14 +900,9 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // ── Create shipment ────────────────────────────────────────────────────────
-    //
-    // The form Pro reveals under "Create New Shipment". It borrows the order items table's
-    // class names so it inherits that table's shape, but its own chrome came straight from
-    // legacy: a 15px inset pinned inline, a rule that stopped short of the card, and two
-    // native buttons.
+    // The form Pro reveals under "Create New Shipment" borrows the order items table's class names for its shape, but its own chrome came straight from legacy: a 15px inset pinned inline, a rule that stopped short of the card, and two native buttons.
 
-    // Only when shipments are already listed above it — otherwise this doubles up with the
-    // card heading's own rule.
+    // Only when shipments are already listed above it — otherwise this doubles up with the card heading's own rule.
     #dokan-order-shipping-status-tracking-shippments:has(.shipping-status-tracking-shippments-inner)
         + #dokan-order-shipping-status-tracking {
         border-top: 1px solid $od-border;
@@ -1132,9 +912,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         // The template pins 15px inline, which no selector can outrank.
         padding: 20px !important;
 
-        // The theme gives every `form` a rem-based bottom margin — 25.9px here — which
-        // stacked under this form's own 20px padding and left the action row sitting 46px
-        // off the card edge where the rest of the view closes at 20.
+        // The theme's rem-based `form` margin stacked under this form's own padding and left the action row 46px off the card edge where the rest of the view closes at 20.
         margin-bottom: 0;
 
         // The item picker leads the form, so it closes on the same step the fields use.
@@ -1142,13 +920,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin-bottom: 20px;
         }
 
-        // Four columns, one per cell the rows render. The checkbox and the quantity are
-        // fixed; the thumbnail matches the order items table above — 44px on a 16px gap.
-        //
-        // One gutter for the whole row: 20px in to the checkbox, then 16px between each
-        // of checkbox, thumbnail and name. The thumbnail cell was leaving 36px on its
-        // right against 16px on its left, so the name sat visibly further from its image
-        // here than the same pairing does in the table above.
+        // One gutter for the whole row — 20px in to the checkbox, then 16px between checkbox, thumbnail and name — because the thumbnail cell was leaving 36px on its right and the name sat further from its image than the same pairing does in the table above.
         th.order_item_select,
         td.order_item_select {
             width: 52px;
@@ -1160,20 +932,11 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin: 0;
         }
 
+        // Narrower than the order items table's 80px because a checkbox column leads the thumbnail here; the image itself is left to the shared `td.thumb img` rule, since restating it hid that rule's placeholder-404 guard.
         th.thumb,
         td.thumb {
             width: 60px;
             padding-right: 16px;
-        }
-
-        td.thumb img {
-            display: block;
-            width: 44px;
-            height: 44px;
-            background-color: #f3f4f6;
-            border: 1px solid #e9e9e9;
-            border-radius: 3px;
-            object-fit: cover;
         }
 
         th.name,
@@ -1186,16 +949,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             width: 96px;
         }
 
-        // The template pins 60px inline, which leaves ~34px for the number once the
-        // control's own padding is taken out.
+        // The template pins 60px inline, which leaves ~34px for the number once the control's own padding is taken out.
         td.quantity input {
             width: 72px !important;
             text-align: center;
         }
 
-        // The quantity is on screen from the start now, greyed until its row is ticked,
-        // so the column reads as "this row has a quantity" rather than as empty space.
-        // Pro marks the wrapper and disables the field together.
+        // The quantity is on screen from the start, greyed until its row is ticked, so the column reads as "this row has a quantity" rather than as empty space.
         .shipping-tracking.is-disabled input {
             background-color: #f9fafb;
             border-color: #e9e9e9;
@@ -1203,8 +963,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             cursor: not-allowed;
         }
 
-        // Backing out reads first, committing reads last — the same order as the refund
-        // row, and the same 24px clearance from the last field.
+        // Backing out reads first, committing reads last — the same order as the refund row, and the same 24px clearance from the last field.
         > .dokan-form-group:has(#add-tracking-status-details) {
             display: flex;
             justify-content: flex-end;
@@ -1217,18 +976,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // One step from a caption to the control it names, everywhere in both shipment forms.
-    // The tracking fields were sitting at 6px against the 8px the rest of the view uses.
-    // `:not(:has(input))` keeps the checkbox rows out of it — those wrap their own control
-    // and are handled as a row below.
+    // One step from a caption to the control it names in both shipment forms; `:not(:has(input))` keeps out the checkbox rows, which wrap their own control and are handled as a row below.
     .shippments-tracking-footer .dokan-control-label:not(:has(input)),
     #add-shipping-tracking-status-form .dokan-control-label:not(:has(input)) {
         display: block;
         margin-bottom: 8px;
     }
 
-    // `rows="4"` sets the height, but the theme's own row calculation lands short of the
-    // design's box — a floor keeps it a comment field rather than a two-line slot.
+    // `rows="4"` sets the height, but the theme's own row calculation lands short of the design's box, so a floor keeps this a comment field rather than a two-line slot.
     #tracking_status_comments,
     .shipping-tracking-comments textarea {
         min-height: 96px;
@@ -1236,10 +991,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         resize: vertical;
     }
 
-    // Chrome paints its own beige over an autofilled field, which is what turned the
-    // tracking number grey the moment it was focused — the rule below is the only way to
-    // repaint it, since the real background is untouchable. The inset shadow covers the
-    // control, and `text-fill` keeps the value legible on it.
+    // Chrome paints its own beige over an autofilled field and the real background is untouchable, so an inset shadow covers the control and `text-fill` keeps the value legible on it.
     input:-webkit-autofill,
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,
@@ -1251,14 +1003,11 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         -webkit-text-fill-color: $od-text;
         box-shadow: 0 0 0 1000px #fff inset !important;
         -webkit-box-shadow: 0 0 0 1000px #fff inset !important;
-        // Chrome repaints its own ground on focus and after any value change, and the
-        // only way to outlast that is to make the transition to it effectively never
-        // arrive. This is the documented workaround, not a hack of ours.
+        // Chrome repaints its ground on focus and after any value change, and the documented workaround is a transition to it that effectively never arrives.
         transition: background-color 5000s ease-in-out 0s;
     }
 
-    // And the plain case, stated outright rather than left to whatever the theme happens
-    // to leave behind: a focused control in this view is white, whatever put it otherwise.
+    // The plain case stated outright rather than left to the theme: a focused control in this view is white, whatever put it otherwise.
     .dokan-form-control:focus,
     input[type="text"]:focus,
     input[type="number"]:focus,
@@ -1269,8 +1018,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background-color: #fff;
     }
 
-    // A label wrapping its own checkbox is a row, not a field caption: the caption rule
-    // stacks the text under the box and bolds it.
+    // A label wrapping its own checkbox is a row, not a field caption, which the caption rule would stack under the box and bold.
     .dokan-form-group > label:has(input[type="checkbox"]) {
         display: inline-flex;
         align-items: center;
@@ -1283,9 +1031,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         cursor: pointer;
     }
 
-    // The browser accent is blue here, and blue appears nowhere else on the page.
-    // Tailwind's form reset paints the checked state with `background-color` rather than
-    // the accent, so both have to be set.
+    // The browser accent is blue and blue appears nowhere else on the page, and Tailwind's form reset paints the checked state with `background-color` rather than the accent, so both have to be set.
     input[type="checkbox"] {
         width: 16px;
         height: 16px;
@@ -1298,37 +1044,24 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Only where something else owns the gap — the label's own `gap` above, and the
-    // table cell's padding. Left global, this would close up the theme's spacing around
-    // checkboxes that sit loose in their row, such as the refund restock box.
+    // Only where something else owns the gap — the label's own `gap`, the cell's padding — since left global this would close up the theme's spacing around checkboxes sitting loose in their row, such as the refund restock box.
     .dokan-form-group > label > input[type="checkbox"],
     td.order_item_select input[type="checkbox"] {
         margin: 0;
     }
 
-    // With shipments already listed, this holds the "Create New Shipment" action alone and
-    // reads as the card's closing row. Legacy nudges it with stray margins from an id
-    // selector, so `!important` is the only way to sit it on the card's own inset.
+    // Legacy nudges this closing row with stray margins from an id selector, so `!important` is the only way to sit it on the card's own inset.
     .shipping-status-tracking-top-info.info-not-shipment-yet {
         margin: 0 !important;
-        // No vertical padding of its own: the button's 16px margins are the whole gap.
-        // With 20px here as well the single action sat in ~76px of air, and the padding
-        // stayed behind as a sliver once the create form hid the button.
+        // No vertical padding of its own: the button's 16px margins are the whole gap, and 20px here left the single action in ~76px of air and a leftover sliver once the create form hid the button.
         padding: 0 20px !important;
         border-top: 1px solid $od-border;
         text-align: left;
     }
 
-    // Nested panels — one per downloadable file — are rows inside a card, not cards of
-    // their own. Flattened so their content keeps the card's single 20px inset.
+    // Nested panels — one per downloadable file — are rows inside a card, not cards of their own, so they are flattened onto the card's single 20px inset.
     .dokan-panel .dokan-panel {
-        // 22px either side of every rule in this section — a touch more air than the
-        // 20px used inside a row, so the rules read as separators rather than as part of
-        // the field rhythm. The design measures 60px
-        // here, but its rows lead with a 40px thumbnail block where ours has a single line
-        // of text, so the same figure reads as far more air. Pulled out to the card edges
-        // so the rule is full-bleed like the notes and general-details dividers, with the
-        // inset put back as padding so the content does not move.
+        // 22px so the rules read as separators rather than part of the field rhythm — the design's 60px assumes rows led by a 40px thumbnail where ours carry one line of text — pulled out to the card edges to be full-bleed like the other dividers, with the inset put back as padding so the content does not move.
         margin: 0 -20px;
         padding: 22px 20px;
         border: 0;
@@ -1345,8 +1078,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             border-bottom: 0;
         }
 
-        // Same 20px that separates a field from the label beneath it, so the product line
-        // sits on the section's own rhythm rather than a wider one of its own.
+        // The same 20px that separates a field from the label beneath it, so the product line sits on the section's own rhythm rather than a wider one.
         > .panel-collapse > .panel-body {
             padding: 20px 0 0;
         }
@@ -1358,13 +1090,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Order items ────────────────────────────────────────────────────────────────
-//
-// The line-item table and the totals beneath it, restyled to the design: a quiet
-// uppercase header rather than a ruled one, white rows separated by hairlines, a 44px
-// product thumbnail, and money right-aligned to the card edge.
-//
-// The markup is Pro's `orders/views/html-order-items` (with Lite's fallback carrying the
-// same class names), so the selectors here name those classes rather than the DOM shape.
+// The line-item table and totals restyled to the design — a quiet uppercase header, white rows on hairlines, a 44px thumbnail and money right-aligned to the card edge — selected through Pro's `html-order-items` class names, which Lite's fallback shares, rather than the DOM shape.
 
 .dokan-order-details-fragment {
     .woocommerce_order_items,
@@ -1376,8 +1102,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background: transparent;
     }
 
-    // The theme zebra-stripes tables and Dokan opts in with `dokan-table-strip`; the
-    // design has plain white rows carrying hairline separators instead.
+    // The theme zebra-stripes tables and Dokan opts in with `dokan-table-strip`; the design has plain white rows carrying hairline separators instead.
     .woocommerce_order_items td,
     .woocommerce_order_items th,
     .wc-order-totals td,
@@ -1385,9 +1110,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         background-color: transparent !important;
     }
 
-    // The rules between rows run to the card edges, like every other divider in this
-    // view. The table is pulled out over the body's 20px inset and the edge cells put it
-    // back, so the content stays aligned with the card heading above it.
+    // The table is pulled out over the body's 20px inset and the edge cells put it back, so the rules between rows run to the card edges while the content stays aligned with the heading above.
     .woocommerce_order_items_wrapper,
     .wc-order-data-row.wc-order-totals-items {
         margin-left: -20px;
@@ -1406,12 +1129,9 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         padding-right: 20px;
     }
 
-    // Column headings are labels, not a ruled header band: Inter 12/16 uppercase in the
-    // muted grey, with a single rule under the row.
+    // Column headings are labels, not a ruled header band: 12/16 uppercase in the muted grey, with a single rule under the row.
     .woocommerce_order_items thead th {
-        // 19px, not 20: the line box adds a pixel below the cap height, so this is what
-        // puts the same 20px of visible air under the labels as the card's inset puts
-        // above them.
+        // 19px, not 20: the line box adds a pixel below the cap height, so this puts the same 20px of visible air under the labels as the card's inset puts above them.
         padding: 0 12px 19px 0;
         border: 0;
         font-size: 12px;
@@ -1432,34 +1152,20 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         vertical-align: middle;
     }
 
-    // Shipping, fee and refund rows render a trailing actions cell that line items do not,
-    // and whose contents Pro has commented out — 34px of nothing. It made the table seven
-    // columns wide with only some rows reaching the last one, so an item row's cells ended
-    // at 1494 while the others reached 1528. A row background paints only under its cells,
-    // so that is where the rule stopped too. Dropping the empty column makes every row the
-    // same six cells. The `:has` guard keeps it if Pro ever puts real actions back.
+    // Pro renders a trailing actions cell on shipping, fee and refund rows with its contents commented out, so item rows ended 34px short of the others and the row rule — which paints only under cells — stopped there too; the `:has` guard keeps the column if Pro ever puts real actions back.
     .woocommerce_order_items th.wc-order-edit-line-item,
     .woocommerce_order_items td.wc-order-edit-line-item:not(:has(a, button, input, select)) {
         display: none;
     }
 
-    // Line items render six cells while shipping, fee and refund rows render seven, so
-    // the separator has to be independent of how many cells a row happens to have.
-    //
-    // A `border` cannot do that here. Under `border-collapse: collapse` the edge is
-    // resolved and painted per cell, so a border declared on the row still stops with its
-    // last cell: item rows ended at 1494 and the rest reached 1528, a 34px stub down the
-    // table. Painting the rule as a background instead follows the row box, which spans
-    // the full width whatever the cell count.
+    // Painted as a background rather than a border because under `border-collapse: collapse` the edge is resolved per cell, so a row border stopped with the six-cell item rows and left a 34px stub beside the seven-cell ones.
     .woocommerce_order_items thead tr,
     .woocommerce_order_items tbody tr {
         border-bottom: 0;
         background: linear-gradient($od-border, $od-border) bottom left / 100% 1px no-repeat;
     }
 
-    // Shipping, fee and refund rows carry a Font Awesome glyph where a product has its
-    // picture. Left alone it renders at 14px against the text baseline; given the same
-    // 44px slot it lines up with the thumbnails above it.
+    // Shipping, fee and refund rows carry a Font Awesome glyph where a product has its picture, and the same 44px slot lines it up with the thumbnails above.
     .woocommerce_order_items td.thumb > div {
         display: flex;
         align-items: center;
@@ -1475,8 +1181,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // 44px at a 3px radius with a hairline, and 16px of air before the name.
     .woocommerce_order_items td.thumb {
-        // Border-box, so this has to carry the card inset and the gap as well as the
-        // image: 20 + 44 + 16. At 60 the padding ate it and the image rendered 24px wide.
+        // Border-box, so this carries the card inset and the gap as well as the image (20 + 44 + 16); at 60 the padding ate it and the image rendered 24px wide.
         width: 80px;
         padding-right: 16px;
 
@@ -1484,9 +1189,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             display: block;
             width: 44px;
             height: 44px;
-            // A product with no image falls back to WooCommerce's placeholder, which is
-            // not present on every install. When it 404s the element collapses to its alt
-            // text and spills across the row, so the box holds its size and clips.
+            // A product with no image falls back to WooCommerce's placeholder, which is not on every install — when it 404s the element collapses to its alt text and spills across the row, so the box holds its size and clips.
             overflow: hidden;
             background-color: #f3f4f6;
             border: 1px solid #e9e9e9;
@@ -1496,8 +1199,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The product reads as the row's subject, so it takes the body colour rather than the
-    // link colour it inherits from the theme.
+    // The product reads as the row's subject, so it takes the body colour rather than the link colour it inherits from the theme.
     .woocommerce_order_items td.name {
         a {
             color: $od-text !important;
@@ -1517,10 +1219,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The design gives the item column roughly 46% and leaves the money columns wide and
-    // left-aligned — headings sit directly over their values rather than everything
-    // crowding the right edge. Fixed widths rather than percentages because refund mode
-    // puts a field in each of these columns and they need guaranteed room.
+    // Fixed widths rather than percentages because refund mode puts a field in each of these columns and they need guaranteed room.
     .woocommerce_order_items th.item_cost,
     .woocommerce_order_items td.item_cost {
         width: 150px;
@@ -1563,8 +1262,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Totals: label left, amount right, on the same 14px body scale as the rows above.
     .wc-order-data-row.wc-order-totals-items {
-        // 16px of box puts the first line's ink 20px clear of the rule above it — the
-        // difference is the half-leading the line box adds over the cap height.
+        // 16px of box puts the first line's ink 20px clear of the rule above it, the difference being the half-leading the line box adds over the cap height.
         margin-top: 16px;
         overflow: hidden;
 
@@ -1575,9 +1273,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     .wc-order-totals td {
-        // 12px gives the list a 44px pitch. The design measures 38, but its rows are a
-        // plain label and figure; ours carry the tips icon and longer localised labels,
-        // which need the extra air to keep from reading as a solid block.
+        // 12px gives the list a 44px pitch: the design measures 38, but its rows are a plain label and figure where ours carry the tips icon and longer localised labels.
         padding: 12px 0;
         border: 0;
         font-size: 14px;
@@ -1591,22 +1287,19 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         white-space: nowrap;
     }
 
-    // Order Total is the figure the row exists for. It has no class of its own, but it is
-    // always the row directly above the refunded one, which does.
+    // Order Total has no class of its own, but it is always the row directly above the refunded one, which does.
     .wc-order-totals tr:has(+ tr .refunded-total) td {
         padding-top: 18px;
         border-top: 1px solid $od-border;
         font-weight: 600;
     }
 
-    // Matching air on the other side of that rule — it had the rows' default 9px above
-    // and 16px below, which read as the total leaning away from the list.
+    // Matching air on the other side of that rule, which otherwise read as the total leaning away from the list.
     .wc-order-totals tr:has(+ tr + tr .refunded-total) td {
         padding-bottom: 18px;
     }
 
-    // The card body already provides the 20px floor every other section closes on, so the
-    // last row adds nothing of its own.
+    // The card body already provides the 20px floor every other section closes on, so the last row adds nothing of its own.
     .wc-order-totals tr:last-child td {
         padding-bottom: 0;
     }
@@ -1624,10 +1317,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Coupon codes are chips in the design, not a bulleted list.
     .wc-used-coupons {
-        // The block is a sibling of the totals table inside a full-bleed row, so it needs
-        // the inset the table gets from its own cells or it starts 20px to their left.
-        // No top margin: the row it sits in already carries one, and the two stacked to
-        // 40px below the item table.
+        // The block is a sibling of the totals table inside a full-bleed row, so it needs the inset the table gets from its own cells; no top margin, because the row already carries one and the two stacked to 40px.
         padding: 0 20px;
         margin: 0 0 12px;
 
@@ -1676,10 +1366,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 
     // ── Refund mode ────────────────────────────────────────────────────────────
-    //
-    // Asking for a refund puts an input into each money column of every line item and
-    // opens the panel below. None of it was styled, so the fields arrived as borderless
-    // grey slabs at a different height from every other control in the view.
+    // Asking for a refund puts an input into each money column of every line item and opens the panel below, none of which was styled — the fields arrived as borderless grey slabs at a different height from every other control in the view.
 
     .woocommerce_order_items .refund {
         margin-top: 8px;
@@ -1687,10 +1374,8 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     .woocommerce_order_items input.refund_order_item_qty,
     .woocommerce_order_items input.refund_line_total,
-    .woocommerce_order_items input.refund_line_tax,
-    .woocommerce_order_items input.refund_line_subtotal {
-        // Beats the inline width the template sets, which left the last column's field
-        // hanging over the card edge.
+    .woocommerce_order_items input.refund_line_tax {
+        // Beats the inline width the template sets, which left the last column's field hanging over the card edge.
         width: 76px !important;
         height: 34px;
         padding: 6px 8px;
@@ -1703,36 +1388,23 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         box-shadow: none;
     }
 
-    // No drawn currency affix on these. A grey chip butted against a field reads as a
-    // detached box rather than part of the control, at every width it was tried at. The
-    // currency states itself in the placeholder, which cannot come apart.
+    // No drawn currency affix on these: a grey chip butted against a field read as a detached box at every width it was tried at, and the placeholder states the currency without coming apart.
 
     .wc-order-data-row.wc-order-refund-items {
         margin-left: -20px;
         margin-right: -20px;
         padding: 20px 0 0;
-        // No rule of its own: the item table's last row already draws one directly above,
-        // and the two sat 1px apart and read as a single thick stripe.
+        // No rule of its own: the item table's last row already draws one directly above, and the two sat 1px apart and read as a single thick stripe.
         border-top: 0;
     }
 
-    // Label and field belong on the same line. Left alone the label sat at the top of a
-    // 56px row while its 38px field centred below it.
-    //
-    // 12px vertical matches the totals list this panel sits under, so the two read as one
-    // rhythm rather than the panel being noticeably tighter. The 20px right is not
-    // optional: this rule is a class deeper than the general `td:last-child` inset, so
-    // without it the values and the restock checkbox sat flush on the card edge.
+    // Label and field on one line, on the 12px rhythm of the totals list this panel sits under; the 20px right is not optional, since this rule is a class deeper than the general `td:last-child` inset and the values sat flush on the card edge without it.
     .wc-order-refund-items .wc-order-totals td {
         padding: 12px 20px;
         vertical-align: middle;
     }
 
-    // No currency affix on these two. The chip works on the line items, where the field is
-    // 76px and it reads as part of the control, but this field is 411px wide and the chip
-    // just floated at the far end of an empty box. The panel reads as the totals list it
-    // sits under — plain label, plain value — and the field states its currency in the
-    // placeholder instead.
+    // No currency affix on these two: the chip reads as part of a 76px line-item field but just floats at the end of this 411px one, so the panel keeps the totals list's plain label and value and the field states its currency in the placeholder.
     .wc-order-refund-items .wc-order-totals td.total {
         // A float clearer has no job here.
         > .clear {
@@ -1740,49 +1412,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The amount field stays disabled until a quantity or line amount is entered, so it
-    // should read that way rather than inviting a value it will not accept. Fading it
-    // rather than filling it grey keeps the field looking like the one it becomes when it
-    // is enabled — the change is in weight, not in kind.
+    // The amount field stays disabled until a quantity or line amount is entered, and fading it rather than filling it grey keeps it the same field it becomes when enabled.
     .wc-order-refund-items input:disabled {
         background: #fff;
         opacity: 0.5;
         cursor: not-allowed;
     }
 
-    .wc-order-refund-items input[type="text"],
-    .wc-order-refund-items input.wc_input_price {
-        width: 100%;
-        height: 38px;
-        padding: 8px 12px;
-        background: #fff;
-        border: 1px solid $od-border;
-        border-radius: 6px;
-        font-size: 14px;
-        line-height: 20px;
-        color: $od-text;
-        box-shadow: none;
-    }
+    // The refund panel's text inputs and its restock checkbox are deliberately not restated here — the view-wide control and checkbox standards below already reach them, and repeating them only created a second place to keep in step.
 
-    // The restock checkbox defaults to the browser accent, which is blue here and the
-    // only blue on the page. Tailwind's form reset paints the checked state with
-    // `background-color` rather than the accent, so both have to be set.
-    .wc-order-refund-items input[type="checkbox"] {
-        width: 16px;
-        height: 16px;
-        accent-color: var(--color-dokan-btn, #7047eb);
-
-        &:checked {
-            background-color: var(--color-dokan-btn, #7047eb);
-            border-color: var(--color-dokan-btn, #7047eb);
-        }
-    }
-
-    // While a refund is being composed each money cell grows by an input, but the cost
-    // column has none — centred vertically, its figure dropped ~17px below the ones it
-    // should line up with. Top alignment holds the row's first line together, and applies
-    // only in refund mode: jQuery clears the panel's inline `display: none` to open it,
-    // so the closed state still centres against the 44px thumbnail.
+    // In refund mode each money cell grows by an input but the cost column has none, so centring dropped its figure below the row's first line; scoped to the open panel, since jQuery clears the inline `display: none` and the closed state still centres against the 44px thumbnail.
     .dokan-panel-body:has(> .wc-order-refund-items:not([style*="none"]))
         .woocommerce_order_items tbody td {
         vertical-align: top;
@@ -1793,21 +1432,16 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         align-items: center;
         justify-content: flex-end;
         gap: 8px;
-        // 24px clears the last field by the same step the fields clear each other. Nothing
-        // below: the card body already provides the 20px floor, and adding to it closed
-        // this section on 40px where every other one closes on 20.
+        // 24px clears the last field by the same step the fields clear each other, and nothing below, because the card body already provides the 20px floor every other section closes on.
         margin-top: 24px;
         padding: 0 20px;
 
-        // Legacy button margins pushed the pair off the right edge the fields above them
-        // sit on.
+        // Legacy button margins pushed the pair off the right edge the fields above them sit on.
         button {
             margin: 0 !important;
         }
 
-        // The template closes this row with a float clearer. As a flex item it takes a
-        // slot of its own after Submit, and the row's 8px gap with it — which is exactly
-        // how far short of the fields the buttons were landing.
+        // The template's float clearer would take a flex slot of its own after Submit, plus the row's gap — which is exactly how far short of the fields the buttons were landing.
         > .clear {
             display: none;
         }
@@ -1818,24 +1452,10 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Two button weights in this view, and both need stating because the theme paints
-    // `.dokan-btn` and `.dokan-btn:hover` the same regardless of role.
-    //
-    // Secondary — the two Cancels — take the treatment the panel's own Back button sets:
-    // white ground, brand border, brand label, tinting rather than filling on hover. Left
-    // to the theme they turn into a second primary the moment the pointer touches them.
+    // Both button weights need stating because the theme paints `.dokan-btn` and its hover the same regardless of role, and the Cancels turn into a second primary the moment the pointer touches them unless given the panel's Back-button treatment.
     .cancel-action,
     .dokan-cancel-status {
-        // The hover state is handed over rather than fought for. The colour module paints
-        // `.dokan-btn:hover` from three custom properties, as `!important` and from a
-        // selector no rule reachable from here can outrank — competing with it on
-        // specificity failed, and an inline `!important` was the only thing that ever won.
-        // Redefining the properties on the button lets the module's own rule paint the
-        // secondary treatment: a tint rather than a fill, with the brand kept for the
-        // border and the label.
-        //
-        // `--color-dokan-btn` itself is deliberately not shadowed here — the values below
-        // read it, and the resting rule underneath needs it to still mean the brand.
+        // The hover state is handed over rather than fought for: the colour module paints `.dokan-btn:hover` `!important` from three custom properties and from a selector nothing reachable here can outrank, so redefining those properties lets its own rule paint the secondary tint — `--color-dokan-btn` itself stays unshadowed because the values below and the resting rule need it to still mean the brand.
         --color-dokan-btn-hover: #{"color-mix(in srgb, var(--color-dokan-btn, #7047eb) 10%, #fff)"};
         --color-dokan-btn-border-hover: var(--color-dokan-btn, #7047eb);
         --color-dokan-btn-text-hover: var(--color-dokan-btn, #7047eb);
@@ -1846,10 +1466,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         text-shadow: none;
     }
 
-    // Primary — everything else — darkens. The theme's hover reached the `<button>`s
-    // carrying `.dokan-btn-default` but not Update, which is an `<input>` on
-    // `.dokan-btn-success`, so identical-looking buttons behaved differently under the
-    // pointer.
+    // The theme's hover reached the `<button>`s carrying `.dokan-btn-default` but not Update, an `<input>` on `.dokan-btn-success`, so identical-looking buttons behaved differently under the pointer.
     .dokan-btn:not(.cancel-action):not(.dokan-cancel-status),
     input[type="submit"].dokan-btn {
         &:hover,
@@ -1864,8 +1481,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 // ── Sidebar ────────────────────────────────────────────────────────────────────
 
 .dokan-order-details-fragment .dokan-order-right-content {
-    // Detail rows: muted label, dark value. Notes carry `list-unstyled` too, and this
-    // selector would outrank the notes block below, so they are excluded here.
+    // Detail rows: muted label, dark value. Notes carry `list-unstyled` too and this selector would outrank the notes block below, so they are excluded here.
     ul.list-unstyled:not(.order_notes) {
         margin: 0;
 
@@ -1877,8 +1493,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             color: #6b6b6b;
             list-style: none;
 
-            // Figma labels the value, not the other way round: dark semibold label,
-            // grey value.
+            // Figma labels the value, not the other way round: dark semibold label, grey value.
             > span:first-child {
                 margin-right: 6px;
                 font-size: 14px;
@@ -1899,11 +1514,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         color: var(--color-dokan-btn, #7047eb);
     }
 
-    // Legacy hangs the divider off the order block, so with "Hide Customer Info" on it
-    // trails under the last row with nothing beneath it. The divider belongs to whatever
-    // follows instead, so it only exists when there is something to separate.
-    // Qualified to outrank `.dokan-orders-content .dokan-orders-area .general-details
-    // ul.order-status`, which draws the divider.
+    // Legacy hangs the divider off the order block, so with "Hide Customer Info" on it trails under the last row with nothing beneath it; it belongs to whatever follows instead, qualified to outrank the legacy three-class rule that draws it.
     .dokan-panel-body.general-details ul.order-status {
         padding-bottom: 0;
         border-bottom: 0;
@@ -1920,10 +1531,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         line-height: 22px;
         color: #6b6b6b;
 
-        // The note arrived unstyled: a 12px label above a 16px body, so the caption read
-        // smaller than the thing it captions. It now matches the detail rows above it —
-        // dark semibold label, grey value — the only difference being that the note gets
-        // its own line, which suits a sentence rather than a field.
+        // The note arrived unstyled as a 12px label above a 16px body, so the caption read smaller than the thing it captions; it now matches the detail rows above, except that the note gets its own line as a sentence should.
         strong {
             display: block;
             margin-bottom: 2px;
@@ -1933,9 +1541,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             color: $od-text;
         }
 
-        // The markup separates label from note with a `<br>`. Once the label is a block
-        // that break contributes a whole empty line of its own — 28px between the two
-        // instead of the 2px the label's own margin sets.
+        // The markup separates label from note with a `<br>`, which once the label is a block contributes a whole empty line instead of the 2px the label's own margin sets.
         br {
             display: none;
         }
@@ -1956,20 +1562,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             flex: 0 0 100%;
         }
 
-        // Update is the primary action, Cancel the secondary one. `!important` answers
-        // the vendor colour-scheme module, which emits its button fill inline.
+        // Update is the primary action; `!important` answers the vendor colour-scheme module, which emits its button fill inline.
         input[type="submit"] {
             background: var(--color-dokan-btn, #7047eb) !important;
             border: 1px solid var(--color-dokan-btn, #7047eb) !important;
             color: #fff !important;
         }
 
-        .dokan-cancel-status {
-            background: #fff !important;
-            border: 1px solid var(--color-dokan-btn, #7047eb) !important;
-            color: var(--color-dokan-btn, #7047eb) !important;
-        }
-
+        // Only the size differs here — the secondary colours come from the shared `.dokan-cancel-status` rule above.
         input[type="submit"],
         .dokan-cancel-status {
             height: 34px;
@@ -1977,19 +1577,14 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // The design separates the customer block from the order block with a divider.
-    // Pulled out to the card edges so the rule reads full-bleed, matching the notes card.
-    // Qualified to outrank `.dokan-orders-content .dokan-orders-area .general-details
-    // ul.customer-details`, which zeroes margin and padding.
+    // Pulled out to the card edges so the divider reads full-bleed like the notes card, and qualified to outrank the legacy three-class rule that zeroes margin and padding.
     .dokan-panel-body.general-details ul.customer-details {
         margin: 16px -20px 0;
         padding: 16px 20px 0;
         border-top: 1px solid $od-border;
     }
 
-    // Store pickup is the one row in this list Pro wraps in a `div` around its `li`, so
-    // the `li + li` step that spaces every other row skips it entirely and it sat flush
-    // against Customer IP above. The wrapper takes the step instead.
+    // Pro wraps this one row's `li` in a `div`, so the `li + li` step that spaces every other row skips it and it sat flush against Customer IP; the wrapper takes the step instead.
     .dokan-panel-body.general-details .vendor-store-pickup-location {
         margin-top: 12px;
 
@@ -1997,13 +1592,13 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             margin: 0;
         }
 
-        // Treated as the customer note is, not as a field row: a pickup address carries a
-        // date, a time window, a hub name and a street address, and at three lines it
-        // wrapped raggedly around its own label. Block label, value beneath, so both read
-        // straight down the column.
+        // Treated as the customer note is rather than as a field row: a pickup address carries a date, a time window, a hub name and a street, and at three lines it wrapped raggedly around its own label.
         > li > span {
             display: block;
             margin: 0 0 2px;
+            // Both sides stated outright: a longhand elsewhere leaves 6px on this label's inline end, which reads as nothing in LTR but pushes the label off the rail the rest of the list sits on once the column is mirrored.
+            margin-right: 0;
+            margin-left: 0;
             font-size: 14px;
             font-weight: 600;
             line-height: 22px;
@@ -2015,6 +1610,12 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             font-size: 14px;
             line-height: 22px;
             color: #6b6b6b;
+        }
+
+        // A pickup address is store data, so on an RTL store it is routinely still Latin; `plaintext` takes the direction from each line's own first strong character, or the browser reorders the time window and throws the label's colon to the wrong end.
+        > li > span,
+        > li > div {
+            unicode-bidi: plaintext;
         }
     }
 
@@ -2043,13 +1644,11 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     .dokan-label-info    { background: #e9f9ff; color: #0b76b7; }
     .dokan-label-default { background: #f2f2f2; color: #5c5c5c; }
 
-    // Notes card: each row owns its padding so the dividers run edge to edge, the way
-    // the RFQ sidebar sections do. The card body therefore carries none.
+    // Each note row owns its padding so the dividers run edge to edge, the way the RFQ sidebar sections do, which is why the card body carries none.
     #dokan-order-notes {
         padding: 0;
 
-        // Qualified with `ul` to outrank `.dokan-orders-content .dokan-orders-area
-        // ul.order_notes .note_content`, which paints the legacy grey bubble.
+        // Qualified with `ul` to outrank the legacy three-class `.note_content` rule, which paints the grey bubble.
         ul.order_notes {
             margin: 0;
 
@@ -2104,8 +1703,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
             }
         }
 
-        // `div.add_note` is qualified: the delivery-time Update button carries the same
-        // class, and would otherwise pick up this block's spacing.
+        // Qualified as `div.add_note` because the delivery-time Update button carries the same class and would otherwise pick up this block's spacing.
         > div.add_note {
             margin: 0;
             padding: 20px;
@@ -2135,8 +1733,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 margin: 0;
             }
 
-            // The note-type select and submit share a floated row; flex lets the select
-            // take the free space and pins the button to the right edge.
+            // The note-type select and submit share a floated row; flex lets the select take the free space and pins the button to the right edge.
             .clearfix {
                 display: flex;
                 align-items: center;
@@ -2166,26 +1763,20 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // Delivery / Store Pickup choice row.
     #vendor-delivery-type {
-        // Flex rather than inline flow: the markup puts a newline between each input and
-        // its label, and that whitespace text node renders as an extra ~4px gap.
+        // Flex rather than inline flow: the newline the markup puts between each input and its label renders as an extra ~4px whitespace gap.
         display: flex;
         align-items: center;
         flex-wrap: wrap;
-        // The date field below carries its own 16px, which is the card's rhythm; adding
-        // more here stacked to 36px and broke the run of fields.
+        // The date field below carries its own 16px, which is the card's rhythm; more here stacked to 36px and broke the run of fields.
         margin-bottom: 0;
 
-        // The module's `.delivery-type-*` classes sit on the label as well as the input,
-        // so the label picks up its padding too and widens the gap to its own control.
+        // The module's `.delivery-type-*` classes sit on the label as well as the input, so the label picks up its padding and widens the gap to its own control.
         .delivery-type-delivery,
         .delivery-type-pickup {
             padding: 0;
         }
 
-        // The module styles these radios as a custom pill via
-        // `.vendor-delivery-time-box form #vendor-delivery-type .delivery-type-delivery`
-        // (padding `0 30px 0 8px`), which under `border-box` inflates a 16px radio into a
-        // 40px lozenge. Scoped through the same id to outrank it.
+        // The module styles these radios as a custom pill whose padding inflates a 16px radio into a 40px lozenge under `border-box`, so this is scoped through the same id to outrank it.
         input[type="radio"],
         input[type="checkbox"] {
             width: 16px;
@@ -2205,9 +1796,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
                 border-color: var(--color-dokan-btn, #7047eb);
             }
 
-            // The module also draws its own radio as a 19px pseudo-element over the real
-            // control, which is what rendered as a grey blob. Drop it and let the
-            // standard control show, matching the radios on the other panel screens.
+            // The module also draws its own radio as a 19px pseudo-element over the real control, which is what rendered as a grey blob.
             &::before,
             &::after,
             &:checked::before,
@@ -2246,10 +1835,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Legacy strips the native arrow with `appearance: none` and puts nothing back, so
-    // the control reads as a plain text box. This restores the affordance.
-    // Also matched as `select.dokan-form-control`: the shared control rule above hits
-    // this element through its class (0,3,0), which outranks a bare element selector.
+    // Legacy strips the native arrow with `appearance: none` and puts nothing back; also matched as `select.dokan-form-control`, because the shared control rule reaches this element through its class and outranks a bare element selector.
     select,
     select.dokan-form-control,
     select.form-control {
@@ -2272,11 +1858,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Buttons ────────────────────────────────────────────────────────────────────
-//
-// One button standard for the whole view, for the same reason as the controls below: this
-// lived under `.dokan-order-right-content` and reached only the sidebar, so the sidebar's
-// buttons sat at 38px on a 6px radius while Request Refund and Create New Shipment in the
-// main column kept legacy's 3px.
+// One button standard for the whole view: this lived under `.dokan-order-right-content` and reached only the sidebar, so Request Refund and Create New Shipment in the main column kept legacy's 3px radius against the sidebar's 6px.
 
 .dokan-order-details-fragment {
     a.dokan-btn {
@@ -2297,9 +1879,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         box-shadow: none;
     }
 
-    // `.dokan-dashboard-wrap .dokan-btn.dokan-btn-theme` pins 3px as `!important`, which
-    // left Create New Shipment and the delivery-time Update on a different corner from
-    // every other button in the view. Naming the modifier as well outranks it.
+    // `.dokan-dashboard-wrap .dokan-btn.dokan-btn-theme` pins 3px as `!important`, so naming the modifier as well is what outranks it.
     &#{&} {
         .dokan-btn,
         .dokan-btn.dokan-btn-theme,
@@ -2311,11 +1891,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Form controls ──────────────────────────────────────────────────────────────
-//
-// One control standard for the whole view. This lived under `.dokan-order-right-content`
-// and so only ever reached the sidebar, which is why the Shipments card's selects came
-// out 35px with square corners and its inputs 37px while the notes and delivery-time
-// fields beside them were 38px on a 6px radius.
+// One control standard for the whole view: this lived under `.dokan-order-right-content` and so only reached the sidebar, which is why the Shipments card's selects came out 35px with square corners beside 38px fields on a 6px radius.
 
 .dokan-order-details-fragment {
     input[type="text"],
@@ -2342,8 +1918,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
-    // Legacy pins selects to 35px while the button beside them sits at 43px, leaving a
-    // row visibly uneven. One height for all of them settles it.
+    // Legacy pins selects to 35px while the button beside them sits at 43px, so one height for all of them settles the row.
     input[type="text"],
     input[type="number"],
     input[type="email"],
@@ -2352,9 +1927,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     select,
     select.dokan-form-control,
     select.form-control {
-        // `select.dokan-form-control` pins 35px at the same specificity as a bare `select`
-        // here and wins on source order, so the class has to be named explicitly or the
-        // selects sit 3px shorter than the inputs beside them.
+        // `select.dokan-form-control` pins 35px at the same specificity as a bare `select` here and wins on source order, so the class has to be named explicitly.
         height: 38px;
     }
 
@@ -2371,13 +1944,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Focus ──────────────────────────────────────────────────────────────────────
-//
-// One treatment for every control in the fragment. Left alone they disagree: the theme
-// paints a 2px orange outline on plain inputs, while anything carrying Tailwind's
-// `.form-input` takes a blue ring — the two downloadable-permission fields sat side by
-// side with different answers. `!important` because both of those origins are themselves
-// `!important` in this build, and last in the file because the section rules above match
-// at the same specificity and would otherwise win on source order.
+// One focus treatment for every control in the fragment: left alone the theme paints a 2px orange outline while anything carrying Tailwind's `.form-input` takes a blue ring, `!important` because both origins are themselves `!important` in this build, and last in the file because the section rules above match at the same specificity.
 .dokan-order-details-fragment {
     input[type="text"]:focus,
     input[type="number"]:focus,
@@ -2394,12 +1961,7 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 }
 
 // ── Panel header ───────────────────────────────────────────────────────────────
-//
-// The header is React, outside the fragment, so it is reached through the page — the
-// same `:has()` guard the grey canvas and the date picker use. Its buttons come from the
-// shared component library at Tailwind's 4px `rounded`, while every control and button
-// inside the view sits at 6px, which put the two buttons closest to the card on a
-// different corner radius from everything they sit above.
+// The header is React, outside the fragment, so it is reached through the page with the same `:has()` guard the grey canvas and the date picker use; its shared-library buttons come at Tailwind's 4px while every control inside the view sits at 6px.
 body:has(.dokan-order-details-fragment) {
     .dokan-header-actions button,
     .dokan-header-actions a {
@@ -2409,15 +1971,10 @@ body:has(.dokan-order-details-fragment) {
 }
 
 // ── jQuery UI date picker ───────────────────────────────────────────────────────
-//
-// The picker is appended to `<body>`, outside the fragment, so it is reached through
-// the page rather than the wrapper. `:has()` keeps that to pages actually showing the
-// fragment, which is the same guard the grey canvas above uses.
+// The picker is appended to `<body>`, outside the fragment, so it is reached through the page, with `:has()` keeping that to pages actually showing the fragment.
 body:has(.dokan-order-details-fragment) {
     #ui-datepicker-div {
-        // jQuery UI writes `z-index: 1` inline from the input's own stacking context, so
-        // the calendar opened *underneath* select2's product search (z-index 1050) and
-        // the search box painted straight through it.
+        // jQuery UI writes `z-index: 1` inline from the input's own stacking context, so the calendar opened underneath select2's product search and the search box painted straight through it.
         z-index: 1100 !important;
         width: 260px;
         padding: 8px;
@@ -2519,14 +2076,10 @@ body:has(.dokan-order-details-fragment) {
 }
 
 // ── select2 product search dropdown ────────────────────────────────────────────
-//
-// The dropdown is a sibling of the field, not a descendant of the fragment wrapper in
-// every select2 configuration, so it is matched on its own classes and kept to pages
-// showing the fragment — the same guard the grey canvas and the date picker use.
+// The dropdown is a sibling of the field rather than a descendant of the fragment wrapper in every select2 configuration, so it is matched on its own classes and kept to pages showing the fragment by the same `:has()` guard.
 body:has(.dokan-order-details-fragment) {
     .select2-container--default .select2-dropdown {
-        // Stock select2 draws a mid-grey #7f868d hairline with 4px corners, which reads
-        // as a black box against the card's #e5e7eb fields.
+        // Stock select2 draws a mid-grey #7f868d hairline with 4px corners, which reads as a black box against the card's #e5e7eb fields.
         border: 1px solid #e5e7eb;
         border-radius: 6px;
         background: #fff;
@@ -2534,8 +2087,7 @@ body:has(.dokan-order-details-fragment) {
         overflow: hidden;
     }
 
-    // Opening upward is select2 reacting to the viewport edge, not a bug — but the shared
-    // corner should be square so the panel reads as attached to the field it belongs to.
+    // Opening upward is select2 reacting to the viewport edge, not a bug, but the shared corner should be square so the panel reads as attached to the field it belongs to.
     .select2-container--default .select2-dropdown--above {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -126,13 +126,65 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
     }
 }
 
+// The main column mixes full-width cards with a two-up address row. Legacy floats them,
+// which cannot equalise the pair's height, so the shorter card stopped short of its
+// neighbour. Flex does, and keeps the same order and widths.
+.dokan-order-details-fragment .dokan-order-left-content > .dokan-clearfix {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+
+    &::before,
+    &::after {
+        content: none;
+    }
+
+    // `gap` owns the spacing; the legacy percentage margins would push the address pair
+    // past 100% of the row and wrap it.
+    > * {
+        flex: 0 0 100%;
+        min-width: 0;
+        margin: 0 !important;
+    }
+
+    // The address pair shares the row, splitting it around the 24px gap.
+    > .dokan-left {
+        flex: 1 1 calc(50% - 12px);
+    }
+
+    // Its card fills the equalised height rather than sitting short inside it.
+    > .dokan-left > .dokan-panel {
+        height: 100%;
+    }
+
+    // A float clearer has no job in a flex row.
+    > .clear {
+        display: none;
+    }
+
+    // The row gap owns the rhythm now.
+    .dokan-panel {
+        margin-bottom: 0;
+    }
+}
+
 // Address cards carry plain body copy rather than the legacy dense block.
 .dokan-order-details-fragment {
     .dokan-order-billing-address .dokan-panel-body,
     .dokan-order-shipping-address .dokan-panel-body {
+        // A 28px line box around 14px text carries ~7px of half-leading above the first
+        // line and below the last, so a flat 20px pad reads as ~27px vertically against
+        // a true 20px on the sides. Trimming the vertical pad evens the optical inset.
+        padding: 13px 20px;
         font-size: 14px;
-        line-height: 22px;
+        // Addresses run to many short lines with no separators between fields, so they
+        // need noticeably more leading than the single-line rows elsewhere to stay
+        // readable as distinct lines.
+        line-height: 28px;
         color: #6b6b6b;
+        // Addresses are free text and can carry long unbroken tokens; wrap rather than
+        // push the card wider than its column.
+        overflow-wrap: anywhere;
 
         address,
         p {
@@ -141,22 +193,317 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         }
     }
 
+    // The download permission details live in a Bootstrap `.panel-collapse.collapse`,
+    // and the panel's own Tailwind bundle defines `.dokan-layout .collapse` as the
+    // `visibility: collapse` utility — same class name, opposite meaning. That collision
+    // hid Downloads Remaining, Access Expires and the download count, which the legacy
+    // page shows because it never loads Tailwind. The design has them always visible.
+    // `!important` is required: the utility is emitted important, so no specificity wins.
+    .panel-collapse.collapse {
+        visibility: visible !important;
+        height: auto;
+    }
+
+    // Title and Revoke share one row, pushed apart — the design's justify-between.
+    // The legacy markup floats the button, which the flex row makes redundant.
+    .order_download_permissions .dokan-panel-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+    }
+
+    // Headings/H4 in the design: 14px semibold at the body text colour. The markup makes
+    // it an `<a>` (it toggles the collapse), so it arrives as a brand-coloured link.
+    // Two of the three parts are links — the product, and the file the permission grants
+    // access to — so those keep the link colour while the connective text stays body
+    // coloured. That contrast is what makes it readable as "these bits are clickable".
+    .order_download_permissions .dokan-panel-heading .title {
+        flex: 1 1 auto;
+        min-width: 0;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 18px;
+        color: $od-text;
+
+        a:hover,
+        a:focus {
+            text-decoration: underline;
+        }
+    }
+
+    // Revoke is a quiet action, not a danger button.
+    .order_download_permissions .revoke_access {
+        flex: 0 0 auto;
+        float: none;
+        height: auto;
+        // `!important`: legacy's `.btn-sm` keeps 10px of side padding, which stopped the
+        // label 10px short of the counter beneath it on the same right edge.
+        padding: 0 !important;
+        background: transparent !important;
+        border: 0 !important;
+        box-shadow: none !important;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 18px;
+        color: var(--color-dokan-btn, #7047eb) !important;
+    }
+
+    // Product search: the design's bordered field with a magnifier, and a real gap
+    // before Grant Access. The legacy toolbar relies on a grid that collapses here.
+    .order_download_permissions .toolbar {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+        // `!important` because legacy sets `margin-top: 15px` from a four-class selector,
+        // which stacked on the last row's 30px and left a wider gap above the rule here
+        // than between the file rows.
+        margin: 0 -20px !important;
+        padding: 0 20px;
+
+        &::before,
+        &::after {
+            content: none;
+        }
+
+        > * {
+            width: 100%;
+            margin: 0 !important;
+            padding: 0;
+            float: none;
+        }
+
+        // select2 mounts its dropdown as a sibling of the field inside this flex column,
+        // so without this it becomes a flex item and pushes Grant Access down.
+        > .select2-container--open .select2-dropdown {
+            width: 100% !important;
+        }
+
+        .dokan-w4 {
+            width: auto;
+        }
+    }
+
+    // A rule above the add-product toolbar, on the same full-bleed line as the dividers
+    // between files, so the list reads as separate from the control that adds to it —
+    // including when there is a single permission and no between-file rules at all.
+    // Conditional on the list actually having rows: with none, a lone rule hanging under
+    // the card header separates nothing.
+    .order_download_permissions .panel-group {
+        margin-bottom: 0;
+    }
+
+    .order_download_permissions .panel-group:has(> .dokan-panel) + .toolbar {
+        padding-top: 22px;
+        border-top: 1px solid $od-border;
+    }
+
+    // select2 renders its own box, so the field styling has to land on that.
+    .order_download_permissions .select2-container {
+        width: 100% !important;
+    }
+
+    .order_download_permissions .select2-container .select2-selection {
+        // Height, not min-height: the inner search input is what grows the box, and it
+        // pushed this to 46px next to the two 40px fields above it.
+        height: 40px;
+        min-height: 40px;
+        padding: 3px 12px 3px 36px;
+        background-color: #fff;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: left 12px center;
+        background-size: 16px 16px;
+        border: 1px solid $od-border;
+        border-radius: 6px;
+        box-shadow: none;
+    }
+
+    // Typed text inherited the placeholder's grey and read as invisible.
+    .order_download_permissions .select2-container .select2-search__field {
+        height: 32px;
+        margin: 0;
+        color: $od-text !important;
+        font-size: 14px;
+        line-height: 30px;
+
+        &::placeholder {
+            color: $od-muted;
+        }
+    }
+
+    // The permission fields are a fixed-layout table whose first row has one cell and
+    // second has two, so the meta line only ever filled the left 60%. Laid out as blocks
+    // they stack full width, the way the design shows them.
+    .wc-metabox-content {
+        display: block;
+        width: 100%;
+        margin: 0;
+
+        tbody,
+        tr {
+            display: block;
+        }
+
+        td {
+            display: block;
+            // Beats the inline `width: 60%` on the first cell.
+            width: auto !important;
+            // 20px from a field to the label under it, per the design's row rhythm.
+            padding: 0 0 20px;
+            // The theme zebra-stripes tables — `table:not(.has-background) tbody td` plus a
+            // `tr:nth-child(2n) td` override — which, once the table is laid out as blocks,
+            // reads as grey bands running the width of the card behind the labels. The
+            // striping selector is four element-selectors deep, so it cannot be outranked
+            // from here on specificity alone.
+            background-color: transparent !important;
+            border: 0;
+            font-size: 14px;
+            line-height: 22px;
+            color: #6b6b6b;
+        }
+
+        tr:last-child td:last-child {
+            padding-bottom: 0;
+        }
+
+        // Headings/H6: 12px semibold, 130%. 27px from the top of the label to the top of
+        // its field is the design's measured gap.
+        label {
+            display: block;
+            margin-bottom: 11px;
+            font-size: 12px;
+            // Legacy resets these labels to `normal` from a three-class selector.
+            font-weight: 600 !important;
+            line-height: 16px;
+            color: $od-text;
+        }
+
+        // The design pairs each field label with its counter on one row — label left,
+        // counter right. The counter lives in its own leading row in this markup, so it
+        // is lifted by exactly its own height onto the following row's line, which lands
+        // the two on a shared baseline without either one moving the fields below.
+        // Paragraphs/Small: 12px regular, 140%.
+        tr:first-child td {
+            display: flex;
+            justify-content: flex-end;
+            height: 16px;
+            margin-bottom: -16px;
+            padding: 0;
+            font-size: 12px;
+            line-height: 16px;
+            color: $od-muted;
+
+            label {
+                display: inline;
+                margin: 0 4px 0 0;
+                font-size: 12px;
+                font-weight: 400 !important;
+                line-height: 16px;
+                color: $od-muted;
+            }
+        }
+
+        // Beats the inline `width: 150px` on both fields. The `!important` run is for the
+        // number field only in practice: it carries Tailwind's `.form-input`, which this
+        // build emits with `!important`, so specificity alone left it square-cornered,
+        // 16px and grey-bordered next to an identically-sized sibling.
+        input[type="number"],
+        input[type="text"] {
+            width: 100% !important;
+            height: 40px !important;
+            padding: 8px 12px !important;
+            background-color: #fff !important;
+            border: 1px solid $od-border !important;
+            border-radius: 6px !important;
+            font-size: 14px !important;
+            line-height: 22px;
+            color: $od-text !important;
+            box-shadow: none !important;
+
+            &::placeholder {
+                color: $od-muted;
+            }
+        }
+
+        input[type="number"] {
+            appearance: textfield;
+
+            &::-webkit-inner-spin-button,
+            &::-webkit-outer-spin-button {
+                appearance: none;
+                margin: 0;
+            }
+        }
+
+        // Calendar affordance on the expiry field, matching the design. `!important` to
+        // match the shared padding above, which needs it to beat Tailwind's `.form-input`
+        // and would otherwise pull the text back under the icon.
+        input.datepicker {
+            padding-left: 38px !important;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23828282' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: left 12px center;
+            background-size: 16px 16px;
+        }
+    }
+
+    // Pro's shipment card uses bare `h4`/`h5` tags, so they inherit the theme's heading
+    // scale — "Shipment #1" rendered at 22.6px weight 300 inside a card whose own titles
+    // are 14px semibold.
+    .shippments-tracking-title {
+        font-size: 15px;
+        font-weight: 600;
+        line-height: 22px;
+        color: $od-text;
+    }
+
+    .shippments-tracking-via {
+        margin: 2px 0 0;
+        font-size: 13px;
+        line-height: 20px;
+        color: $od-muted;
+    }
+
+    .shipping-status-track-info-heading,
+    .dokan-customer-shipment-notes-list-area h5 {
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 22px;
+        color: $od-text;
+    }
+
     // Nested panels — one per downloadable file — are rows inside a card, not cards of
     // their own. Flattened so their content keeps the card's single 20px inset.
     .dokan-panel .dokan-panel {
-        margin: 0;
+        // 22px either side of every rule in this section — a touch more air than the
+        // 20px used inside a row, so the rules read as separators rather than as part of
+        // the field rhythm. The design measures 60px
+        // here, but its rows lead with a 40px thumbnail block where ours has a single line
+        // of text, so the same figure reads as far more air. Pulled out to the card edges
+        // so the rule is full-bleed like the notes and general-details dividers, with the
+        // inset put back as padding so the content does not move.
+        margin: 0 -20px;
+        padding: 22px 20px;
         border: 0;
         border-radius: 0;
         box-shadow: none;
 
-        > .dokan-panel-heading {
-            padding: 12px 0;
-            border-bottom: 0;
-            font-weight: 500;
+        &:first-child {
+            padding-top: 0;
         }
 
-        > .dokan-panel-body {
-            padding: 0 0 12px;
+        > .dokan-panel-heading {
+            padding: 0;
+            background: transparent;
+            border-bottom: 0;
+        }
+
+        // Same 20px that separates a field from the label beneath it, so the product line
+        // sits on the section's own rhythm rather than a wider one of its own.
+        > .panel-collapse > .panel-body {
+            padding: 20px 0 0;
         }
 
         + .dokan-panel {
@@ -569,5 +916,185 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
         font-weight: 500;
         text-shadow: none;
         box-shadow: none;
+    }
+}
+
+// ── Focus ──────────────────────────────────────────────────────────────────────
+//
+// One treatment for every control in the fragment. Left alone they disagree: the theme
+// paints a 2px orange outline on plain inputs, while anything carrying Tailwind's
+// `.form-input` takes a blue ring — the two downloadable-permission fields sat side by
+// side with different answers. `!important` because both of those origins are themselves
+// `!important` in this build, and last in the file because the section rules above match
+// at the same specificity and would otherwise win on source order.
+.dokan-order-details-fragment {
+    input[type="text"]:focus,
+    input[type="number"]:focus,
+    input[type="email"]:focus,
+    input[type="date"]:focus,
+    select:focus,
+    textarea:focus,
+    .select2-container--focus .select2-selection,
+    .select2-container--open .select2-selection {
+        border-color: var(--color-dokan-btn, #7047eb) !important;
+        outline: none !important;
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-dokan-btn, #7047eb) 18%, transparent) !important;
+    }
+}
+
+// ── jQuery UI date picker ───────────────────────────────────────────────────────
+//
+// The picker is appended to `<body>`, outside the fragment, so it is reached through
+// the page rather than the wrapper. `:has()` keeps that to pages actually showing the
+// fragment, which is the same guard the grey canvas above uses.
+body:has(.dokan-order-details-fragment) {
+    #ui-datepicker-div {
+        // jQuery UI writes `z-index: 1` inline from the input's own stacking context, so
+        // the calendar opened *underneath* select2's product search (z-index 1050) and
+        // the search box painted straight through it.
+        z-index: 1100 !important;
+        width: 260px;
+        padding: 8px;
+        background: #fff;
+        border: 1px solid #e5e7eb;
+        border-radius: 6px;
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
+        font-family: inherit;
+        font-size: 13px;
+    }
+
+    .ui-datepicker .ui-datepicker-header {
+        margin: 0 0 4px;
+        padding: 4px 0;
+        background: transparent;
+        border: 0;
+        border-radius: 0;
+    }
+
+    .ui-datepicker .ui-datepicker-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: #25252d;
+    }
+
+    // The stock arrows are sprite-backed and read as grey blobs against a white header.
+    .ui-datepicker .ui-datepicker-prev,
+    .ui-datepicker .ui-datepicker-next {
+        top: 4px;
+        height: 26px;
+        width: 26px;
+        background: transparent;
+        border: 0;
+        border-radius: 4px;
+        cursor: pointer;
+
+        &:hover {
+            background: #f3f4f6;
+            border: 0;
+        }
+
+        .ui-icon {
+            background-image: none;
+            text-indent: 0;
+            overflow: visible;
+            font-size: 0;
+
+            &::before {
+                display: block;
+                width: 8px;
+                height: 8px;
+                margin: 5px auto;
+                border-top: 2px solid #6b6b6b;
+                border-right: 2px solid #6b6b6b;
+                content: "";
+            }
+        }
+    }
+
+    .ui-datepicker .ui-datepicker-prev .ui-icon::before {
+        transform: rotate(-135deg);
+    }
+
+    .ui-datepicker .ui-datepicker-next .ui-icon::before {
+        transform: rotate(45deg);
+    }
+
+    .ui-datepicker th {
+        padding: 6px 0;
+        font-size: 12px;
+        font-weight: 600;
+        color: #828282;
+    }
+
+    .ui-datepicker td {
+        padding: 1px;
+    }
+
+    .ui-datepicker td .ui-state-default {
+        padding: 6px 0;
+        background: transparent;
+        border: 0;
+        border-radius: 4px;
+        font-weight: 400;
+        color: #25252d;
+        text-align: center;
+
+        &:hover {
+            background: #f3f4f6;
+        }
+    }
+
+    .ui-datepicker td .ui-state-active,
+    .ui-datepicker td .ui-state-highlight {
+        background: var(--color-dokan-btn, #7047eb);
+        color: #fff;
+        font-weight: 600;
+    }
+}
+
+// ── select2 product search dropdown ────────────────────────────────────────────
+//
+// The dropdown is a sibling of the field, not a descendant of the fragment wrapper in
+// every select2 configuration, so it is matched on its own classes and kept to pages
+// showing the fragment — the same guard the grey canvas and the date picker use.
+body:has(.dokan-order-details-fragment) {
+    .select2-container--default .select2-dropdown {
+        // Stock select2 draws a mid-grey #7f868d hairline with 4px corners, which reads
+        // as a black box against the card's #e5e7eb fields.
+        border: 1px solid #e5e7eb;
+        border-radius: 6px;
+        background: #fff;
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
+        overflow: hidden;
+    }
+
+    // Opening upward is select2 reacting to the viewport edge, not a bug — but the shared
+    // corner should be square so the panel reads as attached to the field it belongs to.
+    .select2-container--default .select2-dropdown--above {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        box-shadow: 0 -10px 15px -3px rgb(0 0 0 / 10%), 0 -4px 6px -4px rgb(0 0 0 / 10%);
+    }
+
+    .select2-container--default .select2-dropdown--below {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+    }
+
+    .select2-container--default .select2-results__option {
+        padding: 9px 12px;
+        font-size: 14px;
+        line-height: 20px;
+        color: #25252d;
+    }
+
+    // The "type 3 more characters" hint is guidance, not a choice.
+    .select2-container--default .select2-results__message {
+        color: #828282;
+    }
+
+    .select2-container--default .select2-results__option--highlighted[aria-selected] {
+        background-color: #f3f4f6;
+        color: #25252d;
     }
 }

--- a/src/dashboard/orders/order-details-fragment.scss
+++ b/src/dashboard/orders/order-details-fragment.scss
@@ -141,15 +141,23 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
     // `gap` owns the spacing; the legacy percentage margins would push the address pair
     // past 100% of the row and wrap it.
+    //
+    // `min-width` needs `!important` for the same reason, from a rule one class deeper:
+    // legacy pins the address columns to `min-width: 49%`, which only leaves room for the
+    // pair plus the 24px gap while the row is at least 1200px wide. Below that the minimum
+    // outgrows the basis and the second address drops to its own line — so the layout
+    // silently changed with the window rather than staying a two-column pair.
     > * {
         flex: 0 0 100%;
-        min-width: 0;
+        min-width: 0 !important;
         margin: 0 !important;
     }
 
-    // The address pair shares the row, splitting it around the 24px gap.
+    // The address pair shares the row, splitting it around the 24px gap. Sized from a
+    // width rather than a percentage so the pair stacks when there is genuinely no room
+    // for two columns — a 50% basis would hold two 150px columns on a phone.
     > .dokan-left {
-        flex: 1 1 calc(50% - 12px);
+        flex: 1 1 320px;
     }
 
     // Its card fills the equalised height rather than sitting short inside it.
@@ -508,6 +516,245 @@ $od-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%), 0 1px 2px -1px rgb(0 0 0 / 10%);
 
         + .dokan-panel {
             border-top: 1px solid $od-border;
+        }
+    }
+}
+
+// ── Order items ────────────────────────────────────────────────────────────────
+//
+// The line-item table and the totals beneath it, restyled to the design: a quiet
+// uppercase header rather than a ruled one, white rows separated by hairlines, a 44px
+// product thumbnail, and money right-aligned to the card edge.
+//
+// The markup is Pro's `orders/views/html-order-items` (with Lite's fallback carrying the
+// same class names), so the selectors here name those classes rather than the DOM shape.
+
+.dokan-order-details-fragment {
+    .woocommerce_order_items,
+    .wc-order-totals {
+        width: 100%;
+        margin: 0;
+        border: 0;
+        border-collapse: collapse;
+        background: transparent;
+    }
+
+    // The theme zebra-stripes tables and Dokan opts in with `dokan-table-strip`; the
+    // design has plain white rows carrying hairline separators instead.
+    .woocommerce_order_items td,
+    .woocommerce_order_items th,
+    .wc-order-totals td,
+    .wc-order-totals th {
+        background-color: transparent !important;
+    }
+
+    // The rules between rows run to the card edges, like every other divider in this
+    // view. The table is pulled out over the body's 20px inset and the edge cells put it
+    // back, so the content stays aligned with the card heading above it.
+    .woocommerce_order_items_wrapper,
+    .wc-order-data-row.wc-order-totals-items {
+        margin-left: -20px;
+        margin-right: -20px;
+    }
+
+    .woocommerce_order_items th:first-child,
+    .woocommerce_order_items td:first-child,
+    .wc-order-totals td:first-child {
+        padding-left: 20px;
+    }
+
+    .woocommerce_order_items th:last-child,
+    .woocommerce_order_items td:last-child,
+    .wc-order-totals td:last-child {
+        padding-right: 20px;
+    }
+
+    // Column headings are labels, not a ruled header band: Inter 12/16 uppercase in the
+    // muted grey, with a single rule under the row.
+    .woocommerce_order_items thead th {
+        padding: 0 12px 12px 0;
+        border: 0;
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 16px;
+        letter-spacing: 0;
+        text-transform: uppercase;
+        color: $od-muted;
+        vertical-align: bottom;
+    }
+
+    .woocommerce_order_items tbody td {
+        padding: 16px 12px 16px 0;
+        border: 0;
+        font-size: 14px;
+        line-height: 20px;
+        color: $od-text;
+        vertical-align: middle;
+    }
+
+    // The rule belongs to the row, not to its cells. Line items render six cells while a
+    // shipping row renders seven, so a cell-level border stopped 27px short on some rows
+    // and ran to the edge on others — a ragged right edge down the table.
+    .woocommerce_order_items thead tr,
+    .woocommerce_order_items tbody tr {
+        border-bottom: 1px solid $od-border;
+    }
+
+    // Last row closes on the totals block's own rule instead of doubling up.
+    .woocommerce_order_items tbody:last-of-type tr:last-child {
+        border-bottom: 0;
+    }
+
+    // 44px at a 3px radius with a hairline, and 16px of air before the name.
+    .woocommerce_order_items td.thumb {
+        // Border-box, so this has to carry the card inset and the gap as well as the
+        // image: 20 + 44 + 16. At 60 the padding ate it and the image rendered 24px wide.
+        width: 80px;
+        padding-right: 16px;
+
+        img {
+            display: block;
+            width: 44px;
+            height: 44px;
+            border: 1px solid #e9e9e9;
+            border-radius: 3px;
+            object-fit: cover;
+        }
+    }
+
+    // The product reads as the row's subject, so it takes the body colour rather than the
+    // link colour it inherits from the theme.
+    .woocommerce_order_items td.name {
+        a {
+            color: $od-text !important;
+
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
+        }
+
+        .order-product-variation {
+            margin: 4px 0 0;
+            font-size: 13px;
+            line-height: 18px;
+        }
+    }
+
+    // Money and counts get fixed columns so they stop bunching against the right edge,
+    // and the heading sits over its own values.
+    .woocommerce_order_items th.item_cost,
+    .woocommerce_order_items td.item_cost,
+    .woocommerce_order_items th.line_cost,
+    .woocommerce_order_items td.line_cost,
+    .woocommerce_order_items th.line_tax,
+    .woocommerce_order_items td.line_tax {
+        width: 110px;
+        padding-right: 0;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    .woocommerce_order_items th.quantity,
+    .woocommerce_order_items td.quantity {
+        width: 70px;
+        padding-right: 0;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    // A struck original belongs under its replacement, not beside it.
+    .woocommerce_order_items td del {
+        display: block;
+        font-size: 13px;
+        line-height: 18px;
+        color: $od-muted;
+    }
+
+    // Totals: label left, amount right, on the same 14px body scale as the rows above.
+    .wc-order-data-row.wc-order-totals-items {
+        margin-top: 20px;
+        overflow: hidden;
+
+        &::before,
+        &::after {
+            content: none;
+        }
+    }
+
+    .wc-order-totals td {
+        padding: 9px 0;
+        border: 0;
+        font-size: 14px;
+        line-height: 20px;
+        color: $od-text;
+    }
+
+    .wc-order-totals td.total {
+        width: 35%;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    // Order Total is the figure the row exists for. It has no class of its own, but it is
+    // always the row directly above the refunded one, which does.
+    .wc-order-totals tr:has(+ tr .refunded-total) td {
+        padding-top: 16px;
+        border-top: 1px solid $od-border;
+        font-weight: 600;
+    }
+
+    // A refund is money going out, so it reads in the danger colour.
+    .wc-order-totals .refunded-total {
+        color: #d63638;
+    }
+
+    // The question-mark tips are decoration next to a label; they should not outweigh it.
+    .wc-order-totals .dokan-vendor-order-page-tips {
+        color: $od-muted;
+        font-size: 12px;
+    }
+
+    // Coupon codes are chips in the design, not a bulleted list.
+    .wc-used-coupons {
+        margin-bottom: 12px;
+
+        .wc_coupon_list {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+        }
+
+        li {
+            margin: 0;
+            font-size: 13px;
+            line-height: 18px;
+            color: $od-muted;
+        }
+
+        li.code {
+            padding: 2px 10px;
+            background: #f3f4f6;
+            border-radius: 4px;
+            font-weight: 500;
+            color: $od-text;
+
+            a {
+                color: inherit !important;
+            }
+        }
+    }
+
+    // Refund controls sit under the totals as their own action row.
+    .wc-order-data-row.wc-order-bulk-actions {
+        margin-top: 16px;
+
+        .add-items {
+            margin: 0;
         }
     }
 }

--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -343,7 +343,7 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
                                 <h4><?php esc_html_e( 'Add note', 'dokan-lite' ); ?></h4>
                                 <form class="dokan-form-inline" id="add-order-note" role="form" method="post">
                                     <p>
-                                        <textarea type="text" id="add-note-content" name="note" class="form-control" cols="19" rows="3"></textarea>
+                                        <textarea type="text" id="add-note-content" name="note" class="form-control" cols="19" rows="3" placeholder="<?php esc_attr_e( 'Write here', 'dokan-lite' ); ?>"></textarea>
                                     </p>
                                     <div class="clearfix">
                                         <div class="order_note_type dokan-form-group">

--- a/templates/orders/order-download-permission-html.php
+++ b/templates/orders/order-download-permission-html.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         $permission_product_name = apply_filters( 'woocommerce_admin_download_permissions_title', $product->get_title(), $download->product_id, $download->order_id, $download->order_key, $download->download_id );
 
         // Pending, draft and private products 404 on `get_permalink()`, so those titles stay plain text rather than linking nowhere.
-        $permission_product_url  = is_post_publicly_viewable( $product->get_id() ) ? get_permalink( $product->get_id() ) : '';
+        $permission_product_url  = is_post_publicly_viewable( $product->get_id() ) ? $product->get_permalink() : '';
         $permission_product_html = $permission_product_url
             ? '<a href="' . esc_url( $permission_product_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_product_name ) . '</a>'
             : esc_html( $permission_product_name );
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
         </button>
     </div>
 
-    <div id="collapse-<?php echo esc_attr( $download->download_id ); ?>" class="panel-collapse collapse">
+    <div class="panel-collapse">
         <div class="panel-body">
             <table class="wc-metabox-content" style="table-layout: fixed;">
                 <tbody>

--- a/templates/orders/order-download-permission-html.php
+++ b/templates/orders/order-download-permission-html.php
@@ -6,24 +6,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="dokan-panel dokan-panel-default">
     <div class="dokan-panel-heading" style="overflow: hidden;">
         <?php
-        // This used to toggle a Bootstrap collapse, but Bootstrap's plugin is loaded on
-        // neither the panel nor the legacy page, so the accordion never worked and the
-        // href only pushed `#collapse-…` into the address bar. The product the title
-        // names is the useful destination, the way the order items table above links its
-        // products.
+        // Was a Bootstrap collapse toggle, but the plugin loads on neither surface, so the accordion never worked and the href only pushed `#collapse-…` into the address bar.
         $permission_product_name = apply_filters( 'woocommerce_admin_download_permissions_title', $product->get_title(), $download->product_id, $download->order_id, $download->order_key, $download->download_id );
 
-        // Pending, draft and private products have no address a customer could open —
-        // `get_permalink()` still returns one and it 404s — so those titles stay plain
-        // text rather than becoming a link that leads nowhere.
+        // Pending, draft and private products 404 on `get_permalink()`, so those titles stay plain text rather than linking nowhere.
         $permission_product_url  = is_post_publicly_viewable( $product->get_id() ) ? get_permalink( $product->get_id() ) : '';
         $permission_product_html = $permission_product_url
             ? '<a href="' . esc_url( $permission_product_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_product_name ) . '</a>'
             : esc_html( $permission_product_name );
 
-        // The file the permission is actually about. This is the Vendor's own asset, so it
-        // links straight to it; WooCommerce's "customer download link" is deliberately not
-        // used here because that URL carries the buyer's email address in its query string.
+        // Links straight to the Vendor's own asset — WooCommerce's "customer download link" is avoided because that URL carries the buyer's email in its query string.
         $permission_file_url  = $product->get_file_download_path( $download->download_id );
         $permission_file_name = wc_get_filename_from_url( $permission_file_url );
         $permission_file_html = $permission_file_url && $permission_file_name

--- a/templates/orders/order-download-permission-html.php
+++ b/templates/orders/order-download-permission-html.php
@@ -15,12 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
             ? '<a href="' . esc_url( $permission_product_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_product_name ) . '</a>'
             : esc_html( $permission_product_name );
 
-        // Links straight to the Vendor's own asset — WooCommerce's "customer download link" is avoided because that URL carries the buyer's email in its query string.
-        $permission_file_url  = $product->get_file_download_path( $download->download_id );
-        $permission_file_name = wc_get_filename_from_url( $permission_file_url );
-        $permission_file_html = $permission_file_url && $permission_file_name
-            ? '<a href="' . esc_url( $permission_file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_file_name ) . '</a>'
-            : esc_html( $permission_file_name );
+        // Named but not linked, as WooCommerce's own permissions metabox does: under the default Force Downloads method WooCommerce writes `deny from all` over the upload directory, so a direct link to the asset is dead on any server that honours it.
+        $permission_file_name = wc_get_filename_from_url( $product->get_file_download_path( $download->download_id ) );
 
         $permission_title = '#'
             . absint( $product->get_id() )
@@ -31,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 // translators: 1) download count, 2) download file name
                 __( 'File %1$s: %2$s', 'dokan-lite' ),
                 esc_html( $file_count ),
-                $permission_file_html
+                esc_html( $permission_file_name )
             );
         ?>
 
@@ -76,11 +72,11 @@ if ( ! defined( 'ABSPATH' ) ) {
                         <td>
                             <label><?php esc_html_e( 'Access Expires', 'dokan-lite' ); ?>:</label>
                             <?php
-                            // Rendered in the site's date format so it matches what the date picker writes back.
-                            $expire_date = $download->access_expires ? dokan_current_datetime()->modify( $download->access_expires )->format( wc_date_format() ) : '';
+                            // ISO, matching WooCommerce's own permissions metabox and the format the date picker on this field reads and writes.
+                            $expire_date = $download->access_expires ? dokan_current_datetime()->modify( $download->access_expires )->format( 'Y-m-d' ) : '';
                             ?>
 
-                            <input type="text" style="width: 150px;" class="short datepicker" name="access_expires[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $expire_date ); ?>" placeholder="<?php esc_attr_e( 'Never', 'dokan-lite' ); ?>" />
+                            <input type="text" style="width: 150px;" class="short datepicker" name="access_expires[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $expire_date ); ?>" maxlength="10" placeholder="<?php esc_attr_e( 'Never', 'dokan-lite' ); ?>" pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" />
                         </td>
                     </tr>
                 </tbody>

--- a/templates/orders/order-download-permission-html.php
+++ b/templates/orders/order-download-permission-html.php
@@ -5,27 +5,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="dokan-panel dokan-panel-default">
     <div class="dokan-panel-heading" style="overflow: hidden;">
-        <a
-            class="title"
-            data-toggle="collapse"
-            data-parent="#accordion"
-            href="#collapse-<?php echo esc_attr( $download->download_id ); ?>">
-            <?php
-            echo wp_kses_post(
-                '#'
-                . esc_attr( absint( $product->get_id() ) )
-                . ' &mdash; '
-                . apply_filters( 'woocommerce_admin_download_permissions_title', $product->get_title(), $download->product_id, $download->order_id, $download->order_key, $download->download_id )
-                . ' &mdash; '
-                . sprintf(
-                    // translators: 1) download count, 2) download file name
-                    __( 'File %1$s: %2$s', 'dokan-lite' ),
-                    $file_count,
-                    wc_get_filename_from_url( $product->get_file_download_path( $download->download_id ) )
-                )
+        <?php
+        // This used to toggle a Bootstrap collapse, but Bootstrap's plugin is loaded on
+        // neither the panel nor the legacy page, so the accordion never worked and the
+        // href only pushed `#collapse-…` into the address bar. The product the title
+        // names is the useful destination, the way the order items table above links its
+        // products.
+        $permission_product_name = apply_filters( 'woocommerce_admin_download_permissions_title', $product->get_title(), $download->product_id, $download->order_id, $download->order_key, $download->download_id );
+
+        // Pending, draft and private products have no address a customer could open —
+        // `get_permalink()` still returns one and it 404s — so those titles stay plain
+        // text rather than becoming a link that leads nowhere.
+        $permission_product_url  = is_post_publicly_viewable( $product->get_id() ) ? get_permalink( $product->get_id() ) : '';
+        $permission_product_html = $permission_product_url
+            ? '<a href="' . esc_url( $permission_product_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_product_name ) . '</a>'
+            : esc_html( $permission_product_name );
+
+        // The file the permission is actually about. This is the Vendor's own asset, so it
+        // links straight to it; WooCommerce's "customer download link" is deliberately not
+        // used here because that URL carries the buyer's email address in its query string.
+        $permission_file_url  = $product->get_file_download_path( $download->download_id );
+        $permission_file_name = wc_get_filename_from_url( $permission_file_url );
+        $permission_file_html = $permission_file_url && $permission_file_name
+            ? '<a href="' . esc_url( $permission_file_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $permission_file_name ) . '</a>'
+            : esc_html( $permission_file_name );
+
+        $permission_title = '#'
+            . absint( $product->get_id() )
+            . ' &mdash; '
+            . $permission_product_html
+            . ' &mdash; '
+            . sprintf(
+                // translators: 1) download count, 2) download file name
+                __( 'File %1$s: %2$s', 'dokan-lite' ),
+                esc_html( $file_count ),
+                $permission_file_html
             );
-            ?>
-        </a>
+        ?>
+
+        <span class="title"><?php echo wp_kses_post( $permission_title ); ?></span>
 
         <button
             rel="<?php echo esc_attr( absint( $download->product_id ) ) . ',' . esc_attr( $download->download_id ); ?>"
@@ -66,10 +84,11 @@ if ( ! defined( 'ABSPATH' ) ) {
                         <td>
                             <label><?php esc_html_e( 'Access Expires', 'dokan-lite' ); ?>:</label>
                             <?php
-                            $expire_date = $download->access_expires ? dokan_current_datetime()->modify( $download->access_expires )->format( 'Y-m-d' ) : '';
+                            // Rendered in the site's date format so it matches what the date picker writes back.
+                            $expire_date = $download->access_expires ? dokan_current_datetime()->modify( $download->access_expires )->format( wc_date_format() ) : '';
                             ?>
 
-                            <input type="text" style="width: 150px;" class="short datepicker" name="access_expires[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $expire_date ); ?>" maxlength="10" placeholder="<?php esc_attr_e( 'Never', 'dokan-lite' ); ?>" pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" />
+                            <input type="text" style="width: 150px;" class="short datepicker" name="access_expires[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $expire_date ); ?>" placeholder="<?php esc_attr_e( 'Never', 'dokan-lite' ); ?>" />
                         </td>
                     </tr>
                 </tbody>

--- a/tests/php/src/REST/OrderDetailsFragmentTest.php
+++ b/tests/php/src/REST/OrderDetailsFragmentTest.php
@@ -233,11 +233,16 @@ class OrderDetailsFragmentTest extends DokanTestCase {
     }
 
     /**
-     * A trashed order gets a clean error too.
+     * A trashed order still renders.
+     *
+     * The Vendor's order list includes trashed orders and the legacy details page opens
+     * them, and the panel is that same view — refusing them here would take away an order
+     * the Vendor can still reach by another route. Trash is not an ownership boundary;
+     * the ownership check above is what decides access.
      *
      * @return void
      */
-    public function test_trashed_order_returns_not_found(): void {
+    public function test_trashed_order_still_renders(): void {
         $order = wc_get_order( $this->order_id );
         $order->set_status( 'trash' );
         $order->save();
@@ -246,7 +251,28 @@ class OrderDetailsFragmentTest extends DokanTestCase {
 
         $response = $this->get_request( $this->fragment_route( $this->order_id ) );
 
-        $this->assertEquals( 404, $response->get_status() );
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertStringContainsString( 'dokan-order-details-wrap', $response->get_data()['html'] );
+    }
+
+    /**
+     * And a trashed order belonging to someone else is still refused.
+     *
+     * Pinned separately because the trash check used to reject these before the ownership
+     * check ever ran, so dropping it must not open a hole.
+     *
+     * @return void
+     */
+    public function test_trashed_order_of_another_vendor_is_still_forbidden(): void {
+        $order = wc_get_order( $this->order_id );
+        $order->set_status( 'trash' );
+        $order->save();
+
+        wp_set_current_user( $this->seller_id2 );
+
+        $response = $this->get_request( $this->fragment_route( $this->order_id ) );
+
+        $this->assertEquals( 403, $response->get_status() );
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Stacked on #3333. That PR got legacy order details rendering **inside** the Vendor panel; this one makes it look like it belongs there. Five commits, working through the view section by section — the card shell, the **downloadable permissions** card, the **items table and totals**, the **refund view**, and the **Shipments card** — plus the two page-wide standards that finishing them turned out to depend on.

Most of it is one new stylesheet, `src/dashboard/orders/order-details-fragment.scss` (2,246 lines), scoped to `.dokan-order-details-fragment` — a wrapper only the panel adds. The legacy page never carries that class and never loads this bundle, so nothing in the stylesheet can reach it.

Much of that file is specificity work, and **every `!important` and every over-qualified selector carries a comment naming the legacy rule it answers**. They are not decoration: several of those rules are ID-based, which no class selector can outrank, and Pro's `orders.less` is emitted *after* this bundle, so an equal-specificity rule here ties and loses on source order.

Seven files are not stylesheet, and each is there because styling alone could not fix what it found:

| File | Why |
| --- | --- |
| `templates/orders/order-download-permission-html.php` | The permission title was a dead Bootstrap-collapse anchor. It is now a product link plus a file link, both guarded — `is_post_publicly_viewable()`, because a pending product's `get_permalink()` returns a fallback that **404s on the legacy page too**. Expiry uses `wc_date_format()`; the ISO-only `pattern` attribute is dropped. |
| `includes/Assets.php` | Publishes `--dokan-currency-symbol`. The refund templates that need a currency affix are not ours to change, so the symbol is *drawn* rather than inserted. Needs `html_entity_decode` (WooCommerce returns it encoded) and `JSON_UNESCAPED_UNICODE` (`৳` is a JSON escape, not a CSS one — the first attempt printed those six characters literally). |
| `src/dashboard/orders/OrderDetails.tsx` | 32 in-page `#` anchors in the fragment — titles, Edit, Cancel, Delete note — were replacing the panel's route. A delegated handler scrolls to the target instead, leaving `#/` routes alone. Also a loading skeleton that mirrors the real two-column layout, so the page does not visibly reflow when the fragment lands. |
| `assets/src/less/orders.less`, `rtl.less` | **Legacy fix.** Billing and shipping are shrink-to-fit floats pinned to `min-width: 49%`, so a long address made its column wider than half the row and shipping silently dropped to a line of its own. Explicit widths make it a real pair. Both directions. |
| `includes/REST/OrderController.php`, `templates/orders/details.php`, `assets/src/js/orders.js` | Small follow-ons from the above. |

#### One button standard, one control standard

Both lived under `.dokan-order-right-content` and so only ever reached the **sidebar**. That is why the Shipments card's selects came out 35px with square corners while the notes fields beside them were 38px on a 6px radius, and why Create New Shipment and the delivery-time Update kept legacy's 3px radius while every button in the sidebar sat at 6px. Lifted to the fragment, with `.dokan-dashboard-wrap .dokan-btn.dokan-btn-theme`'s `!important` 3px outranked by naming the modifier.

The two Cancels take the panel Back button's treatment — white ground, brand border and label, tinting rather than filling on hover. That hover is **handed over rather than fought for**: the colour module paints `.dokan-btn:hover` from three custom properties, as `!important`, from a selector nothing reachable here can outrank. Redefining those properties on the button lets the module's own rule paint the secondary treatment.

#### Shipments

Never touched before: bare `h4`s inheriting the theme's heading scale, 2px `#ddd` rules where the rest of the view uses hairlines, and each shipment row dressed as a little card of its own — border, shadow and radius — inside a card that already has all three, reading as a doubled edge under the last shipment.

Three defects came out of the work rather than the design:

1. **The expand toggle was 0×0.** `p.shippments-tracking-status` carried `font-size: 0` to close the whitespace gap beside the status pill; the toggle is an empty icon span, so it collapsed to nothing. That one control opens the item list, the tracking form *and* the update timeline, so all three were unreachable — not missing markup, an unclickable chevron. Flex with a real gap instead, and the glyph is now drawn from a masked SVG rather than trusting `fa fa-chevron-down` to resolve against whichever Font Awesome the site loads. It turns over on open by reading `dashicons-arrow-up-alt2`, which Pro's handler flips in step with the panel and which never rendered.
2. **Legacy insets everything twice.** The header, item list and tracking form each take a further 20px inside a row that is already inset, so the shipment title sat 40px from the card edge while the card heading above it sat at 20. Pro's `orders.less` is emitted **after** this bundle, so a two-class rule here ties and loses on source order; naming the row as well outranks it.
3. **The create-shipment form.** Its rule stopped short of the card, its inset was pinned inline at 15px, its three tracking fields were floated at 33% + 2% so the last came out 35px short of the other two, and `#tracking_status_number` was pinned to 98% from an id selector.

#### Downloadable permissions

Measured against Figma node 679-13925. Most of the work there was finding out why rules that looked right did nothing: the grey bands behind the labels were **the theme zebra-striping tables** (four element-selectors deep, so unable to be outranked); Downloads Remaining carries Tailwind's `.form-input`, emitted `!important` in this build; focus was two different answers side by side (the theme's orange outline on plain inputs, a blue ring on `.form-input`); and **jQuery UI writes `z-index: 1` inline** on `#ui-datepicker-div`, so the calendar opened *underneath* select2's product search at 1050 and the search box painted through it.

#### Order items and totals

Left-aligned on the design's column widths, with a quiet uppercase header rather than a ruled band, 44px thumbnails and hairline separators.

Two of these are worth reading, because the obvious fix does not work:

* **Row separators are painted as a background, not a border.** Shipping, fee and refund rows render a trailing actions cell that line items do not, so under `border-collapse: collapse` — where the edge is resolved and painted **per cell** — a border declared on the row still stopped with its last cell: item rows ended at 1494 while the rest reached 1528, a 34px stub down the table. A `linear-gradient` background follows the row box, which spans the full width whatever the cell count. The empty column is dropped as well, behind a `:has` guard in case Pro ever puts real actions back.
* **`display: flex` on `td.total` removed it from the table column model** and collapsed the column from 411px to 219px. It is a normal cell again with an absolutely-positioned `::before`.

#### A trap worth naming

**Never set `display` on an element Pro opens with jQuery `.toggle()`.** It carries `.dokan-hide`, which any two-class selector beats — so the block renders while collapsed — and jQuery opens it by writing an inline `display`, which beats the rule straight back. The update timeline did exactly this before it was caught. Style those containers with everything *except* `display`.

### Related Pull Request(s)

* Base: getdokan/dokan#3333 — the fragment this restyles
* Pro companion: getdokan/dokan-pro#6087 — the markup fixes this styling assumes
* Sibling: getdokan/dokan#3347 — the first-party React view behind the same switch

### Closes

* Part of getdokan/plugin-internal-tasks#2144

### How to test the changes in this Pull Request:

1. Check out this branch **and** the Pro companion branch, then `npm run build` in Lite.
2. Open a vendor order in the panel: `/dashboard/new/#/orders/<id>`.
3. **Items and totals** — columns left-aligned, one hairline per row running the full card width with no 34px stub, money not clipped.
4. **Refund** — click Request Refund. Fields carry the order's currency as a placeholder, Submit and Cancel are right-aligned with Cancel first and secondary, and Cancel tints rather than fills on hover.
5. **Shipments, order with a shipment** — a chevron sits beside the status pill. Click it: items, tracking form and Shipment Updates Timeline all open, the chevron turns over, and the timeline's markers clear the text. Collapse it: everything closes, including the timeline.
6. **Shipments, order with none** — click Create New Shipment. Header labels sit over the right columns, ticking an item reveals its quantity, Cancel/Create Shipment are themed and right-aligned, and there is no blank line under them.
7. **Nothing moved on legacy** — `/dashboard/orders/?order_id=<id>&_view_mode=email` renders as before.

### Changelog entry

*Restyle the Vendor order details panel: items, totals, refund and shipments*

**Previously** the panel's order details view carried the legacy dashboard's appearance: money columns right-aligned against the design, row separators that stopped 34px short on line items, refund and shipment controls at a different height and corner radius from the sidebar's, and a Shipments card that could not be expanded at all because its chevron rendered at zero size.

**Now** the whole view sits on one set of tokens — 38px controls, 6px radius, hairline dividers, a uniform 20px inset from both card edges — with the items table, totals, refund flow and Shipments card matched to the design, and the Shipments card expandable.

### CI

The job named **"PHPCS inspection" runs PHPUnit**, and two `OrderStatusChangeTest` data sets fail in it. They are red on `develop` and on the base PR #3333 (`Tests: 279, Failures: 2`, both in that class) — nothing on this branch touches order status transitions.

One failure in that job *was* this branch's and is fixed here: `get_viewable_order()` stopped refusing trashed orders — the Vendor's list includes them and the legacy page opens them, so a 404 took away an order the Vendor can still reach by another route — but the test that came with the fragment still asserted the 404. Renamed to say what it now checks, with a second case pinning that another Vendor's trashed order is *still* 403, because the trash check used to reject those before the ownership check ever ran. Verified by direct dispatch against a real trashed order as well as in CI.

### Before Changes

<!-- Screenshots attached separately: the Shipments card collapsed with no chevron, and the unstyled create-shipment form. -->

### After Changes

<!-- Screenshots attached separately: the expanded shipment with items, tracking form and timeline, and the restyled create-shipment form. -->
