### PR TITLE
fix(admin): stop the legacy dashboard preference expiring after 15 days

### DIFF
--- a/includes/Admin/Dashboard/LegacySwitcher.php
+++ b/includes/Admin/Dashboard/LegacySwitcher.php
@@ -21,15 +21,6 @@ class LegacySwitcher implements Hookable {
     public const PRODUCT_EDITOR_SWITCH_ACTION = 'switch_product_editor';
 
     /**
-     * Default transient expiration time in seconds (15 days)
-     *
-     * @since 4.1.3
-     *
-     * @var int
-     */
-    protected int $transient_expiration = 15 * DAY_IN_SECONDS;
-
-    /**
      * Register hooks for the LegacySwitcher
      *
      * @since 4.1.3
@@ -126,7 +117,8 @@ class LegacySwitcher implements Hookable {
         if ( $current_is_legacy ) {
             delete_transient( $filtered_legacy_key );
         } else {
-            set_transient( $filtered_legacy_key, $new_legacy_state, $this->transient_expiration );
+            // Stored without an expiry: this is a preference the marketplace owner set, not a cache entry.
+            set_transient( $filtered_legacy_key, $new_legacy_state );
         }
 
         // Redirect to the new admin page, if needed.


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Choosing the **legacy** admin dashboard wrote a transient with a 15-day TTL, and reading it never refreshed that TTL:

```php
protected int $transient_expiration = 15 * DAY_IN_SECONDS;   // :30
set_transient( $filtered_legacy_key, $new_legacy_state, $this->transient_expiration );   // :129
```

Fifteen days after an admin last clicked switch, their choice silently reverted and the new React dashboard came back with no warning. This is a **preference the marketplace owner set, not a cache entry**, so it should not expire at all.

The TTL is dropped and the now-unused `$transient_expiration` property goes with it.

Storage stays a transient and the key names are unchanged, so **Dokan Pro's own reads keep working untouched** (`dokan-pro/includes/Admin/ToolsActions.php:76`, `dokan-pro/includes/Admin/Notices/WhatsNew.php:40`).

### Closes

* Closes getdokan/plugin-internal-tasks#2345
* Parent: getdokan/plugin-internal-tasks#2342

### How to test the changes in this Pull Request:

1. WP Admin → Dokan → Dashboard → switch to the **legacy** dashboard.
2. Confirm the Dokan → Dashboard menu item points at `admin.php?page=dokan`.
3. Simulate the TTL elapsing — `wp transient delete dokan_legacy_dashboard_page` is the end state the old 15-day expiry produced.

**Before:** after 15 days the preference is gone and the menu silently flips back to `page=dokan-dashboard`.
**After:** the preference has no expiry and persists until the admin switches back.

Round-trip verified through the real key helper:

```
key=dokan_legacy_dashboard_page  read_back=true  after_delete=false
```

phpcs clean on the changed file.

### Changelog entry

**Fix — the legacy admin dashboard preference no longer resets itself**

Previously, choosing the legacy Dokan admin dashboard was stored with a 15-day expiry, so a fortnight later the new dashboard silently came back without the admin changing anything. The preference now persists until it is explicitly changed.

### Notes for the reviewer

Known remaining gap, deliberately **not** addressed here: on a site with a persistent object cache the transient never reaches the options table, so any cache flush still drops the preference — verified with `wp cache flush`, after which the Dokan → Dashboard menu item flips back from `page=dokan` to `page=dokan-dashboard`. Closing that means moving the preference to an option and migrating **seven read sites in Lite plus two in Pro**, which is a larger and riskier change than this bug warrants on its own. Documented on getdokan/plugin-internal-tasks#2345.
