### PR TITLE
fix(admin): stop stacking the pending-vendor meta query onto every user query

### DIFF
--- a/includes/Admin/UserList.php
+++ b/includes/Admin/UserList.php
@@ -71,6 +71,12 @@ class UserList {
             return $query;
         }
 
+        // Only the list table asks for this role; every other user query on the screen -- the pending
+        // count badge among them -- already carries its own criteria and must not be stacked on to.
+        if ( 'pending_vendor' !== $query->get( 'role' ) ) {
+            return $query;
+        }
+
         // Unset the role parameter for fetch all users and set our custom role query.
         $query->set( 'role', '' );
         $query->set( 'role__in', [ 'seller', 'administrator' ] );

--- a/includes/Admin/UserList.php
+++ b/includes/Admin/UserList.php
@@ -71,8 +71,11 @@ class UserList {
             return $query;
         }
 
+        // Core copies $_REQUEST['role'] into the query var raw, so normalise it the same way the guard above does.
+        $query_role = sanitize_text_field( wp_unslash( $query->get( 'role' ) ) );
+
         // Only the list table asks for this role; the pending-count badge query on the same screen already carries its own criteria.
-        if ( 'pending_vendor' !== $query->get( 'role' ) ) {
+        if ( 'pending_vendor' !== $query_role ) {
             return $query;
         }
 

--- a/includes/Admin/UserList.php
+++ b/includes/Admin/UserList.php
@@ -71,8 +71,7 @@ class UserList {
             return $query;
         }
 
-        // Only the list table asks for this role; every other user query on the screen -- the pending
-        // count badge among them -- already carries its own criteria and must not be stacked on to.
+        // Only the list table asks for this role; the pending-count badge query on the same screen already carries its own criteria.
         if ( 'pending_vendor' !== $query->get( 'role' ) ) {
             return $query;
         }


### PR DESCRIPTION
### Changes proposed in this Pull Request

`UserList::filter_pending_vendors()` hooks `pre_get_users`, which fires for **every** `WP_User_Query` built while `users.php?role=pending_vendor` renders — including the one `dokan_get_pending_vendor_count()` runs through `Vendor\Manager::get_vendors()`, which already builds its own `dokan_enable_selling` group for `status => pending`.

Stacked, WordPress compiles four `LEFT JOIN wp_usermeta`, three of them with no `meta_key` in the `ON` clause, so each user fans out across its own meta rows before the `WHERE` filters anything.

The reporter measured **141,238,050 rows examined to return a single value**, 193–221 seconds per request, on a site with 319 users and a 24k-row `wp_usermeta`.

Only the list table asks for that role — WordPress passes `'role' => $_REQUEST['role']` (`wp-admin/includes/class-wp-users-list-table.php:107`) — while `get_vendors()` scopes with `role__in` and never sets `role`. Gating on that leaves the list query working and the badge query alone.

### Closes

* Closes #

### How to test the changes in this Pull Request

1. On a site with a few hundred sellers and no persistent object cache, open **wp-admin → Users → Pending Vendor**.
2. Watch the slow query log / `SHOW PROCESSLIST`.

**Expected:** no `WP_User_Query` with four `LEFT JOIN wp_usermeta` and three `dokan_enable_selling` clauses. The Pending Vendor list itself, and the pending badge on Dokan → Vendors, are unchanged.

### Test results

Measured on a real admin request with a temporary `pre_user_query` probe, `wp-admin → Users → Pending Vendor`:

```
before (develop)              after (this PR)
joins=3 clauses=2             joins=3 clauses=2   <- list table query, unchanged
joins=4 clauses=3   <-- !!    joins=0 clauses=1   <- badge query, no longer stacked
joins=3 clauses=2
```

The `joins=4 / clauses=3` query is the one from the issue's slow log; it is gone.

Independently, building both shapes and running `EXPLAIN` on a 50-user site:

```
get_vendors group only    joins=0   est. rows examined     1,485
both groups stacked       joins=4   est. rows examined 2,205,225
```

Same combinatorial shape the reporter hit at 319 users.

### Notes

The pending **count** and the pending **list** still disagree about vendors whose `dokan_enable_selling` meta is absent — `get_vendors()` matches only `= 'no'` while this filter and `dokan_get_seller_status_count()` also treat a missing key as pending. That is #3321 and is fixed separately in getdokan/dokan#3400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)