### PR TITLE
fix(vendor): treat a missing selling flag as pending when listing vendors

### DIFF
--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -70,7 +70,7 @@ class Manager {
         }
 
         // if featured
-        if ( 'yes' == $args['featured'] ) {
+        if ( 'yes' === $args['featured'] ) {
             $args['meta_query']['relation'] = 'AND';
             $args['meta_query'][] = [
                 'key'     => 'dokan_feature_seller',
@@ -210,26 +210,28 @@ class Manager {
         /**
          * @since 3.2.7 added $data parameter
          */
-        $store_data = apply_filters( 'dokan_vendor_create_data', [
-            'store_name'              => ! empty( $data['store_name'] ) ? $data['store_name'] : '',
-            'social'                  => ! empty( $data['social'] ) ? $data['social'] : [],
-            'payment'                 => ! empty( $data['payment'] ) ? $data['payment'] : [
-                'paypal' => [ 'email' ],
-                'bank'   => [],
-            ],
-            'phone'                   => ! empty( $data['phone'] ) ? $data['phone'] : '',
-            'show_email'              => ! empty( $data['show_email'] ) ? $data['show_email'] : 'no',
-            'address'                 => ! empty( $data['address'] ) ? $data['address'] : [],
-            'location'                => ! empty( $data['location'] ) ? $data['location'] : '',
-            'banner'                  => ! empty( $data['banner_id'] ) ? $data['banner_id'] : 0,
-            'icon'                    => ! empty( $data['icon'] ) ? $data['icon'] : '',
-            'gravatar'                => ! empty( $data['gravatar_id'] ) ? $data['gravatar_id'] : 0,
-            'enable_tnc'              => ! empty( $data['enable_tnc'] ) ? $data['enable_tnc'] : 'off',
-            'store_tnc'               => ! empty( $data['store_tnc'] ) ? $data['store_tnc'] : '',
-            'show_min_order_discount' => ! empty( $data['show_min_order_discount'] ) ? $data['show_min_order_discount'] : 'no',
-            'store_seo'               => ! empty( $data['store_seo'] ) ? $data['store_seo'] : [],
-            'dokan_store_time'        => ! empty( $data['store_open_close'] ) ? $data['store_open_close'] : [],
-        ], $data );
+        $store_data = apply_filters(
+            'dokan_vendor_create_data', [
+				'store_name'              => ! empty( $data['store_name'] ) ? $data['store_name'] : '',
+				'social'                  => ! empty( $data['social'] ) ? $data['social'] : [],
+				'payment'                 => ! empty( $data['payment'] ) ? $data['payment'] : [
+					'paypal' => [ 'email' ],
+					'bank'   => [],
+				],
+				'phone'                   => ! empty( $data['phone'] ) ? $data['phone'] : '',
+				'show_email'              => ! empty( $data['show_email'] ) ? $data['show_email'] : 'no',
+				'address'                 => ! empty( $data['address'] ) ? $data['address'] : [],
+				'location'                => ! empty( $data['location'] ) ? $data['location'] : '',
+				'banner'                  => ! empty( $data['banner_id'] ) ? $data['banner_id'] : 0,
+				'icon'                    => ! empty( $data['icon'] ) ? $data['icon'] : '',
+				'gravatar'                => ! empty( $data['gravatar_id'] ) ? $data['gravatar_id'] : 0,
+				'enable_tnc'              => ! empty( $data['enable_tnc'] ) ? $data['enable_tnc'] : 'off',
+				'store_tnc'               => ! empty( $data['store_tnc'] ) ? $data['store_tnc'] : '',
+				'show_min_order_discount' => ! empty( $data['show_min_order_discount'] ) ? $data['show_min_order_discount'] : 'no',
+				'store_seo'               => ! empty( $data['store_seo'] ) ? $data['store_seo'] : [],
+				'dokan_store_time'        => ! empty( $data['store_open_close'] ) ? $data['store_open_close'] : [],
+			], $data
+        );
 
         $vendor = dokan()->vendor->get( $vendor_id );
 
@@ -425,7 +427,7 @@ class Manager {
 
         // for backward compatibility we'll allow both `enable_tnc` and `toc_enabled` to set store trams and condition settings
         if ( ( isset( $data['enable_tnc'] ) && dokan_validate_boolean( $data['enable_tnc'] ) )
-             || ( isset( $data['toc_enabled'] ) && dokan_validate_boolean( $data['toc_enabled'] ) ) ) {
+            || ( isset( $data['toc_enabled'] ) && dokan_validate_boolean( $data['toc_enabled'] ) ) ) {
             $vendor->set_enable_tnc( 'on' );
         } else {
             $vendor->set_enable_tnc( 'off' );

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -77,9 +77,7 @@ class Manager {
                 continue;
             }
 
-            // A vendor that never had the meta written carries no key at all, and both the status
-            // counters and the Users list read that as pending -- so the listing has to agree, or the
-            // tab reports a count it cannot show.
+            // The status counters and the Users list both read a missing key as pending, so the listing has to agree or the tab shows a count it cannot list.
             $meta_query[] = [
                 'relation' => 'OR',
                 [

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -67,10 +67,30 @@ class Manager {
                 continue;
             }
 
+            if ( 'approved' === $stat ) {
+                $meta_query[] = [
+                    'key'     => 'dokan_enable_selling',
+                    'value'   => 'yes',
+                    'compare' => '=',
+                ];
+
+                continue;
+            }
+
+            // A vendor that never had the meta written carries no key at all, and both the status
+            // counters and the Users list read that as pending -- so the listing has to agree, or the
+            // tab reports a count it cannot show.
             $meta_query[] = [
-                'key'     => 'dokan_enable_selling',
-                'value'   => ( $stat == 'approved' ) ? 'yes' : 'no',
-                'compare' => '=',
+                'relation' => 'OR',
+                [
+                    'key'     => 'dokan_enable_selling',
+                    'value'   => 'no',
+                    'compare' => '=',
+                ],
+                [
+                    'key'     => 'dokan_enable_selling',
+                    'compare' => 'NOT EXISTS',
+                ],
             ];
         }
 

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -58,28 +58,15 @@ class Manager {
 
         $args = wp_parse_args( $args, $defaults );
 
-        $status         = (array) $args['status'];
-        $filter_status  = ! in_array( 'all', $status, true );
-        $wants_approved = $filter_status && in_array( 'approved', $status, true );
-        $wants_pending  = $filter_status && (bool) array_diff( $status, [ 'approved' ] );
+        $status = $this->resolve_status( $args['status'] );
 
-        // Asking for approved and pending together is asking for everyone.
-        if ( $wants_approved && ! $wants_pending ) {
-            $meta_query = [
-                'relation' => 'OR',
-                [
-                    'key'     => 'dokan_enable_selling',
-                    'value'   => 'yes',
-                    'compare' => '=',
-                ],
+        if ( 'approved' === $status ) {
+            $args['meta_query']['relation'] = 'AND';
+            $args['meta_query'][]           = [
+                'key'     => 'dokan_enable_selling',
+                'value'   => 'yes',
+                'compare' => '=',
             ];
-
-            if ( ! empty( $args['meta_query'] ) ) {
-                $args['meta_query']['relation'] = 'AND';
-                $args['meta_query'][]           = $meta_query;
-            } else {
-                $args['meta_query'] = $meta_query;
-            }
         }
 
         // if featured
@@ -95,8 +82,8 @@ class Manager {
         unset( $args['status'] );
         unset( $args['featured'] );
 
-        // Pending is everyone not approved. One keyed subquery costs no usermeta joins; an OR group with NOT EXISTS costs three.
-        if ( $wants_pending && ! $wants_approved ) {
+        // Pending is everyone not approved, a missing flag included, exactly as the status counters and dokan_is_seller_enabled() read it.
+        if ( 'pending' === $status ) {
             add_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
         }
 
@@ -119,10 +106,35 @@ class Manager {
     }
 
     /**
-     * Drop every vendor whose selling flag is approved from a user query.
+     * Collapse the requested statuses into the single filter the query applies.
      *
-     * The status counters and the Users list both read a missing dokan_enable_selling key as pending,
-     * so the listing has to agree or the Pending tab reports a count it cannot show.
+     * Anything other than 'approved' or 'all' has always been read as pending, and asking
+     * for approved and pending together is asking for everyone.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string|string[] $status
+     *
+     * @return string One of 'all', 'approved' or 'pending'.
+     */
+    private function resolve_status( $status ): string {
+        $statuses = array_unique(
+            array_map(
+                static function ( $item ) {
+                    return in_array( $item, [ 'all', 'approved' ], true ) ? $item : 'pending';
+                },
+                (array) $status
+            )
+        );
+
+        return 1 === count( $statuses ) ? reset( $statuses ) : 'all';
+    }
+
+    /**
+     * Drop every approved vendor from a user query, leaving the pending ones.
+     *
+     * A keyed subquery adds no usermeta join, where the equivalent OR / NOT EXISTS meta
+     * query adds two and turns every join on the query into a LEFT JOIN.
      *
      * @since DOKAN_SINCE
      *

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -58,45 +58,28 @@ class Manager {
 
         $args = wp_parse_args( $args, $defaults );
 
-        $status = (array) $args['status'];
+        $status         = (array) $args['status'];
+        $filter_status  = ! in_array( 'all', $status, true );
+        $wants_approved = $filter_status && in_array( 'approved', $status, true );
+        $wants_pending  = $filter_status && (bool) array_diff( $status, [ 'approved' ] );
 
-        $meta_query = [ 'relation' => 'OR' ];
-
-        foreach ( $status as $stat ) {
-            if ( $stat === 'all' ) {
-                continue;
-            }
-
-            if ( 'approved' === $stat ) {
-                $meta_query[] = [
-                    'key'     => 'dokan_enable_selling',
-                    'value'   => 'yes',
-                    'compare' => '=',
-                ];
-
-                continue;
-            }
-
-            // The status counters and the Users list both read a missing key as pending, so the listing has to agree or the tab shows a count it cannot list.
-            $meta_query[] = [
+        // Asking for approved and pending together is asking for everyone.
+        if ( $wants_approved && ! $wants_pending ) {
+            $meta_query = [
                 'relation' => 'OR',
                 [
                     'key'     => 'dokan_enable_selling',
-                    'value'   => 'no',
+                    'value'   => 'yes',
                     'compare' => '=',
                 ],
-                [
-                    'key'     => 'dokan_enable_selling',
-                    'compare' => 'NOT EXISTS',
-                ],
             ];
-        }
 
-        if ( ! empty( $args['meta_query'] ) ) {
-            $args['meta_query']['relation'] = 'AND';
-            $args['meta_query'][]           = $meta_query;
-        } else {
-            $args['meta_query'] = $meta_query;
+            if ( ! empty( $args['meta_query'] ) ) {
+                $args['meta_query']['relation'] = 'AND';
+                $args['meta_query'][]           = $meta_query;
+            } else {
+                $args['meta_query'] = $meta_query;
+            }
         }
 
         // if featured
@@ -112,8 +95,15 @@ class Manager {
         unset( $args['status'] );
         unset( $args['featured'] );
 
+        // Pending is everyone not approved. One keyed subquery costs no usermeta joins; an OR group with NOT EXISTS costs three.
+        if ( $wants_pending && ! $wants_approved ) {
+            add_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
+        }
+
         $user_query = new WP_User_Query( $args );
         $results    = $user_query->get_results();
+
+        remove_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
 
         $this->total_users = $user_query->total_users;
 
@@ -126,6 +116,28 @@ class Manager {
         }
 
         return $vendors;
+    }
+
+    /**
+     * Drop every vendor whose selling flag is approved from a user query.
+     *
+     * The status counters and the Users list both read a missing dokan_enable_selling key as pending,
+     * so the listing has to agree or the Pending tab reports a count it cannot show.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param \WP_User_Query $query
+     *
+     * @return void
+     */
+    public function exclude_approved_vendors( $query ) {
+        global $wpdb;
+
+        $query->query_where .= $wpdb->prepare(
+            " AND {$wpdb->users}.ID NOT IN ( SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value = %s )",
+            'dokan_enable_selling',
+            'yes'
+        );
     }
 
     /**

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -19,7 +19,7 @@ class Manager {
      *
      * @var integer
      */
-    private $total_users;
+    protected $total_users;
 
     /**
      * Get all vendors
@@ -36,6 +36,10 @@ class Manager {
 
     /**
      * Get vendors
+     *
+     * `status` accepts 'all', 'approved' or 'pending' (string or array); anything else reads
+     * as pending, and a mix of them reads as 'all'. Pending is applied through the
+     * `dokan_pending_only` query var, which `exclude_approved_vendors()` acts on.
      *
      * @param array $args
      *
@@ -84,13 +88,18 @@ class Manager {
 
         // Pending is everyone not approved, a missing flag included, exactly as the status counters and dokan_is_seller_enabled() read it.
         if ( 'pending' === $status ) {
+            // Carried into the query so the callback can tell our query from any other one running inside the same hook.
+            $args['dokan_pending_only'] = true;
+
             add_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
         }
 
-        $user_query = new WP_User_Query( $args );
-        $results    = $user_query->get_results();
-
-        remove_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
+        try {
+            $user_query = new WP_User_Query( $args );
+            $results    = $user_query->get_results();
+        } finally {
+            remove_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
+        }
 
         $this->total_users = $user_query->total_users;
 
@@ -108,8 +117,8 @@ class Manager {
     /**
      * Collapse the requested statuses into the single filter the query applies.
      *
-     * Anything other than 'approved' or 'all' has always been read as pending, and asking
-     * for approved and pending together is asking for everyone.
+     * Anything other than 'approved' or 'all' has always been read as pending, and any mix of
+     * statuses — 'approved' with 'pending', or either of them with 'all' — is asking for everyone.
      *
      * @since DOKAN_SINCE
      *
@@ -117,7 +126,7 @@ class Manager {
      *
      * @return string One of 'all', 'approved' or 'pending'.
      */
-    private function resolve_status( $status ): string {
+    protected function resolve_status( $status ): string {
         $statuses = array_unique(
             array_map(
                 static function ( $item ) {
@@ -133,8 +142,9 @@ class Manager {
     /**
      * Drop every approved vendor from a user query, leaving the pending ones.
      *
-     * A keyed subquery adds no usermeta join, where the equivalent OR / NOT EXISTS meta
-     * query adds two and turns every join on the query into a LEFT JOIN.
+     * Correlated on user_id so it rides the usermeta index and stops at the first match per
+     * row, where the equivalent meta query adds two joins and turns every join on the query
+     * into a LEFT JOIN.
      *
      * @since DOKAN_SINCE
      *
@@ -145,8 +155,13 @@ class Manager {
     public function exclude_approved_vendors( $query ) {
         global $wpdb;
 
+        // The hook is global while our query runs, so anyone else's nested user query would inherit this clause.
+        if ( ! $query->get( 'dokan_pending_only' ) ) {
+            return;
+        }
+
         $query->query_where .= $wpdb->prepare(
-            " AND {$wpdb->users}.ID NOT IN ( SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value = %s )",
+            " AND NOT EXISTS ( SELECT 1 FROM {$wpdb->usermeta} WHERE user_id = {$wpdb->users}.ID AND meta_key = %s AND meta_value = %s )",
             'dokan_enable_selling',
             'yes'
         );
@@ -212,25 +227,25 @@ class Manager {
          */
         $store_data = apply_filters(
             'dokan_vendor_create_data', [
-				'store_name'              => ! empty( $data['store_name'] ) ? $data['store_name'] : '',
-				'social'                  => ! empty( $data['social'] ) ? $data['social'] : [],
-				'payment'                 => ! empty( $data['payment'] ) ? $data['payment'] : [
-					'paypal' => [ 'email' ],
-					'bank'   => [],
-				],
-				'phone'                   => ! empty( $data['phone'] ) ? $data['phone'] : '',
-				'show_email'              => ! empty( $data['show_email'] ) ? $data['show_email'] : 'no',
-				'address'                 => ! empty( $data['address'] ) ? $data['address'] : [],
-				'location'                => ! empty( $data['location'] ) ? $data['location'] : '',
-				'banner'                  => ! empty( $data['banner_id'] ) ? $data['banner_id'] : 0,
-				'icon'                    => ! empty( $data['icon'] ) ? $data['icon'] : '',
-				'gravatar'                => ! empty( $data['gravatar_id'] ) ? $data['gravatar_id'] : 0,
-				'enable_tnc'              => ! empty( $data['enable_tnc'] ) ? $data['enable_tnc'] : 'off',
-				'store_tnc'               => ! empty( $data['store_tnc'] ) ? $data['store_tnc'] : '',
-				'show_min_order_discount' => ! empty( $data['show_min_order_discount'] ) ? $data['show_min_order_discount'] : 'no',
-				'store_seo'               => ! empty( $data['store_seo'] ) ? $data['store_seo'] : [],
-				'dokan_store_time'        => ! empty( $data['store_open_close'] ) ? $data['store_open_close'] : [],
-			], $data
+                'store_name'              => ! empty( $data['store_name'] ) ? $data['store_name'] : '',
+                'social'                  => ! empty( $data['social'] ) ? $data['social'] : [],
+                'payment'                 => ! empty( $data['payment'] ) ? $data['payment'] : [
+                    'paypal' => [ 'email' ],
+                    'bank'   => [],
+                ],
+                'phone'                   => ! empty( $data['phone'] ) ? $data['phone'] : '',
+                'show_email'              => ! empty( $data['show_email'] ) ? $data['show_email'] : 'no',
+                'address'                 => ! empty( $data['address'] ) ? $data['address'] : [],
+                'location'                => ! empty( $data['location'] ) ? $data['location'] : '',
+                'banner'                  => ! empty( $data['banner_id'] ) ? $data['banner_id'] : 0,
+                'icon'                    => ! empty( $data['icon'] ) ? $data['icon'] : '',
+                'gravatar'                => ! empty( $data['gravatar_id'] ) ? $data['gravatar_id'] : 0,
+                'enable_tnc'              => ! empty( $data['enable_tnc'] ) ? $data['enable_tnc'] : 'off',
+                'store_tnc'               => ! empty( $data['store_tnc'] ) ? $data['store_tnc'] : '',
+                'show_min_order_discount' => ! empty( $data['show_min_order_discount'] ) ? $data['show_min_order_discount'] : 'no',
+                'store_seo'               => ! empty( $data['store_seo'] ) ? $data['store_seo'] : [],
+                'dokan_store_time'        => ! empty( $data['store_open_close'] ) ? $data['store_open_close'] : [],
+            ], $data
         );
 
         $vendor = dokan()->vendor->get( $vendor_id );

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -15,6 +15,15 @@ use WeDevs\Dokan\Vendor\Vendor;
 class Manager {
 
     /**
+     * The statuses the vendor listing knows how to filter on.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @var string[]
+     */
+    const STATUSES = [ 'all', 'approved', 'pending' ];
+
+    /**
      * Total vendors found
      *
      * @var integer
@@ -37,9 +46,9 @@ class Manager {
     /**
      * Get vendors
      *
-     * `status` accepts 'all', 'approved' or 'pending' (string or array); anything else reads
-     * as pending, and a mix of them reads as 'all'. Pending is applied through the
-     * `dokan_pending_only` query var, which `exclude_approved_vendors()` acts on.
+     * `status` accepts 'all', 'approved' or 'pending' (string or array); asking for both halves
+     * means everyone and anything unrecognised falls back to 'approved'. Pending is applied
+     * through the `dokan_pending_only` query var, which `exclude_approved_vendors()` acts on.
      *
      * @param array $args
      *
@@ -116,8 +125,10 @@ class Manager {
     /**
      * Collapse the requested statuses into the single filter the query applies.
      *
-     * Anything other than 'approved' or 'all' has always been read as pending, and any mix of
-     * statuses — 'approved' with 'pending', or either of them with 'all' — is asking for everyone.
+     * Only 'all', 'approved' and 'pending' are understood. Asking for both halves — or for 'all'
+     * outright — means everyone. Anything else names no status this listing can filter on, so it
+     * falls back to the default rather than widening the result, the same way
+     * `Abilities\Definitions\VendorsQuery::resolve_status()` coerces an unknown status.
      *
      * @since DOKAN_SINCE
      *
@@ -126,16 +137,14 @@ class Manager {
      * @return string One of 'all', 'approved' or 'pending'.
      */
     protected function resolve_status( $status ): string {
-        $statuses = array_unique(
-            array_map(
-                static function ( $item ) {
-                    return in_array( $item, [ 'all', 'approved' ], true ) ? $item : 'pending';
-                },
-                (array) $status
-            )
-        );
+        $known = array_values( array_unique( array_intersect( (array) $status, self::STATUSES ) ) );
 
-        return 1 === count( $statuses ) ? reset( $statuses ) : 'all';
+        // Never let a typo read as a wider set than the caller asked for.
+        if ( empty( $known ) ) {
+            return 'approved';
+        }
+
+        return 1 === count( $known ) ? $known[0] : 'all';
     }
 
     /**

--- a/includes/Vendor/Manager.php
+++ b/includes/Vendor/Manager.php
@@ -19,7 +19,7 @@ class Manager {
      *
      * @var integer
      */
-    protected $total_users;
+    private $total_users;
 
     /**
      * Get all vendors
@@ -91,15 +91,14 @@ class Manager {
             // Carried into the query so the callback can tell our query from any other one running inside the same hook.
             $args['dokan_pending_only'] = true;
 
-            add_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
+            // Hooked once and left in place: it is a no-op without the query var, and unhooking it around the query let a nested listing disarm the outer one.
+            if ( ! has_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] ) ) {
+                add_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
+            }
         }
 
-        try {
-            $user_query = new WP_User_Query( $args );
-            $results    = $user_query->get_results();
-        } finally {
-            remove_action( 'pre_user_query', [ $this, 'exclude_approved_vendors' ] );
-        }
+        $user_query = new WP_User_Query( $args );
+        $results    = $user_query->get_results();
 
         $this->total_users = $user_query->total_users;
 
@@ -140,11 +139,9 @@ class Manager {
     }
 
     /**
-     * Drop every approved vendor from a user query, leaving the pending ones.
+     * Drop every approved vendor from a user query that asked for pending ones only.
      *
-     * Correlated on user_id so it rides the usermeta index and stops at the first match per
-     * row, where the equivalent meta query adds two joins and turns every join on the query
-     * into a LEFT JOIN.
+     * A correlated NOT EXISTS rides the usermeta index and stops at the first match per row.
      *
      * @since DOKAN_SINCE
      *
@@ -155,7 +152,7 @@ class Manager {
     public function exclude_approved_vendors( $query ) {
         global $wpdb;
 
-        // The hook is global while our query runs, so anyone else's nested user query would inherit this clause.
+        // Every user query on the site passes through here once hooked, so only the one that asked for pending gets the clause.
         if ( ! $query->get( 'dokan_pending_only' ) ) {
             return;
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3484,14 +3484,9 @@ if ( ! function_exists( 'dokan_get_pending_vendor_count' ) ) {
     /**
      * Count the vendors that are waiting for admin approval.
      *
-     * Delegates to the very query the Vendors list is built from instead of reusing
-     * `dokan_get_seller_status_count()['inactive']`. That figure is derived as
-     * "everything that is not approved", so it also counts users carrying no
-     * `dokan_enable_selling` meta at all — every administrator, for one, since
-     * `dokan_admin_user_register()` only writes that meta for the `seller` role. The
-     * listing matches on `dokan_enable_selling = 'no'` and therefore leaves those users
-     * out, so a count taken from `inactive` is one an admin can never clear: the page it
-     * points at has nothing pending to show.
+     * Delegates to the very query the Vendors list is built from, so the badge can never
+     * claim a count the Pending tab is unable to show. Both read a missing
+     * `dokan_enable_selling` flag as pending, the same way `dokan_is_seller_enabled()` does.
      *
      * Cached in the shared `vendors` group, which VendorCache already invalidates on
      * vendor create/update/delete and on enable/disable.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1500,7 +1500,7 @@ function dokan_get_seller_count( $from = null, $to = null ) {
     $now              = dokan_current_datetime();
     $inactive_sellers = dokan_get_sellers(
         [
-            'number' => - 1,
+            'number' => 1, // Only the total is read; one row keeps this from building a Vendor object per pending seller.
             'status' => 'pending',
         ]
     );
@@ -3486,7 +3486,10 @@ if ( ! function_exists( 'dokan_get_pending_vendor_count' ) ) {
      *
      * Delegates to the very query the Vendors list is built from, so the badge can never
      * claim a count the Pending tab is unable to show. Both read a missing
-     * `dokan_enable_selling` flag as pending, the same way `dokan_is_seller_enabled()` does.
+     * `dokan_enable_selling` flag as pending, as `dokan_is_seller_enabled()`,
+     * `dokan_get_seller_status_count()` and the Users-screen "Pending Vendors" filter all
+     * do. That includes an administrator who never touched the seller fields, since
+     * `dokan_admin_user_register()` only writes the flag for the `seller` role.
      *
      * Cached in the shared `vendors` group, which VendorCache already invalidates on
      * vendor create/update/delete and on enable/disable.

--- a/tests/php/src/Vendor/VendorStatusFilterTest.php
+++ b/tests/php/src/Vendor/VendorStatusFilterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Vendor;
+
+use WP_UnitTestCase;
+use WP_User_Query;
+
+/**
+ * The status filter on the vendor listing.
+ *
+ * @group vendor
+ */
+class VendorStatusFilterTest extends WP_UnitTestCase {
+
+    /**
+     * @var int Vendor with dokan_enable_selling = yes.
+     */
+    private $approved;
+
+    /**
+     * @var int Vendor with dokan_enable_selling = no.
+     */
+    private $disabled;
+
+    /**
+     * @var int Vendor that never had the flag written.
+     */
+    private $flagless;
+
+    public function set_up() {
+        parent::set_up();
+
+        $this->approved = $this->factory()->user->create( [ 'role' => 'seller' ] );
+        $this->disabled = $this->factory()->user->create( [ 'role' => 'seller' ] );
+        $this->flagless = $this->factory()->user->create( [ 'role' => 'seller' ] );
+
+        update_user_meta( $this->approved, 'dokan_enable_selling', 'yes' );
+        update_user_meta( $this->disabled, 'dokan_enable_selling', 'no' );
+        delete_user_meta( $this->flagless, 'dokan_enable_selling' );
+    }
+
+    /**
+     * Run the listing scoped to the three fixtures and return the matched IDs.
+     */
+    private function ids_for( $status ): array {
+        $args = [
+            'include' => [ $this->approved, $this->disabled, $this->flagless ],
+            'fields'  => 'ID',
+            'number'  => -1,
+        ];
+
+        if ( null !== $status ) {
+            $args['status'] = $status;
+        }
+
+        $ids = array_map( 'intval', dokan()->vendor->get_vendors( $args ) );
+        sort( $ids );
+
+        return $ids;
+    }
+
+    public function status_provider(): array {
+        return [
+            'default is approved'    => [ null, 'approved' ],
+            'approved string'        => [ 'approved', 'approved' ],
+            'approved array'         => [ [ 'approved' ], 'approved' ],
+            'pending string'         => [ 'pending', 'pending' ],
+            'pending array'          => [ [ 'pending' ], 'pending' ],
+            'unknown reads pending'  => [ 'no', 'pending' ],
+            'all string'             => [ 'all', 'all' ],
+            'approved plus pending'  => [ [ 'approved', 'pending' ], 'all' ],
+            'all plus approved'      => [ [ 'all', 'approved' ], 'all' ],
+            'empty list'             => [ [], 'all' ],
+        ];
+    }
+
+    /**
+     * @dataProvider status_provider
+     */
+    public function test_status_filter( $status, string $expected ) {
+        $expected_ids = [
+            'approved' => [ $this->approved ],
+            'pending'  => [ $this->disabled, $this->flagless ],
+            'all'      => [ $this->approved, $this->disabled, $this->flagless ],
+        ][ $expected ];
+        sort( $expected_ids );
+
+        $this->assertSame( $expected_ids, $this->ids_for( $status ) );
+        $this->assertSame( count( $expected_ids ), dokan()->vendor->get_total() );
+    }
+
+    public function test_pending_filter_is_detached_after_the_query() {
+        $this->ids_for( 'pending' );
+
+        $this->assertFalse( has_action( 'pre_user_query', [ dokan()->vendor, 'exclude_approved_vendors' ] ) );
+
+        $query = new WP_User_Query(
+            [
+                'include' => [ $this->approved ],
+                'fields'  => 'ID',
+            ]
+        );
+
+        $this->assertSame( [ $this->approved ], array_map( 'intval', $query->get_results() ) );
+    }
+
+    public function test_pending_filter_keeps_caller_meta_query() {
+        update_user_meta( $this->disabled, 'dokan_store_name', 'Disabled Shop' );
+        update_user_meta( $this->flagless, 'dokan_store_name', 'Flagless Shop' );
+
+        $ids = dokan()->vendor->get_vendors(
+            [
+                'include'    => [ $this->approved, $this->disabled, $this->flagless ],
+                'status'     => 'pending',
+                'fields'     => 'ID',
+                'number'     => -1,
+                'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+                    [
+                        'key'     => 'dokan_store_name',
+                        'value'   => 'Flagless',
+                        'compare' => 'LIKE',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertSame( [ $this->flagless ], array_map( 'intval', $ids ) );
+    }
+}

--- a/tests/php/src/Vendor/VendorStatusFilterTest.php
+++ b/tests/php/src/Vendor/VendorStatusFilterTest.php
@@ -70,11 +70,14 @@ class VendorStatusFilterTest extends DokanTestCase {
             'default is approved'   => [ null, 'approved' ],
             'approved string'       => [ 'approved', 'approved' ],
             'pending array'         => [ [ 'pending' ], 'pending' ],
-            'unknown reads pending' => [ 'no', 'pending' ],
             'all string'            => [ 'all', 'all' ],
             'approved plus pending' => [ [ 'approved', 'pending' ], 'all' ],
             'all plus approved'     => [ [ 'all', 'approved' ], 'all' ],
-            'empty list'            => [ [], 'all' ],
+            // An unknown status names nothing to filter on, so it must not widen the listing.
+            'unknown alone'         => [ 'rejected', 'approved' ],
+            'unknown with approved' => [ [ 'approved', 'rejected' ], 'approved' ],
+            'unknown with pending'  => [ [ 'pending', 'rejected' ], 'pending' ],
+            'empty list'            => [ [], 'approved' ],
         ];
     }
 

--- a/tests/php/src/Vendor/VendorStatusFilterTest.php
+++ b/tests/php/src/Vendor/VendorStatusFilterTest.php
@@ -113,7 +113,7 @@ class VendorStatusFilterTest extends DokanTestCase {
     }
 
     /**
-     * The clause is welded onto query_where, so it must not outlive the listing that asked for it.
+     * The callback stays hooked after the listing, so it must sit out every query that did not ask for pending.
      */
     public function test_pending_filter_does_not_outlive_the_query() {
         $this->ids_for( 'pending' );
@@ -145,25 +145,27 @@ class VendorStatusFilterTest extends DokanTestCase {
     }
 
     /**
-     * A throw mid-query must not leave every later user query filtered.
+     * A listing started from inside pre_get_users must not disarm the pending listing already running.
      */
-    public function test_pending_filter_is_detached_when_the_query_throws() {
-        $boom = static function () {
-            throw new \RuntimeException( 'boom' );
+    public function test_nested_listing_does_not_disarm_the_pending_filter() {
+        $nested = null;
+
+        $spy = function () use ( &$nested, &$spy ) {
+            remove_action( 'pre_get_users', $spy, 5 );
+
+            $nested = $this->ids_for( 'approved' );
         };
 
-        add_action( 'pre_user_query', $boom, 20 );
+        add_action( 'pre_get_users', $spy, 5 );
 
         try {
-            $this->ids_for( 'pending' );
-            $this->fail( 'The query was expected to throw.' );
-        } catch ( \RuntimeException $e ) {
-            $this->assertSame( 'boom', $e->getMessage() );
+            $outer = $this->ids_for( 'pending' );
         } finally {
-            remove_action( 'pre_user_query', $boom, 20 );
+            remove_action( 'pre_get_users', $spy, 5 );
         }
 
-        $this->assertEqualSets( [ $this->approved ], $this->unfiltered_ids() );
+        $this->assertEqualSets( [ $this->approved ], $nested );
+        $this->assertEqualSets( [ $this->disabled, $this->flagless ], $outer );
     }
 
     public function test_pending_filter_keeps_caller_meta_query() {

--- a/tests/php/src/Vendor/VendorStatusFilterTest.php
+++ b/tests/php/src/Vendor/VendorStatusFilterTest.php
@@ -118,7 +118,7 @@ class VendorStatusFilterTest extends DokanTestCase {
     /**
      * The callback stays hooked after the listing, so it must sit out every query that did not ask for pending.
      */
-    public function test_pending_filter_does_not_outlive_the_query() {
+    public function test_hooked_filter_is_a_noop_for_other_queries() {
         $this->ids_for( 'pending' );
 
         $this->assertEqualSets( [ $this->approved ], $this->unfiltered_ids() );

--- a/tests/php/src/Vendor/VendorStatusFilterTest.php
+++ b/tests/php/src/Vendor/VendorStatusFilterTest.php
@@ -2,7 +2,8 @@
 
 namespace WeDevs\Dokan\Test\Vendor;
 
-use WP_UnitTestCase;
+use WeDevs\Dokan\Cache;
+use WeDevs\Dokan\Test\DokanTestCase;
 use WP_User_Query;
 
 /**
@@ -10,26 +11,34 @@ use WP_User_Query;
  *
  * @group vendor
  */
-class VendorStatusFilterTest extends WP_UnitTestCase {
+class VendorStatusFilterTest extends DokanTestCase {
+
+    /**
+     * The listing is queried directly here, so the REST server and the shared user fixtures are dead weight.
+     *
+     * @var bool
+     */
+    protected $is_unit_test = true;
 
     /**
      * @var int Vendor with dokan_enable_selling = yes.
      */
-    private $approved;
+    protected $approved;
 
     /**
      * @var int Vendor with dokan_enable_selling = no.
      */
-    private $disabled;
+    protected $disabled;
 
     /**
      * @var int Vendor that never had the flag written.
      */
-    private $flagless;
+    protected $flagless;
 
     public function set_up() {
         parent::set_up();
 
+        // Not the seller factory: it runs Dokan registration, which writes the very flag the flagless fixture must not have.
         $this->approved = $this->factory()->user->create( [ 'role' => 'seller' ] );
         $this->disabled = $this->factory()->user->create( [ 'role' => 'seller' ] );
         $this->flagless = $this->factory()->user->create( [ 'role' => 'seller' ] );
@@ -42,8 +51,8 @@ class VendorStatusFilterTest extends WP_UnitTestCase {
     /**
      * Run the listing scoped to the three fixtures and return the matched IDs.
      */
-    private function ids_for( $status ): array {
-        $args = [
+    protected function ids_for( $status, array $extra = [] ): array {
+        $args = $extra + [
             'include' => [ $this->approved, $this->disabled, $this->flagless ],
             'fields'  => 'ID',
             'number'  => -1,
@@ -53,24 +62,19 @@ class VendorStatusFilterTest extends WP_UnitTestCase {
             $args['status'] = $status;
         }
 
-        $ids = array_map( 'intval', dokan()->vendor->get_vendors( $args ) );
-        sort( $ids );
-
-        return $ids;
+        return array_map( 'intval', dokan()->vendor->get_vendors( $args ) );
     }
 
     public function status_provider(): array {
         return [
-            'default is approved'    => [ null, 'approved' ],
-            'approved string'        => [ 'approved', 'approved' ],
-            'approved array'         => [ [ 'approved' ], 'approved' ],
-            'pending string'         => [ 'pending', 'pending' ],
-            'pending array'          => [ [ 'pending' ], 'pending' ],
-            'unknown reads pending'  => [ 'no', 'pending' ],
-            'all string'             => [ 'all', 'all' ],
-            'approved plus pending'  => [ [ 'approved', 'pending' ], 'all' ],
-            'all plus approved'      => [ [ 'all', 'approved' ], 'all' ],
-            'empty list'             => [ [], 'all' ],
+            'default is approved'   => [ null, 'approved' ],
+            'approved string'       => [ 'approved', 'approved' ],
+            'pending array'         => [ [ 'pending' ], 'pending' ],
+            'unknown reads pending' => [ 'no', 'pending' ],
+            'all string'            => [ 'all', 'all' ],
+            'approved plus pending' => [ [ 'approved', 'pending' ], 'all' ],
+            'all plus approved'     => [ [ 'all', 'approved' ], 'all' ],
+            'empty list'            => [ [], 'all' ],
         ];
     }
 
@@ -83,37 +87,92 @@ class VendorStatusFilterTest extends WP_UnitTestCase {
             'pending'  => [ $this->disabled, $this->flagless ],
             'all'      => [ $this->approved, $this->disabled, $this->flagless ],
         ][ $expected ];
-        sort( $expected_ids );
 
-        $this->assertSame( $expected_ids, $this->ids_for( $status ) );
+        $this->assertEqualSets( $expected_ids, $this->ids_for( $status ) );
         $this->assertSame( count( $expected_ids ), dokan()->vendor->get_total() );
     }
 
-    public function test_pending_filter_is_detached_after_the_query() {
-        $this->ids_for( 'pending' );
+    /**
+     * The bug behind #3321: the Pending tab counted vendors it could not list.
+     */
+    public function test_pending_counter_matches_the_pending_list() {
+        Cache::invalidate_group( 'vendors' );
 
-        $this->assertFalse( has_action( 'pre_user_query', [ dokan()->vendor, 'exclude_approved_vendors' ] ) );
-
-        $query = new WP_User_Query(
+        $listed = dokan()->vendor->get_vendors(
             [
-                'include' => [ $this->approved ],
-                'fields'  => 'ID',
+                'status' => 'pending',
+                'fields' => 'ID',
+                'number' => -1,
             ]
         );
 
-        $this->assertSame( [ $this->approved ], array_map( 'intval', $query->get_results() ) );
+        $counts = dokan_get_seller_status_count();
+
+        $this->assertSame( count( $listed ), $counts['inactive'] );
+        $this->assertSame( count( $listed ), dokan_get_pending_vendor_count() );
+    }
+
+    /**
+     * The clause is welded onto query_where, so it must not outlive the listing that asked for it.
+     */
+    public function test_pending_filter_does_not_outlive_the_query() {
+        $this->ids_for( 'pending' );
+
+        $this->assertEqualSets( [ $this->approved ], $this->unfiltered_ids() );
+    }
+
+    /**
+     * The hook is global while the listing runs, so it must not reach anyone else's query.
+     */
+    public function test_pending_filter_leaves_a_nested_user_query_alone() {
+        $nested = null;
+
+        $spy = function () use ( &$nested, &$spy ) {
+            remove_action( 'pre_user_query', $spy, 5 );
+
+            $nested = $this->unfiltered_ids();
+        };
+
+        add_action( 'pre_user_query', $spy, 5 );
+
+        try {
+            $this->ids_for( 'pending' );
+        } finally {
+            remove_action( 'pre_user_query', $spy, 5 );
+        }
+
+        $this->assertEqualSets( [ $this->approved ], $nested );
+    }
+
+    /**
+     * A throw mid-query must not leave every later user query filtered.
+     */
+    public function test_pending_filter_is_detached_when_the_query_throws() {
+        $boom = static function () {
+            throw new \RuntimeException( 'boom' );
+        };
+
+        add_action( 'pre_user_query', $boom, 20 );
+
+        try {
+            $this->ids_for( 'pending' );
+            $this->fail( 'The query was expected to throw.' );
+        } catch ( \RuntimeException $e ) {
+            $this->assertSame( 'boom', $e->getMessage() );
+        } finally {
+            remove_action( 'pre_user_query', $boom, 20 );
+        }
+
+        $this->assertEqualSets( [ $this->approved ], $this->unfiltered_ids() );
     }
 
     public function test_pending_filter_keeps_caller_meta_query() {
         update_user_meta( $this->disabled, 'dokan_store_name', 'Disabled Shop' );
         update_user_meta( $this->flagless, 'dokan_store_name', 'Flagless Shop' );
 
-        $ids = dokan()->vendor->get_vendors(
+        $ids = $this->ids_for(
+            'pending',
             [
-                'include'    => [ $this->approved, $this->disabled, $this->flagless ],
-                'status'     => 'pending',
-                'fields'     => 'ID',
-                'number'     => -1,
                 'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
                     [
                         'key'     => 'dokan_store_name',
@@ -124,6 +183,29 @@ class VendorStatusFilterTest extends WP_UnitTestCase {
             ]
         );
 
-        $this->assertSame( [ $this->flagless ], array_map( 'intval', $ids ) );
+        $this->assertEqualSets( [ $this->flagless ], $ids );
+    }
+
+    public function test_featured_narrows_the_pending_list() {
+        update_user_meta( $this->flagless, 'dokan_feature_seller', 'yes' );
+
+        $this->assertEqualSets(
+            [ $this->flagless ],
+            $this->ids_for( 'pending', [ 'featured' => 'yes' ] )
+        );
+    }
+
+    /**
+     * The approved fixture through a plain user query: filtered means the pending clause leaked.
+     */
+    protected function unfiltered_ids(): array {
+        $query = new WP_User_Query(
+            [
+                'include' => [ $this->approved ],
+                'fields'  => 'ID',
+            ]
+        );
+
+        return array_map( 'intval', $query->get_results() );
     }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Three code paths defined "pending" three different ways:

| Path | Definition |
|---|---|
| `dokan_get_seller_status_count()` | `all − active`, so a **missing** key counts as pending |
| `UserList::filter_pending_vendors()` | `dokan_enable_selling = 'no'` **OR** `NOT EXISTS` |
| `Vendor\Manager::get_vendors()` | `dokan_enable_selling = 'no'` only |

A vendor that never had the meta written — created before the flag existed, or through a path that doesn't set it — is therefore **counted** as pending but can never be **listed**. The Vendors screen shows a non-zero Pending tab that opens on "No data found".

`get_vendors()` is the odd one out, so it now agrees with the other two. Approved is untouched and still matches `'yes'` exactly.

The `status` argument also gained an explicit whitelist while the two were being reconciled. Only `all`, `approved` and `pending` are understood; asking for both halves (or for `all` outright) means everyone; anything else names no status this listing can filter on and falls back to the listing's own default, `approved`, rather than widening the result. That is the coercion `Abilities\Definitions\VendorsQuery::resolve_status()` already applies to the same three statuses.

### Related Pull Request(s)

* None. `UserList::filter_pending_vendors()` touches the same meta on `pre_get_users` and is fixed separately in #3399.

### Refs

* Refs #3321

Not `Closes`: #3321 reports **All (0), Approved (0), Pending (0)** with "No data found" while a direct REST call returns two stores. This PR fixes a **non-zero** Pending counter that opens onto an empty list — a different failure. The tab counters come from the `X-Status-*` response headers, i.e. `dokan_get_seller_status_count()` over `role__in = [ seller, administrator ]`, so **All can never be 0** while an administrator is looking at the page — the viewing admin is in the result set themselves. The reported screen matches `src/admin/dashboard/pages/vendors.tsx` instead, where `counts` initialises to `{ all: 0, approved: 0, pending: 0 }` and the `catch` in `fetchVendors` resets `data` and `totalItems` but never `counts`: a failed or unauthorised **first** fetch renders exactly three zero tabs and "No data found". That also explains the reporter's healthy-looking manual REST check — an unauthenticated `GET /dokan/v1/stores` returns `200` with rows but **without** the `X-Status-*` headers. Worth asking the reporter for the Vendors screen's own Network entry (status code plus response headers) before closing that issue.

### How to test the changes in this Pull Request

1. Make sure at least one seller has **no** `dokan_enable_selling` user meta at all:
   ```sql
   SELECT u.ID FROM wp_users u
     JOIN wp_usermeta c ON c.user_id = u.ID AND c.meta_key = 'wp_capabilities' AND c.meta_value LIKE '%"seller"%'
     LEFT JOIN wp_usermeta e ON e.user_id = u.ID AND e.meta_key = 'dokan_enable_selling'
    WHERE e.umeta_id IS NULL;
   ```
2. Open **Dokan → Vendors** and click the **Pending** tab.

**Expected:** the tab lists exactly as many vendors as its counter claims. Check the **Approved** and **All** tabs are unchanged.

Worth testing on **both** admin surfaces — the legacy screen (`admin.php?page=dokan#/vendors`) and the new dashboard (`admin.php?page=dokan-dashboard#/vendors`). Both consume the same REST endpoint and both were affected.

For the whitelist, `GET /dokan/v1/stores?status=<anything else>` should now return the approved directory instead of the pending set.

### Changelog entry

**Fixed the Vendors screen's Pending tab counting vendors it could not list**

The Pending tab counted every vendor that was not approved, but listed only the ones explicitly disabled. A vendor carrying no selling flag at all — created before the flag existed, or through a path that never wrote it — was counted but never shown, so the tab opened on "No data found" with a non-zero counter next to it. The listing now reads a missing flag as pending, the same way the counters, the Users screen's "Pending Vendors" filter and `dokan_is_seller_enabled()` already did, so the tab and its counter always agree. An unrecognised `status` on the store listing now returns the approved directory instead of a wider set.

### Test results

On a site with 33 vendors carrying `dokan_enable_selling = 'yes'`, **none** carrying `'no'`, and **9** sellers with no key at all:

```
                                     rows   X-WP-Total   All  Approved  Pending
before  status=(none)                 40        40        40     31        9
        status=approved               31        31        40     31        9
        status=pending                 0         0        40     31        9   <-- counter says 9, list is empty

after   status=(none)                 40        40        40     31        9
        status=approved               31        31        40     31        9
        status=pending                 9         9        40     31        9   <-- agrees
```

Verified in the browser on both surfaces: the Pending tab went from "No data found" / "No vendors found" (0 items) to listing all 9, with All and Approved unchanged. Re-verified after the whitelist change — All (43) / Approved (34) / Pending (9) on both screens, Pending listing 9 rows.

PHPCS on the changed files: 0 errors. `Manager.php` keeps one pre-existing `slow_db_query_meta_query` warning; `functions.php` is at its `develop` warning count.

`VendorStatusFilterTest`: 16 tests, 60 assertions. The nested-listing test fails against `9a5229238`, and the three whitelist cases fail against `75df70e93`.

### Behaviour notes

* **Flagless administrators appear under Pending.** `role__in` defaults to `[ seller, administrator ]` and `dokan_admin_user_register()` only writes `dokan_enable_selling` for the `seller` role, so an administrator who never touched the seller fields has no flag. `dokan_get_seller_status_count()` has counted them as inactive since 2.9.23 and the Users-screen "Pending Vendors" filter (`UserList::filter_pending_vendors()`) already lists them; `get_vendors()` was the one place that did not. This PR makes the Vendors screen agree with the other two rather than carving administrators out of all three — that is a separate decision if anyone wants it.
* **Pro fallout, accepted deliberately:** dokan-pro's `Announcement\Manager` sends the `disabled_seller` announcement to `status => [ 'pending' ]` with no `role__in` override, so a flagless administrator now receives it. Measured on a site with 9 flagless sellers: `disabled_seller` goes from 0 recipients to 10. The same account is already in the `all_seller` audience today (that type asks for `status => [ 'all' ]`, which has always included administrators), so this makes the announcement audiences consistent rather than introducing admins to them. Scoping the vendor announcement types to `role__in => [ 'seller' ]` is a Pro-side change and belongs to all four types, not just this one, so it is left to a Pro follow-up. Labelled `Dependency With Pro`.
* **An unknown status is no longer read as pending.** Before, anything that was not `approved` or `all` meant `dokan_enable_selling = 'no'`; the first cut of this PR carried that forward onto the much wider "everyone not approved" set, and a mix such as `[ 'approved', 'rejected' ]` collapsed to `all`. Both now resolve to `approved`. A genuine mix of the two halves — `[ 'approved', 'pending' ]` — still means everyone, as it did before this PR through the OR meta group. `[ 'all', 'approved' ]` used to collapse to approved-only and now means everyone, which is what it asks for. No caller in Lite or Pro passes a mix or an unknown status.
* **`dokan_get_seller_count()` agrees too.** The admin dashboard's vendor widget takes its inactive figure from `status => 'pending'`, so it now matches the badge as well. That listing is capped at one row, since only the total is read and the pending set is larger than it used to be.
* **The `pre_user_query` callback stays registered** after the first pending listing. It is a no-op for any query without the `dokan_pending_only` var; unhooking it around the query let a nested `get_vendors()` (from inside `pre_get_users`) disarm the outer one. Covered by `test_nested_listing_does_not_disarm_the_pending_filter`.

### Notes for the reviewer

Two adjacent things found while investigating, both left out of this PR:

1. `src/stores/vendors/resolvers.ts` — the `getVendors` resolver fetches `/dokan/v1/stores` and then never dispatches `setVendors()` or clears `setLoading( true )`. This matches the "Source-code observation" in #3321, but that store is not what drives either vendors list (`pages/vendors.tsx` does its own `apiFetch`), so it is dead-code rot rather than the cause. Worth its own issue.
2. The `status` collection param on `GET /dokan/v1/stores` still declares no `enum`. With the whitelist in place an unknown value is coerced to `approved` rather than silently widening, so this is now cosmetic — an `enum` would turn it into a `400` instead. Note the endpoint is `permission_callback => '__return_true'` while `Abilities\Definitions\VendorsQuery::resolve_status()` forces non-Store-Admins to `approved`; the REST controller arguably should do the same. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
