### PR TITLE
fix(admin): show the new-vendor fields on the legacy Add Vendor form

### DIFF
--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -129,7 +129,8 @@ export default {
             requiredFields: [
                 'store_name',
                 'user_login',
-                'email'
+                'email',
+                'user_pass'
             ],
             errors: [],
             storeAvailable: false,

--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -436,6 +436,41 @@ export default {
                         }
                     }
 
+                    .password-field {
+                        position: relative;
+
+                        // Keep the value clear of the reveal control.
+                        .dokan-form-input {
+                            padding-right: 36px;
+                        }
+
+                        .password-toggle {
+                            position: absolute;
+                            top: 6px;
+                            right: 0;
+                            height: 40px;
+                            width: 36px;
+                            padding: 0;
+                            border: 0;
+                            background: none;
+                            cursor: pointer;
+                            color: #82878c;
+
+                            &:hover,
+                            &:focus {
+                                color: #23282d;
+                            }
+
+                            .dashicons {
+                                width: 20px;
+                                height: 20px;
+                                font-size: 20px;
+                                line-height: 20px;
+                                vertical-align: middle;
+                            }
+                        }
+                    }
+
                     .password-generator {
                         margin-top: 6px;
                         // Stands in for an input, so it carries the same bottom rhythm.

--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -478,9 +478,16 @@ export default {
 
                         .regen-button {
                             margin-right: 5px;
+                            // Centre the icon against the label instead of guessing a line-height.
+                            display: inline-flex;
+                            align-items: center;
+                            gap: 4px;
 
-                            span {
-                                line-height: 26px;
+                            .dashicons {
+                                width: 20px;
+                                height: 20px;
+                                font-size: 20px;
+                                line-height: 20px;
                             }
                         }
                     }

--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -402,6 +402,12 @@ export default {
                     content: " ";
                 }
 
+                // Slot-filled groups (Pro fields) share the row model; floats stagger and leave holes.
+                > .form-group {
+                    display: flex;
+                    flex-wrap: wrap;
+                }
+
                 .column {
                     float: left;
                     width: 50%;
@@ -432,6 +438,8 @@ export default {
 
                     .password-generator {
                         margin-top: 6px;
+                        // Stands in for an input, so it carries the same bottom rhythm.
+                        margin-bottom: 16px;
 
                         .regen-button {
                             margin-right: 5px;
@@ -444,6 +452,7 @@ export default {
 
                     .checkbox-left.notify-vendor {
                         margin-top: 6px;
+                        margin-bottom: 16px;
                     }
 
                     .multiselect {

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -96,7 +96,9 @@
 
                 <template v-if="! getId()">
                     <div class="column">
-                        <label for="user-login">{{ __( 'Username', 'dokan-lite') }}</label><span class="required-field">*</span>
+                        <label for="user-login">{{ __( 'Username', 'dokan-lite') }}</label>
+                        <span class="required-field">*</span>
+
                         <input type="text" class="dokan-form-input"
                             id="user-login"
                             v-model="vendorInfo.user_login"

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -258,8 +258,7 @@ export default {
 
         // getId function has been used to identify whether is it vendor edit page or not
         getId() {
-            // Numeric, not a string: the templates read this as "are we editing?", and "0" is truthy.
-            // parseInt still pins it so a crafted route param can't traverse the REST path (XSS, #3290).
+            // Templates read this as "are we editing?" and the string "0" is truthy; parseInt keeps the numeric pin from #3290.
             return parseInt( this.$route.params.id, 10 ) || 0;
         },
 

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -124,13 +124,23 @@
                         <label for="store-password">{{ __( 'Password', 'dokan-lite') }}</label>
                         <span class="required-field">*</span>
 
-                        <input
-                            id="store-password"
-                            type="text"
-                            v-model="vendorInfo.user_pass"
-                            :class="{'dokan-form-input': true, 'has-error': getError('user_pass')}"
-                            :placeholder="getError( 'user_pass' ) ? __( 'Password is required', 'dokan-lite' ) : __( 'Enter password or Generate', 'dokan-lite' )"
-                        >
+                        <div class="password-field">
+                            <input
+                                id="store-password"
+                                :type="passwordVisible ? 'text' : 'password'"
+                                v-model="vendorInfo.user_pass"
+                                :class="{'dokan-form-input': true, 'has-error': getError('user_pass')}"
+                                :placeholder="getError( 'user_pass' ) ? __( 'Password is required', 'dokan-lite' ) : __( 'Enter password or Generate', 'dokan-lite' )"
+                            >
+
+                            <button type="button"
+                                class="password-toggle"
+                                :aria-pressed="passwordVisible ? 'true' : 'false'"
+                                :aria-label="passwordVisible ? __( 'Hide password', 'dokan-lite' ) : __( 'Show password', 'dokan-lite' )"
+                                @click.prevent="passwordVisible = ! passwordVisible">
+                                <span class="dashicons" :class="passwordVisible ? 'dashicons-hidden' : 'dashicons-visibility'"></span>
+                            </button>
+                        </div>
 
                         <password-generator
                             @passwordGenerated="setPassword"
@@ -183,6 +193,8 @@ export default {
     data() {
         return {
             showStoreUrl: true,
+            // The generated password is readable only on request; masking is the resting state.
+            passwordVisible: false,
             otherStoreUrl: null,
             banner: '',
             defaultUrl: dokan.urls.siteUrl + dokan.urls.storePrefix + '/',
@@ -242,6 +254,7 @@ export default {
         // Cancel only drops the generated value; the input stays so a required field is always fillable.
         this.$root.$on( 'passwordCancelled', () => {
             this.vendorInfo.user_pass = '';
+            this.passwordVisible = false;
         } );
     },
 

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -256,8 +256,9 @@ export default {
 
         // getId function has been used to identify whether is it vendor edit page or not
         getId() {
-            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
-            return String( parseInt( this.$route.params.id, 10 ) || 0 );
+            // Numeric, not a string: the templates read this as "are we editing?", and "0" is truthy.
+            // parseInt still pins it so a crafted route param can't traverse the REST path (XSS, #3290).
+            return parseInt( this.$route.params.id, 10 ) || 0;
         },
 
         onSelectBanner( image ) {

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -122,13 +122,14 @@
 
                     <div class="column">
                         <label for="store-password">{{ __( 'Password', 'dokan-lite') }}</label>
+                        <span class="required-field">*</span>
+
                         <input
                             id="store-password"
-                            v-if="showPassword"
                             type="text"
                             v-model="vendorInfo.user_pass"
-                            class="dokan-form-input"
-                            placeholder="********"
+                            :class="{'dokan-form-input': true, 'has-error': getError('user_pass')}"
+                            :placeholder="getError( 'user_pass' ) ? __( 'Password is required', 'dokan-lite' ) : __( 'Enter password or Generate', 'dokan-lite' )"
                         >
 
                         <password-generator
@@ -182,7 +183,6 @@ export default {
     data() {
         return {
             showStoreUrl: true,
-            showPassword: false,
             otherStoreUrl: null,
             banner: '',
             defaultUrl: dokan.urls.siteUrl + dokan.urls.storePrefix + '/',
@@ -239,8 +239,9 @@ export default {
         this.checkStoreName = debounce( this.checkStore, this.delay );
         this.checkUsername = debounce( this.searchUsername, this.delay );
         this.checkEmail = debounce( this.searchEmail, this.delay );
+        // Cancel only drops the generated value; the input stays so a required field is always fillable.
         this.$root.$on( 'passwordCancelled', () => {
-            this.showPassword = false;
+            this.vendorInfo.user_pass = '';
         } );
     },
 
@@ -380,7 +381,6 @@ export default {
         },
 
         setPassword( password ) {
-            this.showPassword = true;
             this.vendorInfo.user_pass = password;
         },
 

--- a/src/admin/pages/VendorPaymentFields.vue
+++ b/src/admin/pages/VendorPaymentFields.vue
@@ -170,8 +170,7 @@ export default {
         },
 
         getId() {
-            // Numeric, not a string: the templates read this as "are we editing?", and "0" is truthy.
-            // parseInt still pins it so a crafted route param can't traverse the REST path (XSS, #3290).
+            // Templates read this as "are we editing?" and the string "0" is truthy; parseInt keeps the numeric pin from #3290.
             return parseInt( this.$route.params.id, 10 ) || 0;
         },
     }

--- a/src/admin/pages/VendorPaymentFields.vue
+++ b/src/admin/pages/VendorPaymentFields.vue
@@ -170,8 +170,9 @@ export default {
         },
 
         getId() {
-            // Pin to a numeric ID so a crafted route param can't traverse the REST path into another endpoint (XSS).
-            return String( parseInt( this.$route.params.id, 10 ) || 0 );
+            // Numeric, not a string: the templates read this as "are we editing?", and "0" is truthy.
+            // parseInt still pins it so a crafted route param can't traverse the REST path (XSS, #3290).
+            return parseInt( this.$route.params.id, 10 ) || 0;
         },
     }
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

**1. The hidden fields (the reported bug)**

`getId()` returned `String( parseInt( this.$route.params.id, 10 ) || 0 )`. On the add-vendor route that is the string `"0"` — and `"0"` is **truthy** in JavaScript, so every template condition that reads it as *"are we editing an existing vendor?"* took the edit branch and hid the fields that only exist when creating one.

Seven conditions across two components were affected:

| Component | Hidden by the bug |
|---|---|
| `VendorAccountFields.vue` | vendor picture, banner upload, store URL, username, password, and both required-field markers |
| `VendorPaymentFields.vue` | the `edit-mode` class and the `column` / `checkbox-group` layout |

Returning the number restores the intended semantics and keeps the numeric pin from #3290 — `parseInt` is what stops a crafted route param traversing the REST path; the `String()` wrapper was incidental to that fix.

```
add route (no :id)      before "0"  -> ! getId() === false   fields hidden
                        after   0   -> ! getId() === true    fields shown
edit route (:id = 42)   before "42" -> ! getId() === false   fields hidden
                        after   42  -> ! getId() === false   unchanged
```

Neither of these two components ever concatenates the route id into a REST path — their only `dokan.api` calls are the three `/stores/check` lookups — so `getId()` there is purely an "am I editing?" flag and the `String()` pin bought nothing. The components that **are** the sinks #3290 was written for keep their pin untouched: `VendorSingle.vue:457` and `ReverseWithdrawalTransactions.vue:229`.

**2. Password is required**

The form always POSTs `user_pass`, so the key is present-but-empty when nobody clicks *Generate Password*. `wp_parse_args` in `Vendor\Manager::create()` therefore never applies its `wp_generate_password()` default, and `wp_insert_user` takes its *"force the password reset flow"* branch (`wp-includes/user.php:2287`) — **every vendor created this way got a blank password plus a WP warning.**

`user_pass` is now in `requiredFields`, matching the React dashboard, whose `dokan-create-vendor-required-fields` has listed it all along. The input is always rendered rather than appearing only after *Generate Password* is clicked — a required field the admin cannot see is the same dead end this PR set out to fix. *Cancel* clears the value instead of hiding the input, which also stops a cancelled password still shipping in the payload.

**3. Form rhythm around the slot fields**

The slot wrapper Pro fills (`.form-group`) is a plain block, so its floated cells staggered instead of pairing — one cell taller than its partner pushed the next out of the left lane and left a hole. It now gets the same flex row model as `.dokan-form-group`, so unequal heights can never open a gap.

The email toggle and the password generator stand in for inputs at the end of their columns but carried no bottom margin, leaving 2–3px before the next row against the form's ~17px rhythm. They now carry the same `margin-bottom` an input does.

### Related Pull Request(s)

* getdokan/dokan-pro#6127 — removes the inline `style="margin-top: 10px"` in Germanized's `VendorTaxFields.vue` that triggered the stagger in the first place. This PR makes the row model resilient; that one removes the trigger.

### Closes

* Closes #3392

### How to test the changes in this Pull Request

1. **Dokan → Vendors → Add New** on the legacy admin screen (`admin.php?page=dokan#/vendors`).
2. Confirm **Vendor Picture**, **Upload Banner**, **Store URL**, **Username** and **Password** are all present, with the markers reading `Store Name *`, `Email *`, `Username *`, `Password *`.
3. Press **Next** with the form empty — `Password is required` should appear in red alongside the other required fields.
4. Click **Generate Password**, then **Cancel** — the input stays and is emptied.
5. Fill the form and create the vendor, then confirm the typed password works (`wp_check_password` against the stored hash).
6. Check the company fields below: **Company Name** and **Company ID/EUID Number** on one baseline, no empty gap, and ~17px of breathing room under the email toggle and the Generate Password button.
7. Open an existing vendor for editing and confirm the create-only fields are still hidden.

### Test results

Verified in the browser on the legacy screen.

* Add: vendor picture with Gravatar link, banner upload, store URL with live `http://…/store/` preview, `Username *`, `Password *` with an always-visible input, the account-email toggle, and `payment-info` without `edit-mode` (PayPal in `checkbox-group`).
* Edit (`#/vendors/2`): create-only fields absent, no required markers, `payment-info edit-mode`, PayPal in `column`.
* End to end: created a vendor with a typed password; `wp_check_password` returns true against the stored hash, so the forced-reset branch is no longer taken.
* Spacing measured in the DOM — gaps went from 3px / 2px to 19px / 18px against a 17px in-form reference.

The **new React dashboard** (`admin.php?page=dokan-dashboard#/vendors/create`) has its own implementation, was checked, and was never affected — it already renders Username, Password and the banner upload. This PR is legacy-only.

### Notes for the reviewer

I also tried moving the "Send the vendor an email" toggle out of the Username cell to close the vertical offset between the two columns, and **backed it out**: `.dokan-form-group` is `display:flex; flex-wrap:wrap` with `.column { width: 50% }`, so cells pair strictly by DOM order and inserting one shifts every pairing below it without fixing the offset. Fixing the missing bottom margins turned out to be the real cause.

The flex row model deliberately lives here rather than in a `<style scoped>` block in the Pro component: `modules/germanized/module.php:183` registers only `script-admin.js` and never a stylesheet, so CSS emitted from that SFC would never be enqueued. Lite owns the grid its slot children sit in.

ESLint's parse errors on these files are pre-existing tooling config, not this change — `develop`'s own copies fail identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XwKvaSv3z32pSu8tBhDQr
