### PR TITLE
fix(components): read the plugin-ui external lazily in the DataViews wrapper

### DIFF
--- a/src/components/dataviews/DokanDataViews.tsx
+++ b/src/components/dataviews/DokanDataViews.tsx
@@ -2,14 +2,14 @@ import { DataViews as PluginUIDataViews } from '@wedevs/plugin-ui';
 import type { DataViewsProps } from '@wedevs/plugin-ui';
 import { __ } from '@wordpress/i18n';
 
-// plugin-ui's generic defers a conditional on Item that TS cannot forward; runtime props are unchanged.
-const ForwardedDataViews = PluginUIDataViews as (
-    props: any // eslint-disable-line @typescript-eslint/no-explicit-any
-) => JSX.Element;
-
 // plugin-ui labels its chrome with core's `default` domain, which Dokan's language files can never reach.
 function DokanDataViews< Item >( props: DataViewsProps< Item > ) {
     const { actions, filter, emptyTitle } = props;
+
+    // plugin-ui's generic defers a conditional on Item that TS cannot forward; runtime props are unchanged.
+    const ForwardedDataViews = PluginUIDataViews as (
+        p: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ) => JSX.Element;
 
     // Only a destructive action reaches the confirm dialog, so leave every other action object untouched.
     const localizedActions = actions?.map( ( action ) =>
@@ -45,11 +45,20 @@ function DokanDataViews< Item >( props: DataViewsProps< Item > ) {
     );
 }
 
-// Callers render these directly, so they must survive the wrap.
-export default Object.assign( DokanDataViews, {
-    Pagination: PluginUIDataViews.Pagination,
-    Layout: PluginUIDataViews.Layout,
-    Search: PluginUIDataViews.Search,
-    Filters: PluginUIDataViews.Filters,
-    BulkActionToolbar: PluginUIDataViews.BulkActionToolbar,
-} );
+/*
+ * Callers render these directly, so they must survive the wrap — but only through lazy getters.
+ * `@wedevs/plugin-ui` is externalised to the `window.dokan.pluginUI` global, which not every
+ * page this module ships to defines, so reading it while the module initialises crashes the
+ * whole bundle (getdokan/dokan-pro#6099). The getters defer each read to first use, by which
+ * point rendering a DataViews guarantees plugin-ui is loaded.
+ */
+export default Object.defineProperties( DokanDataViews, {
+    Pagination: { enumerable: true, get: () => PluginUIDataViews.Pagination },
+    Layout: { enumerable: true, get: () => PluginUIDataViews.Layout },
+    Search: { enumerable: true, get: () => PluginUIDataViews.Search },
+    Filters: { enumerable: true, get: () => PluginUIDataViews.Filters },
+    BulkActionToolbar: {
+        enumerable: true,
+        get: () => PluginUIDataViews.BulkActionToolbar,
+    },
+} ) as typeof PluginUIDataViews;


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

#3382 wrapped plugin-ui's `DataViews` in `DokanDataViews.tsx` and, in doing so, evaluated `@wedevs/plugin-ui` **at module scope** twice: a top-level `const ForwardedDataViews = PluginUIDataViews as …` alias, and an eager `Object.assign( DokanDataViews, { Pagination: PluginUIDataViews.Pagination, … } )`. `@wedevs/plugin-ui` is a webpack external that compiles to the `window.dokan.pluginUI` global (`webpack-dependency-mapping.js`, `SHARED_UI_EXTERNALS`), so those two statements compile to *reads of that global while the bundle is still initialising*. On any page where the global is not there at that moment, the module throws `TypeError: Cannot read properties of undefined (reading 'DataViews')` uncaught, and the **entire bundle containing it dies** — three of them: `product-editor-utils.js`, `frontend.js` and `dokan-admin-dashboard.js`, exactly the three in getdokan/dokan-pro#6099.

**Why the global is missing even though `plugin-ui.js` is enqueued first** — reproduced locally on builds whose `?ver=` hashes are byte-identical to the issue report. The dependency graph does order `plugin-ui.js` correctly; what kills it is print order *within* the page:

1. `plugin-ui.js` runs and sets `window.dokan.pluginUI` ✓ — then `components.js` initialises fine (which is why it is *not* among the throwing bundles)
2. `wp_localize_script( 'dokan-vue-vendor', 'dokan', … )` (`includes/Assets.php:103`) prints `var dokan = {…}`, which **replaces `window.dokan` wholesale**, wiping `pluginUI`, `dokanUI`, `components`, `utilities`
3. `product-editor-utils.js`, `frontend.js` and `dokan-admin-dashboard.js` initialise after that block, and #3382's eager reads hit `undefined.DataViews` → three uncaught TypeErrors

The clobber itself is long-standing, systemic (three active `wp_localize_script( …, 'dokan', … )` sites) and harmless to every other module, because the shared-bundle contract has always been *everything lazy*: webpack's harmony re-exports and in-render reads never touch the globals during module init. The wrapper was the sole violation of that contract in both Lite and Pro (verified with an AST scan of every importer of `@wedevs/plugin-ui`, `@getdokan/dokan-ui` and the `@dokan/*` externals family — zero other module-scope reads). So the right-altitude fix is to restore the contract in the wrapper, not to touch the localize (renaming/merging the decade-old public `dokan` object is a separate hardening with its own blast radius; and it would not subsume this fix anyway, since third-party enqueue order can still produce pages where the global is legitimately absent).

**The fix:**

* The type-cast alias moves inside the component, so the external is first read at render time — when plugin-ui is necessarily loaded.
* The five sub-components (`Pagination`, `Layout`, `Search`, `Filters`, `BulkActionToolbar`) are forwarded through **lazy `Object.defineProperties` getters** instead of eager `Object.assign` values. They stay enumerable, keep returning the same (stable) component references, and remain reachable for runtime consumers via `window.dokan.components.DataViews.*`. `Object.assign` with getter objects or spreads is *not* equivalent — both evaluate getters at module scope, which is the bug.
* The export is typed `as typeof PluginUIDataViews`, i.e. exactly the type the barrel exposed before #3382, reusing plugin-ui's own function-plus-namespace declaration for the statics.
* The in-file comment records why the reads must stay lazy, with the issue reference, so the "obvious cleanup" back to `Object.assign` is not made blindly.

This PR is deliberately a one-file change. The wider invariant — *never evaluate a binding imported from `@wedevs/plugin-ui`, `@getdokan/dokan-ui` or any `@dokan/*` external at module scope* — is worth writing down in the shared-bundle headers and the frontend docs, but that is documentation churn rather than part of this regression fix and can follow separately.

Everything #3382 shipped is preserved: the `dokan-lite`-domain labels (`No data found`, `Add Filter` / `Remove filter`, the destructive-confirm message), caller overrides, and Pro's no-rebuild consumption through `window.dokan.components`.

### Related Pull Request(s)

* #3382 — the PR that introduced the eager reads

### Closes

* Closes getdokan/dokan-pro#6099

### How to test the changes in this Pull Request:

1. Build from this branch: `npm ci && npm run build` (a cold build matters — a warm `node_modules/.cache/webpack` from an older tree can silently produce a non-externalised bundle that hides the bug).
2. Log in to wp-admin, open **Dokan → Settings**, and open the browser console.
3. **Before (develop):** three uncaught `TypeError: Cannot read properties of undefined (reading 'DataViews')` — one each from `product-editor-utils.js`, `frontend.js`, `dokan-admin-dashboard.js`. **After (this branch):** none.
4. Confirm the Dokan admin Dashboard (`admin.php?page=dokan`) still renders its React UI.
5. Confirm no regression of #3382 on a vendor-dashboard list, e.g. `/dashboard/new/#/withdraw-requests` with an empty tab: the list renders, the empty state still shows the (translatable) `No data found`, and the sub-components still resolve — quick console probe on that page:

```js
typeof dokan.components.DataViews             // "function"
typeof dokan.components.DataViews.Pagination  // "function" (getter, resolved lazily)
Object.keys( dokan.components.DataViews )     // ["Pagination","Layout","Search","Filters","BulkActionToolbar"]
```

### Changelog entry

*Fix – Uncaught JavaScript errors while Dokan's bundles load*

A recent change made the vendor-dashboard DataViews wrapper read the shared plugin-ui bundle's global while JavaScript bundles were still initialising. On pages where that global was not available at that instant, three bundles (`product-editor-utils.js`, `frontend.js`, `dokan-admin-dashboard.js`) each crashed on load with an uncaught `TypeError: Cannot read properties of undefined (reading 'DataViews')` — in wp-admin and on the storefront — silently breaking any feature living in those bundles on the affected pages. The wrapper now defers every read until the component or its sub-components are actually used, so the bundles initialise cleanly everywhere, while the translatable list labels the wrapper exists for keep working exactly as before.

### Before Changes

On `develop` (byte-identical `?ver=` hashes to the issue: `541eb079…`, `45ebaadb…`, `bf4b63cb…`), wp-admin **Dokan → Settings**, `window.dokan.pluginUI` undefined at bundle-init time — executing each bundle against the live page state:

| Bundle | Result |
|---|---|
| `product-editor-utils.js` | `TypeError: Cannot read properties of undefined (reading 'DataViews')` |
| `frontend.js` | `TypeError: Cannot read properties of undefined (reading 'DataViews')` |
| `dokan-admin-dashboard.js` | `TypeError: Cannot read properties of undefined (reading 'DataViews')` |
| `components.js` | no throw (initialises before the `var dokan = {…}` overwrite) |

### After Changes

Same page, same missing global, fixed build — verified live:

| Check | Result |
|---|---|
| `product-editor-utils.js` / `frontend.js` / `dokan-admin-dashboard.js` init with `window.dokan.pluginUI` undefined | no throw ✅ |
| Compiled output audit | every `.DataViews` access sits inside the component body or a getter closure; module scope only holds the harmless external require ✅ |
| Dokan admin Dashboard (`admin.php?page=dokan`) | React UI renders ✅ |
| Vendor dashboard `/dashboard/new/#/withdraw-requests`, Pending (0) | list renders, empty state shows `No data found` from the `dokan-lite` domain ✅ |
| `DataViews.Pagination/Layout/Search/Filters/BulkActionToolbar` | all resolve through the getters and stay enumerable ✅ |
| `npx tsc` | project baseline unchanged (no errors in the touched files); ESLint clean ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
