### PR TITLE
fix(dashboard): recover the vendor dashboard when the current-user resolver fails

### DIFF
--- a/src/dashboard/index.tsx
+++ b/src/dashboard/index.tsx
@@ -6,6 +6,7 @@ import Layout from '../layout';
 import getRoutes, { withRouter } from '../routing';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import coreStore from '@dokan/stores/core';
 import Skeleton from '@src/layout/Skeleton';
 import InternalError from '@src/layout/500';
@@ -37,6 +38,16 @@ const App = () => {
 
     // @ts-ignore — invalidateResolution is a store metadata action, absent from the store's own types.
     const { invalidateResolution } = useDispatch( coreStore );
+    // @ts-ignore — same metadata action on the WordPress store Dokan's resolver reads through.
+    const { invalidateResolution: invalidateCoreData } =
+        useDispatch( coreDataStore );
+
+    // Dokan's resolver awaits resolveSelect( coreDataStore ).getCurrentUser(), which replays that
+    // store's cached failure, so retrying only Dokan's own resolution would never re-issue the request.
+    const retryCurrentUser = () => {
+        invalidateCoreData( 'getCurrentUser', [] );
+        invalidateResolution( 'getCurrentUser', [] );
+    };
 
     const mapedRoutes = routes.map( ( route ) => {
         const WithRouterComponent = withRouter(
@@ -71,7 +82,7 @@ const App = () => {
                     'Your account details could not be read. Try again, and contact the marketplace owner if this keeps happening.',
                     'dokan-lite'
                 ) }
-                onRefresh={ () => invalidateResolution( 'getCurrentUser', [] ) }
+                onRefresh={ retryCurrentUser }
             />
         );
     }

--- a/src/dashboard/index.tsx
+++ b/src/dashboard/index.tsx
@@ -5,9 +5,10 @@ import { __ } from '@wordpress/i18n';
 import Layout from '../layout';
 import getRoutes, { withRouter } from '../routing';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import coreStore from '@dokan/stores/core';
 import Skeleton from '@src/layout/Skeleton';
+import InternalError from '@src/layout/500';
 import { generateColorVariants } from '@dokan/utilities';
 
 // `<DataViews>` (via @wordpress/dataviews) renders its Actions column header
@@ -34,6 +35,9 @@ const App = () => {
         return select( coreStore ).getResolutionState( 'getCurrentUser' );
     }, [] );
 
+    // @ts-ignore — invalidateResolution is a store metadata action, absent from the store's own types.
+    const { invalidateResolution } = useDispatch( coreStore );
+
     const mapedRoutes = routes.map( ( route ) => {
         const WithRouterComponent = withRouter(
             route.element,
@@ -57,6 +61,20 @@ const App = () => {
     } );
 
     const router = createHashRouter( mapedRoutes );
+
+    // A failed resolver would otherwise sit on the skeleton forever — the "stays on loading" report.
+    if ( 'error' === loading?.status ) {
+        return (
+            <InternalError
+                title={ __( 'We could not load your dashboard', 'dokan-lite' ) }
+                message={ __(
+                    'Your account details could not be read. Try again, and contact the marketplace owner if this keeps happening.',
+                    'dokan-lite'
+                ) }
+                onRefresh={ () => invalidateResolution( 'getCurrentUser', [] ) }
+            />
+        );
+    }
 
     if ( ! loading || loading?.status !== 'finished' ) {
         return <Skeleton />;

--- a/src/dashboard/index.tsx
+++ b/src/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { createRoot } from '@wordpress/element';
+import { createRoot, useEffect } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -38,16 +38,32 @@ const App = () => {
 
     // @ts-ignore — invalidateResolution is a store metadata action, absent from the store's own types.
     const { invalidateResolution } = useDispatch( coreStore );
-    // @ts-ignore — same metadata action on the WordPress store Dokan's resolver reads through.
-    const { invalidateResolution: invalidateCoreData } =
-        useDispatch( coreDataStore );
+    // @ts-ignore — same metadata actions on the WordPress store Dokan's resolver reads through.
+    const {
+        invalidateResolution: invalidateCoreData,
+        invalidateResolutionForStoreSelector: invalidateCoreDataSelector,
+    } = useDispatch( coreDataStore );
 
-    // Dokan's resolver awaits resolveSelect( coreDataStore ).getCurrentUser(), which replays that
-    // store's cached failure, so retrying only Dokan's own resolution would never re-issue the request.
+    // Dokan's resolver awaits both getCurrentUser() and getUser( id ), and either leg replays its own
+    // cached failure, so a retry that misses one is a permanent no-op for whoever failed on that leg.
     const retryCurrentUser = () => {
+        invalidateCoreDataSelector( 'getUser' );
         invalidateCoreData( 'getCurrentUser', [] );
         invalidateResolution( 'getCurrentUser', [] );
     };
+
+    // Without the WP_Error, support cannot tell a blocking security plugin from a network blip.
+    useEffect( () => {
+        if ( 'error' !== loading?.status ) {
+            return;
+        }
+
+        // eslint-disable-next-line no-console
+        console.error(
+            'Dokan: current user resolution failed',
+            loading?.error
+        );
+    }, [ loading?.status, loading?.error ] );
 
     const mapedRoutes = routes.map( ( route ) => {
         const WithRouterComponent = withRouter(


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

The vendor dashboard gated its entire render on the `getCurrentUser` resolution reaching `finished`, with no branch for `error`:

```tsx
if ( ! loading || loading?.status !== 'finished' ) {
    return <Skeleton />;
}
```

`getResolutionState()` returns `resolving | finished | **error**`. Because `error` is a terminal state that never becomes `finished`, any failure of that REST call left the dashboard rendering the spinner **forever** — no message, no retry, no way out. This is what vendors report as the dashboard *"just staying on loading"*.

Nothing throws on this path, so no error boundary would ever have caught it. It is a missing `if`.

An error now renders the existing `InternalError` panel (`src/layout/500.tsx`) with a **Try again** button that invalidates the resolution, so the dashboard recovers in place once the endpoint answers — no full page reload.

### Closes

* Closes getdokan/plugin-internal-tasks#2344
* Parent: getdokan/plugin-internal-tasks#2342

### How to test the changes in this Pull Request:

Reproduce a genuine failure with a temporary mu-plugin that blocks the REST users endpoint, the way a security plugin does:

```php
add_filter( 'rest_pre_dispatch', function ( $result, $server, $request ) {
    if ( 0 === strpos( $request->get_route(), '/wp/v2/users' ) ) {
        return new WP_Error( 'rest_forbidden', 'Blocked.', [ 'status' => 403 ] );
    }
    return $result;
}, 1, 3 );
```

Then, on the vendor dashboard console, force the current-user resolution to re-run against the blocked endpoint:

```js
wp.data.dispatch( 'core' ).invalidateResolution( 'getCurrentUser', [] );
wp.data.dispatch( 'dokan/core' ).invalidateResolution( 'getCurrentUser', [] );
```

**Before:** endless spinner; `getResolutionState('getCurrentUser')` is `{status:"error", code:"rest_forbidden", 403}` and the UI never reflects it.
**After:** *"We could not load your dashboard"* with **Try Again**; clicking it returns the resolution to `finished` and the dashboard renders normally.

A synthetic trigger works too, without the mu-plugin:

```js
wp.data.dispatch( 'dokan/core' ).failResolution( 'getCurrentUser', [] );
```

### Changelog entry

**Fix — the vendor dashboard no longer hangs on a spinner when it cannot load your account**

Previously, if the request for the vendor's account details failed — a blocked REST endpoint, a 403, a proxy problem — the dashboard showed a loading spinner indefinitely with no explanation and no way to retry. It now shows a clear message with a Try again button that recovers the dashboard in place.

### Notes for the reviewer

The trigger is narrower than "any failed request": WordPress hydrates the current user into the page, so blocking the endpoint alone does not break a plain page load — the cached value has to actually be re-fetched. Documented on getdokan/plugin-internal-tasks#2344. Still worth fixing, since a permanent unrecoverable spinner with no message is the worst possible failure mode.

ESLint clean. `invalidateResolution` was confirmed present on the live `dokan/core` store dispatch.
