### PR TITLE
fix(product-editor): stop the vendor's first gallery image becoming the featured image

### DIFF
--- a/includes/ProductEditor/PayloadResolver.php
+++ b/includes/ProductEditor/PayloadResolver.php
@@ -183,6 +183,9 @@ class PayloadResolver {
      * schema sets no `additionalProperties`. ProductControllerV3::apply_image_positions() is the
      * only consumer.
      *
+     * The two fields compile into one WooCommerce array, so a request carrying either of them
+     * describes the product's whole image state — sending only one clears the other side.
+     *
      * @since 5.0.0
      *
      * @param array $data Request body keyed by schema field id.

--- a/includes/ProductEditor/PayloadResolver.php
+++ b/includes/ProductEditor/PayloadResolver.php
@@ -176,32 +176,57 @@ class PayloadResolver {
     /**
      * Transform featured image and gallery image IDs into the WC REST images array.
      *
+     * Every entry carries a `position` — 0 for the featured image, 1..n for the gallery — because
+     * the flat array on its own cannot express a product that has gallery images but no featured
+     * image. This mirrors the convention ProductController (v1) already splits on; WooCommerce's
+     * own v3 images schema has no `position`, and ignores the key while preserving it, since that
+     * schema sets no `additionalProperties`. ProductControllerV3::apply_image_positions() is the
+     * only consumer.
+     *
      * @since 5.0.0
+     *
+     * @param array $data Request body keyed by schema field id.
+     *
+     * @return array
      */
     public function resolve_images( array $data ): array {
-        $images = [];
+        $has_featured = array_key_exists( Elements::FEATURED_IMAGE_ID, $data );
+        $has_gallery  = isset( $data[ Elements::GALLERY_IMAGE_IDS ] ) && is_array( $data[ Elements::GALLERY_IMAGE_IDS ] );
 
-        if ( ! empty( $data[ Elements::FEATURED_IMAGE_ID ] ) ) {
-            $id = $this->extract_image_id( $data[ Elements::FEATURED_IMAGE_ID ] );
-            if ( $id > 0 ) {
-                $images[] = [ 'id' => $id ];
-            }
-            unset( $data[ Elements::FEATURED_IMAGE_ID ] );
+        if ( ! $has_featured && ! $has_gallery ) {
+            return $data;
         }
 
-        if ( isset( $data[ Elements::GALLERY_IMAGE_IDS ] ) && is_array( $data[ Elements::GALLERY_IMAGE_IDS ] ) ) {
+        $images = [];
+
+        if ( $has_featured ) {
+            $id = $this->extract_image_id( $data[ Elements::FEATURED_IMAGE_ID ] );
+            unset( $data[ Elements::FEATURED_IMAGE_ID ] );
+
+            if ( $id > 0 ) {
+                $images[] = [
+                    'id'       => $id,
+                    'position' => 0,
+                ];
+            }
+        }
+
+        if ( $has_gallery ) {
+            $position = 1;
             foreach ( $data[ Elements::GALLERY_IMAGE_IDS ] as $img ) {
                 $id = $this->extract_image_id( $img );
                 if ( $id > 0 ) {
-                    $images[] = [ 'id' => $id ];
+                    $images[] = [
+                        'id'       => $id,
+                        'position' => $position++,
+                    ];
                 }
             }
             unset( $data[ Elements::GALLERY_IMAGE_IDS ] );
         }
 
-        if ( ! empty( $images ) ) {
-            $data['images'] = $images;
-        }
+        // An empty array is meaningful — it is how a vendor who removed every image clears them.
+        $data['images'] = $images;
 
         return $data;
     }

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -350,6 +350,8 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
             return $invalid;
         }
 
+        $product = $this->apply_image_positions( $product, $request );
+
         /**
          * Filters a vendor product prepared for the database, before it is saved.
          *
@@ -364,6 +366,56 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
          * @param bool            $creating Whether a new product is being created.
          */
         return apply_filters( "dokan_rest_pre_insert_{$this->post_type}_object", $product, $request, $creating );
+    }
+
+    /**
+     * Restore the vendor's featured/gallery split after WooCommerce has consumed `images`.
+     *
+     * WooCommerce takes the featured image from array index 0, and its v3 images schema has no
+     * `position` at all, so a product saved with gallery images but no featured image loses its
+     * first gallery image to the featured slot — with a single gallery image the gallery ends up
+     * empty. PayloadResolver::resolve_images() tags every entry with the position the vendor
+     * actually chose, so the split is reapplied here.
+     *
+     * Payloads this plugin did not resolve carry no positions and are left to WooCommerce.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param WC_Data|WC_Product $product Product assembled from the request, not yet saved.
+     * @param WP_REST_Request    $request Full details about the request.
+     *
+     * @return WC_Data|WC_Product
+     */
+    protected function apply_image_positions( $product, $request ) {
+        $images = $request['images'];
+
+        // An empty array already cleared both sides in WooCommerce's own setter, so there is nothing to restore.
+        if ( ! $product instanceof WC_Product || ! is_array( $images ) || empty( $images ) ) {
+            return $product;
+        }
+
+        $featured = 0;
+        $gallery  = [];
+
+        foreach ( $images as $image ) {
+            if ( ! is_array( $image ) || ! isset( $image['id'], $image['position'] ) ) {
+                return $product;
+            }
+
+            $id = absint( $image['id'] );
+
+            if ( 0 === absint( $image['position'] ) ) {
+                $featured = $id;
+                continue;
+            }
+
+            $gallery[] = $id;
+        }
+
+        $product->set_image_id( $featured > 0 ? $featured : '' );
+        $product->set_gallery_image_ids( $gallery );
+
+        return $product;
     }
 
     /**

--- a/includes/REST/ProductControllerV3.php
+++ b/includes/REST/ProductControllerV3.php
@@ -389,7 +389,7 @@ class ProductControllerV3 extends WC_REST_Products_Controller {
     protected function apply_image_positions( $product, $request ) {
         $images = $request['images'];
 
-        // An empty array already cleared both sides in WooCommerce's own setter, so there is nothing to restore.
+        // Nothing to restore: not a product, no images in the request, or an empty array WooCommerce already cleared.
         if ( ! $product instanceof WC_Product || ! is_array( $images ) || empty( $images ) ) {
             return $product;
         }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Saving a product from the new React product editor with **gallery images but no featured image** moved the vendor's first gallery image into the featured slot and dropped it from the gallery. With a single gallery image the gallery ended up empty. This is the defect behind the recurring report *"vendors are unable to add more than one photo to the product image gallery."*

`PayloadResolver::resolve_images()` flattened `image_id` and `gallery_image_ids` into WooCommerce's positional `images` array and relied on array order alone. `ProductControllerV3` extends `WC_REST_Products_Controller` without overriding `set_product_images()`, so WooCommerce's own implementation runs — and it takes the featured image from **array index 0** (`class-wc-rest-products-controller.php:703`). With no featured image, index 0 is a gallery image. WooCommerce's v3 `images` schema has no `position` field, so the flat array simply cannot express "gallery images, no featured image".

The resolver now tags each entry with the position the vendor chose — the same convention `ProductController` (v1) already splits on — and the v3 controller reapplies that split after WooCommerce has consumed `images`. Payloads Dokan did not resolve carry no positions and are left to WooCommerce untouched.

Emitting `images` even when empty also fixes a second bug in the same method: a vendor who removed **every** image sent no `images` key at all, so the old images survived.

### Closes

* Closes getdokan/plugin-internal-tasks#2343
* Parent: getdokan/plugin-internal-tasks#2342

### How to test the changes in this Pull Request:

1. WP Admin → Dokan → Settings → Appearance → **Vendor Product Editor** = *New UI*.
2. Vendor dashboard → Products → **Add new product**. Fill Title, Price, Description. **Leave Feature Image empty.**
3. Gallery Image → add **two** images (pick one → *Use this media*, then repeat for a second).
4. Confirm the editor shows Feature Image empty and 2 gallery thumbnails. Save.
5. Reopen the product.

**Before:** Feature Image shows the vendor's first gallery image; gallery has only the second.
**After:** Feature Image stays empty; gallery keeps both.

Verified against `dokan/v3/products` on WooCommerce 11.0.1:

| Vendor sets | Before | After |
|---|---|---|
| 2 gallery, no featured | `featured=A, gallery=[B]` | `featured=(none), gallery=[A,B]` |
| 1 gallery, no featured | `featured=B, gallery=[]` | `featured=(none), gallery=[B]` |
| featured + gallery | correct | unchanged |
| every image removed | no-op | both cleared |
| partial update (price only) | untouched | unchanged |
| `image_id: 0` alone, no gallery key | featured **kept**, gallery kept | featured cleared, gallery **also cleared** |

Because `images` is now always emitted, the two fields compile into one WooCommerce array and a request naming **either** of them describes the product's whole image state — so clearing the featured image alone also clears the gallery. This matches WooCommerce's own all-or-nothing `images` semantics, and the product editor always sends both keys, but it is a behaviour change for a partial API update and is called out in the changelog below.

### Changelog entry

**Fix — product editor no longer loses a gallery image on save**

Previously, saving a product from the new product editor without a featured image moved the vendor's first gallery image into the featured slot and removed it from the gallery; with one gallery image the gallery was emptied. Removing every image also did nothing. Now the featured image and gallery are saved exactly as the vendor set them, and clearing all images works. Note for API clients: a request that sends either `image_id` or `gallery_image_ids` describes the product's whole image state, so sending only one of them clears the other.

### Notes for the reviewer

Three follow-ups deliberately left out of scope:

* `position` survives only because WooCommerce's v3 images schema sets no `additionalProperties`, so WordPress preserves the unknown key. This controller does not override `get_item_schema()`, while the v1 `ProductController` declares `position` explicitly. If WooCommerce ever tightens that schema the split silently stops being applied and the bug returns with no error. Declaring `position` in a v3 schema override would close it, at the cost of deep-merging into WooCommerce's nested schema.

* WooCommerce still attaches index 0 to the product via `post_parent` before the split is corrected, leaving a gallery image parented to the product. Cosmetic (Media Library "Uploaded to" only). Removing it means overriding `set_product_images()` and owning WooCommerce's URL-upload path — considered and rejected as the riskier trade.
* Pro's variation resolver (`dokan-pro/includes/Product/PayloadResolver.php:41`) guards on `! empty( $data['images'] )`, so the cleared-everything case does not reach variations. Pre-existing; needs a Pro-side change.

The legacy vendor form writes through `Product\Manager::update()` and was never affected, so this is a 5.0 rewrite regression. Variations are unaffected — Pro's variation controller extends `WC_REST_Product_Variations_Controller`, not this one.

