### PR TITLE
fix(e2e): repair the vendor-verification spec after dokan-pro #5861

### DIFF
--- a/tests/pw/tests/e2e/settings/settingsPage.ts
+++ b/tests/pw/tests/e2e/settings/settingsPage.ts
@@ -329,8 +329,8 @@ const settingsSelectors = {
         verifiedIconByIcon: (iconName: string) => `//i[@class='${iconName}']//../..`,
         verificationMethodRow: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..`,
         enableVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//label[@class="switch tips"]`,
-        editVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//button[contains(@class, 'rounded-full bg-violet')]`,
-        deleteVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//button[contains(@class, 'rounded-full bg-red')]`,
+        editVerificationMethod: (methodName: string) => `button[aria-label="Edit ${methodName} verification method"]`,
+        deleteVerificationMethod: (methodName: string) => `button[aria-label="Delete ${methodName} verification method"]`,
 
         confirmDelete: '.swal2-confirm',
         cancelDelete: '.swal2-cancel',
@@ -612,23 +612,17 @@ const settingsSelectors = {
         addField: (blockName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//span[normalize-space(text())='Add Field']/..`,
 
         fieldSection: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../..`,
-        enableField: (blockName: string, fieldName: string) =>
-            `(//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../..//span[normalize-space(text())='Enabled']/..//label[@class="switch tips"])[last()]`, //todo: resolve the issue
+        enableField: (blockName: string, fieldName: string) => `(//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../..//span[normalize-space(text())='Enabled']/..//label[@class="switch tips"])[last()]`, //todo: resolve the issue
         requireField: (blockName: string, fieldName: string) =>
             `(//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../..//span[normalize-space(text())='Required']/..//label[@class="switch tips"])[last()]`,
         editField: (blockName: string, fieldName: string) => `(//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../..//button[contains(@class,'field-edit-button')])[last()]`,
 
         fieldContents: {
-            label: (blockName: string, fieldName: string) =>
-                `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id="field-input-label"]`,
-            type: (blockName: string, fieldName: string) =>
-                `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//select[@id="field-input-type"]`,
-            placeholder: (blockName: string, fieldName: string) =>
-                `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id='input-placeholder']`,
-            helpContent: (blockName: string, fieldName: string) =>
-                `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id='input-help-content']`,
-            cancel: (blockName: string, fieldName: string) =>
-                `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//button[@id="input-Cancel"]`,
+            label: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id="field-input-label"]`,
+            type: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//select[@id="field-input-type"]`,
+            placeholder: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id='input-placeholder']`,
+            helpContent: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//input[@id='input-help-content']`,
+            cancel: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//button[@id="input-Cancel"]`,
             done: (blockName: string, fieldName: string) => `//h3[contains(@class,'block-header-title') and normalize-space(text())="${blockName}"]/../../../../..//h3[normalize-space(text())='${fieldName}']/../../..//div[@class="field-form-control-wrapper"]//button[@id="input-submit"]`,
         },
 
@@ -756,10 +750,7 @@ export class SettingsPage {
         const span = this.switcherSpan(selector);
         const value = await this.getBackgroundColor(span);
         if (!value.includes('rgb(0, 144, 255)')) {
-            const [response] = await Promise.all([
-                this.page.waitForResponse(resp => resp.url().includes(subUrl) && resp.status() === code),
-                this.page.locator(span).click(),
-            ]);
+            const [response] = await Promise.all([this.page.waitForResponse(resp => resp.url().includes(subUrl) && resp.status() === code), this.page.locator(span).click()]);
             return response;
         }
         return '';
@@ -780,14 +771,7 @@ export class SettingsPage {
         await this.page.waitForLoadState('networkidle');
         await expect(async () => {
             const [response] = await Promise.all([
-                this.page.waitForResponse(
-                    resp =>
-                        resp.url().includes(data.subUrls.ajax) &&
-                        resp.request().method() === 'POST' &&
-                        (resp.request().postData() ?? '').includes('action=dokan_save_settings') &&
-                        resp.status() === 200,
-                    { timeout: 15000 },
-                ),
+                this.page.waitForResponse(resp => resp.url().includes(data.subUrls.ajax) && resp.request().method() === 'POST' && (resp.request().postData() ?? '').includes('action=dokan_save_settings') && resp.status() === 200, { timeout: 15000 }),
                 this.page.locator(settingsSelectors.saveChanges).click(),
             ]);
             expect(response.status()).toBe(200);
@@ -806,10 +790,7 @@ export class SettingsPage {
     }
 
     private async typeAndWaitForResponse(subUrl: string, selector: string, text: string, code = 200): Promise<void> {
-        await Promise.all([
-            this.page.waitForResponse(resp => resp.url().includes(subUrl) && resp.status() === code),
-            this.page.locator(selector).fill(text),
-        ]);
+        await Promise.all([this.page.waitForResponse(resp => resp.url().includes(subUrl) && resp.status() === code), this.page.locator(selector).fill(text)]);
     }
 
     // assert every leaf selector in a (possibly nested) selector object is visible;
@@ -844,7 +825,13 @@ export class SettingsPage {
     private async isVisible(selector: string, timeoutSec = 2): Promise<boolean> {
         const start = Date.now();
         while (Date.now() - start < timeoutSec * 1000) {
-            if (await this.page.locator(selector).isVisible().catch(() => false)) return true;
+            if (
+                await this.page
+                    .locator(selector)
+                    .isVisible()
+                    .catch(() => false)
+            )
+                return true;
             await this.page.waitForTimeout(100);
         }
         return false;

--- a/tests/pw/tests/e2e/vendor-verifications/vendorVerificationsPage.ts
+++ b/tests/pw/tests/e2e/vendor-verifications/vendorVerificationsPage.ts
@@ -33,8 +33,8 @@ const selectors = {
             verifiedIconByIcon: (iconName: string) => `//i[@class='${iconName}']//../..`,
             verificationMethodRow: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..`,
             enableVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//label[@class="switch tips"]`,
-            editVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//button[contains(@class, 'rounded-full bg-violet')]`,
-            deleteVerificationMethod: (methodName: string) => `//p[text()[normalize-space()='${methodName}']]/../../..//button[contains(@class, 'rounded-full bg-red')]`,
+            editVerificationMethod: (methodName: string) => `button[aria-label="Edit ${methodName} verification method"]`,
+            deleteVerificationMethod: (methodName: string) => `button[aria-label="Delete ${methodName} verification method"]`,
             confirmDelete: '.swal2-confirm',
             methodCreateSuccessMessage: '//div[text()="Created Successfully."]',
             methodUpdateSuccessMessage: '//div[text()="Updated Successfully."]',
@@ -284,7 +284,10 @@ export class VendorVerificationsPage {
     }
 
     private async getBackgroundColor(selector: string): Promise<string> {
-        return await this.page.locator(selector).first().evaluate(el => window.getComputedStyle(el).getPropertyValue('background-color'));
+        return await this.page
+            .locator(selector)
+            .first()
+            .evaluate(el => window.getComputedStyle(el).getPropertyValue('background-color'));
     }
 
     private async forceLinkToSameTab(selector: string): Promise<void> {
@@ -423,11 +426,16 @@ export class VendorVerificationsPage {
         await this.page.reload();
         await this.page.locator(settingsAdmin.menus.vendorVerification).click();
 
-        // The edit button is CSS hover-revealed (visibility:hidden until the row
-        // is hovered via `group-hover/item:visible`), which Playwright cannot
-        // reliably surface in headless; dispatch the click to fire the Vue handler.
-        await this.page.locator(settingsAdmin.vendorVerification.verificationMethodRow(methodName)).hover();
-        await this.page.locator(settingsAdmin.vendorVerification.editVerificationMethod(methodName)).dispatchEvent('click');
+        /*
+         * The action buttons are no longer hover-revealed. dokan-pro #5861
+         * ("make method actions discoverable") replaced the hover-only icons with
+         * permanently visible buttons carrying an aria-label, and dropped the
+         * `rounded-full bg-violet` classes the old selector matched. That selector
+         * therefore never resolved and every attempt died on a 30s dispatchEvent
+         * timeout. Target the aria-label, which is semantic and survives restyling,
+         * and click normally now that the button is actually visible.
+         */
+        await this.page.locator(settingsAdmin.vendorVerification.editVerificationMethod(methodName)).click();
         await this.updateVerificationMethod(verificationMethod);
         await this.clickAndWaitForResponse(data.subUrls.api.dokan.verificationMethods, settingsAdmin.vendorVerification.addNewVerification.update);
         await expect(this.page.locator(settingsAdmin.vendorVerification.methodUpdateSuccessMessage)).toBeVisible();
@@ -443,10 +451,11 @@ export class VendorVerificationsPage {
         await this.page.reload();
         await this.page.locator(settingsAdmin.menus.vendorVerification).click();
 
-        // The delete button is CSS hover-revealed (visibility:hidden until the row
-        // is hovered); dispatch the click to fire the Vue handler in headless.
-        await this.page.locator(settingsAdmin.vendorVerification.verificationMethodRow(methodName)).hover();
-        await this.page.locator(settingsAdmin.vendorVerification.deleteVerificationMethod(methodName)).dispatchEvent('click');
+        // Same change as the edit path: dokan-pro #5861 made these buttons
+        // permanently visible and aria-labelled, so no hover dance is needed.
+        // Note the built-in Address method renders no delete button at all
+        // (`v-if="'address' !== doc.kind"`), matching the API's 403 guard.
+        await this.page.locator(settingsAdmin.vendorVerification.deleteVerificationMethod(methodName)).click();
         await this.clickAndWaitForResponse(data.subUrls.api.dokan.verificationMethods, settingsAdmin.vendorVerification.confirmDelete, 204);
         await expect(this.page.locator(settingsAdmin.vendorVerification.methodDeleteSuccessMessage)).toBeVisible();
 

--- a/tests/pw/utils/apiUtils.ts
+++ b/tests/pw/utils/apiUtils.ts
@@ -51,11 +51,13 @@ export class ApiUtils {
             // wire one. Callers that pass a real context are unaffected.
             let ctx: APIRequestContext | null = null;
             this.request = new Proxy({} as APIRequestContext, {
-                get: (_t, prop) => async (...args: unknown[]) => {
-                    if (!ctx) ctx = await pwRequest.newContext();
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return (ctx as any)[prop](...args);
-                },
+                get:
+                    (_t, prop) =>
+                    async (...args: unknown[]) => {
+                        if (!ctx) ctx = await pwRequest.newContext();
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        return (ctx as any)[prop](...args);
+                    },
             });
         }
     }
@@ -311,12 +313,12 @@ export class ApiUtils {
 
             // get store id if already exists
             sellerId = await this.getSellerId(payload.store_name, auth);
-            
+
             // If not found by store name, try to find by username (for cases where user exists but store might not)
             if (!sellerId && payload.user_login) {
                 sellerId = await this.getSellerIdByUsername(payload.user_login, auth);
             }
-            
+
             storeName = payload.store_name;
 
             // update store if already exists and sellerId is found
@@ -1597,7 +1599,24 @@ export class ApiUtils {
             console.log('No verification method exists');
             return;
         }
-        const allMethodIds = allVerificationMethods.map((o: { id: unknown }) => o.id);
+        /*
+         * Skip the built-in Address method.
+         *
+         * dokan-pro #5861 made it undeletable: VerificationMethodsApi::delete_item() returns
+         * `dokan_pro_rest_cannot_delete` (403) for `kind === 'address'`, because the seller-address
+         * auto-fill flows query by that kind and install seeding never recreates it. Deleting every
+         * method blindly therefore fails the request, and `delete()` asserts `response.ok()`, so the
+         * whole cleanup throws and takes the calling test with it.
+         *
+         * Filtering here rather than tolerating the 403 in `delete()`, so a genuine delete failure
+         * on a custom method is still loud.
+         */
+        const deletableMethods = allVerificationMethods.filter((o: { kind?: string }) => o.kind !== 'address');
+        if (!deletableMethods.length) {
+            console.log('Only built-in verification methods exist, nothing to delete');
+            return;
+        }
+        const allMethodIds = deletableMethods.map((o: { id: unknown }) => o.id);
         for (const methodId of allMethodIds) {
             await this.delete(endPoints.deleteVerificationMethod(methodId), { headers: auth });
         }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

`deleteAllVerificationMethods()` deletes **every** verification method, including the built-in Address one. dokan-pro #5861 made that method undeletable: `VerificationMethodsApi::delete_item()` now returns `dokan_pro_rest_cannot_delete` (403) for `kind === 'address'`, because the seller-address auto-fill flows query by that kind and install seeding never recreates it.

`ApiUtils.delete()` asserts `response.ok()`, so the 403 throws. That call sits in `beforeAll`, which means the whole `vendorVerifications` spec dies before its first test runs.

This filters the built-in method out by `kind` rather than tolerating a 403 inside `delete()`, so a genuine delete failure on a custom method is still loud.

### Related Pull Request(s)

* Caused by dokan-pro **#5861** (`fix(vendor-verification): make method actions discoverable and fix silent edit/delete failures`)
* Also included in **#3387** (Stripe Connect Tier 1 suite). Cherry-picked here so the nightly can be fixed without waiting on that PR, which is itself blocked on dokan-pro #5646. Whichever merges first, the other rebases cleanly: it is the same commit touching one file.

### Closes

* Closes #

### How to test the changes in this Pull Request:

```bash
cd wp-content/plugins/dokan-lite/tests/pw
NO_SETUP=true npx playwright test tests/e2e/vendor-verifications/vendorVerifications.spec.ts \
  --project=e2e_tests --workers=1 --retries=0 --reporter=line
```

Measured on `develop` (`f0158eec5`) with dokan-pro `feat/stripe-connect-revemp`:

| | result |
|---|---|
| develop, before either fix | **1 failed, 4 passed** in 17.8s — `beforeAll` throws, run aborts after 5 of 36 |
| after commit 1 only | **34 passed, 2 failed** — spec runs, but the stale selectors time out |
| after both commits | **36 passed, 0 failed** |

Verified on two stacks:

| stack | result |
|---|---|
| WordPress 7.0.3 + WooCommerce 11.0.1 (pinned) | 36 passed |
| WordPress **7.1** + WooCommerce **11.0.1** (latest) | 36 passed, 3 skipped |

One trap worth recording for anyone repeating this: updating wp-env core invalidates the admin session, and the spec then fails with a spread of click timeouts that look like a compatibility break. Re-running `--project=auth_setup` clears it. The admin storage state stays small (~1.4 KB) because it is session-scoped by design, so file size is not a usable health signal — check for the `wordpress_logged_in_*` cookie instead.

### Changelog entry

*Fix the vendor-verification e2e spec aborting on the built-in Address method*

The e2e helper that clears verification methods tried to delete the built-in Address method, which the REST API refuses with a 403. The refusal happened inside `beforeAll`, so the entire vendor-verification spec aborted before running. The helper now skips built-in methods and deletes only custom ones.

### Second fix: the stale action-button selectors

The first commit alone was **not enough**. It stopped the spec aborting, but two tests then failed on a 30s `dispatchEvent` timeout:

```
waiting for locator('//p[...]/../../..//button[contains(@class, 'rounded-full bg-violet')]')
```

Same root cause, different symptom. dokan-pro #5861 also rewrote the method row: the edit and delete icons are no longer hover-revealed, they lost the `rounded-full bg-violet` / `rounded-full bg-red` classes, and they gained an `aria-label`. The selector matched on those classes, so it never resolved.

The second commit targets the `aria-label` the component actually exposes, which is semantic and survives restyling, and drops the hover step and the `dispatchEvent` workaround since the buttons are permanently visible now. Both copies of the selector are updated (they were duplicated in `settings/settingsPage.ts`) so they cannot drift apart.

**Result: `vendorVerifications.spec.ts` now passes 36/36.**

### CI evidence

`getdokan/dokan` run **32685419684** (E2E_API Tests #4873, scheduled, `develop`), shard 5:

```
End-point:  http://localhost:9999/wp-json/dokan/v1/verification-methods/4
Status Code:  403
{"code":"dokan_pro_rest_cannot_delete","message":"The Address verification method is built in and cannot be deleted."}
  at ApiUtils.deleteAllVerificationMethods (tests/pw/utils/apiUtils.ts:1602:13)
  at tests/e2e/vendor-verifications/vendorVerifications.spec.ts:39:9
```

Run **32718538127** on this branch confirmed commit 1 removed the 403 and the abort, and that the two selector failures remained. Commit 2 addresses those.

That nightly keeps failing shard 5 until this lands. Shard 8 is unrelated: it fails on a dokan-lite product bug tracked at getdokan/dokan-pro#6099, which no test change can fix.

### PR Self Review Checklist:

* Filtering on `kind` matches the API contract: `kind` is exposed in the REST schema with `enum [ address, custom ]`, so this is not a heuristic.
* The early return when only built-in methods remain avoids a pointless empty loop and logs why.
