### PR TITLE
ci: a skipped isolation re-run must not clear a shard

### DIFF
--- a/.github/workflows/e2e_api_tests.yml
+++ b/.github/workflows/e2e_api_tests.yml
@@ -645,6 +645,26 @@ jobs:
                   NO_SETUP=true npx playwright test --project=e2e_tests --last-failed \
                       --reporter=list 2>&1 | tee /tmp/recheck.log
 
+                  # A SKIPPED test is not a passing test. Playwright exits 0 for a skip, so the exit
+                  # code alone cannot distinguish "passed alone" from "never ran" -- and this step's
+                  # outcome is what the gate below reads. Every test in this re-run was failing
+                  # moments ago; if one skips it is because a `test.skip(!x)` guard depends on state
+                  # an earlier test in its describe.serial block sets, and `--last-failed` runs it
+                  # alone. Running it alone verified nothing, so the shard must NOT be cleared.
+                  #
+                  # Measured: run 32359050741 shard 8. SE-NCS-10/11 failed 3/3, the re-run reported
+                  # "1 skipped", and the shard was reported GREEN with the summary claiming the test
+                  # "passed alone". A real defect shipped past the gate.
+                  # Matched loosely on purpose: playwright prints the tally as "1 skipped" on its
+                  # own line for a single test, but as "2 passed  1 skipped" when several re-run
+                  # together, so an anchored pattern misses the multi-test case. Erring toward NOT
+                  # clearing is the right bias here -- a false red costs one investigation, a false
+                  # green costs a shipped defect.
+                  if grep -qE '[0-9]+ skipped' /tmp/recheck.log; then
+                      echo "::error::The isolation re-run SKIPPED a previously-failing test instead of running it. A skip verifies nothing, so this shard is NOT cleared. The test almost certainly depends on state set by an earlier test in its describe.serial block, which --last-failed does not run."
+                      exit 1
+                  fi
+
             # Always say out loud which tests were rescued by the isolation re-run. A test that
             # fails with its shard-mates but passes alone is the signature of shard-state
             # pollution (an earlier spec leaving a global option/module/product dirty), NOT a
@@ -667,7 +687,9 @@ jobs:
                       echo
                       echo '```'
                       if [ -f /tmp/recheck.log ]; then
-                          grep -E '^[[:space:]]+(✓|✘|×)' /tmp/recheck.log | head -50
+                          # `-` is included so a SKIPPED re-run is visible here rather than
+                          # rendering an empty block that reads like nothing went wrong.
+                          grep -E '^[[:space:]]+(✓|✘|×|-)' /tmp/recheck.log | head -50
                       else
                           echo "(no re-run log — first pass failed without recorded test failures)"
                       fi


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

<!-- CI-config only: no PHP and no test code is touched, so PHPCS is a no-op here. -->

### Changes proposed in this Pull Request:

**The gate could report a shard GREEN while a test was failing.** This is a one-file change to
`e2e_api_tests.yml`; it fixes how the isolation re-run decides whether a shard is cleared.

When a shard fails, the workflow re-runs the failed tests **alone**. If they pass, the failure is
attributed to shard-state pollution and the shard is allowed through — a reasonable design. The
problem is how "pass" is determined:

```yaml
if: always() && steps.e2e-test.outcome == 'failure' && steps.e2e-recheck.outcome != 'success'
```

`steps.e2e-recheck.outcome` is `success` whenever Playwright exits `0`, and **Playwright exits `0`
for a SKIPPED test just as it does for a passing one.** So "never ran" and "passed alone" were
indistinguishable to the gate.

The re-run uses `--last-failed`, which runs the failed test on its own. A test inside a
`describe.serial` block that guards on state an earlier test sets:

```ts
test.skip(!orderId, 'depends on the order from SE-NCS-04/06');
```

…then **skips**, exits `0`, and clears the shard.

### It already happened

Run [32359050741](https://github.com/getdokan/dokan/actions/runs/32359050741), shard 8.
`SE-NCS-10/11` failed **all three attempts**:

```
✘ 133  SE-NCS-10/11 ... (7ms)
✘ 139  SE-NCS-10/11 ... (retry #1) (8ms)
✘ 145  SE-NCS-10/11 ... (retry #2) (10ms)
```

The isolation re-run then reported:

```
Running 1 test using 1 worker
  1 skipped
```

and the run summary printed:

> ⚠️ **These tests failed alongside their shard-mates but passed alone.**

That statement is contradicted by its own log. **Shard: green. Run: green.** A real defect — a
timezone bug in the maturation assertion, since fixed — shipped past the gate. It was noticed only
because the merge-reports summary happened to surface a failure count.

### A second, compounding flaw

The step that prints the re-run evidence grepped:

```
grep -E '^[[:space:]]+(✓|✘|×)' /tmp/recheck.log
```

A skipped test prints `-`, which that pattern does not match — so the evidence block rendered
**empty**, and nothing on the run page hinted the re-run had done no work. `-` is now included.

### Related Pull Request(s)

* #3384 — where the masked failure was found (merged)

### Closes

* No issue filed; found during #3384 and fixed directly as test-infrastructure work.

### How to test the changes in this Pull Request:

The guard is a `grep` over the re-run's own log, so it can be exercised without a CI run:

```bash
printf 'Running 1 test using 1 worker\n  1 passed (3.0s)\n'          > /tmp/pass.log
printf 'Running 1 test using 1 worker\n  1 skipped\n'                > /tmp/skip.log
printf 'Running 3 tests using 1 worker\n  2 passed  1 skipped\n'     > /tmp/mixed.log

for f in pass skip mixed; do
  if grep -qE '[0-9]+ skipped' /tmp/$f.log; then echo "$f -> NOT cleared"; else echo "$f -> cleared"; fi
done
```

Expected:

```
pass  -> cleared
skip  -> NOT cleared
mixed -> NOT cleared
```

For an end-to-end check, make any `describe.serial` test fail while a later test in the same block
guards on its state. Before this change the shard goes green with `1 skipped` in the re-run; after
it, the shard is red with an `::error::` explaining why.

### Changelog entry

**Not applicable — CI configuration only.**

No plugin source and no test code is touched, so there is no user-facing behaviour change.

### Before Changes

`SE-NCS-10/11` failing 3/3, re-run reporting `1 skipped`, shard and run both reported **green**,
and the summary claiming the test "passed alone". The evidence block on the run page was empty
because the grep could not match a skip.

### After Changes

The re-run inspects its own log and fails when anything was skipped:

```
::error::The isolation re-run SKIPPED a previously-failing test instead of running it.
A skip verifies nothing, so this shard is NOT cleared.
```

Verified against the recorded log line plus three synthetic tallies (`pass` → cleared,
`skip` → not cleared, `2 passed  1 skipped` → not cleared).

A note on the matching: `[0-9]+ skipped` is deliberately loose, because Playwright prints the tally
on its own line for a single test but as `2 passed  1 skipped` when several re-run together — an
anchored pattern missed the multi-test case. It could in principle fire on a test *title* containing
"skipped"; that trade is intentional, since a false red costs one investigation while a false green
costs a shipped defect.
