### PR TITLE
ci(phpcs): run on pull requests against the files they change

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,16 +1,10 @@
 on:
-  # Runs once a day only, to keep Actions cost down. Pull requests no longer
-  # trigger this workflow -- it now inspects every PHP file committed to the
-  # default branch in the last 24 hours.
-  # Target start time is 9:00 AM BDT. GitHub queues scheduled runs and releases
-  # them once capacity frees up: on this repository that delay has been roughly
-  # 70 minutes every day, so 02:00 UTC (nominally 8:00 AM BDT) is what actually
-  # starts the run near 9:00 AM BDT. Check the real start times of recent
-  # scheduled runs before "correcting" this to 03:00 UTC.
-  schedule:
-    - cron: 0 2 * * *
-  # workflow can be manually triggered
-  workflow_dispatch:
+  # Every pull request that touches a PHP file, inspecting only the files that
+  # pull request changes. The paths filter keeps frontend-only work from
+  # spending a runner on a job with nothing to check.
+  pull_request:
+    paths:
+      - '**.php'
 
 # Cancels a previous run of this workflow that has not completed.
 concurrency:
@@ -23,11 +17,14 @@ jobs:
     name: Run PHPCS inspection
     runs-on: ubuntu-latest
     steps:
-      # Full history so the 24-hour git log window below can resolve commits.
+      # A pull_request checkout is the merge commit, whose first parent is the
+      # base branch tip and second parent is the pull request head. Depth 2 is
+      # therefore all the history the diff below needs -- full history costs a
+      # clone of the whole repository to answer the same question.
       # The job never pushes, so the checkout token is not kept on disk.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Setup PHP
@@ -51,20 +48,17 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress || composer update --prefer-dist --no-progress
 
-      # PHP files that reached this branch in the last 24 hours. --first-parent
-      # plus --diff-merges=first-parent counts a merge by when it landed, not by
-      # when its commits were originally written, so a pull request merged today
-      # is inspected even when the work inside it is older than the window.
-      # Deleted files are dropped by the -f test, as in the old PR check.
+      # The PHP files this pull request changes: the merge commit against its
+      # first parent, so nothing that merely landed on the base branch in the
+      # meantime is inspected. Deleted files are dropped by the -f test.
       - id: changes
         run: |
-          FILES=$(git log --first-parent --diff-merges=first-parent \
-              --since='24 hours ago' --name-only --pretty=format: -- '*.php' \
+          FILES=$(git diff --name-only HEAD^1 HEAD -- '*.php' \
             | sort -u \
             | while read -r f; do [ -n "$f" ] && [ -f "$f" ] && echo "$f"; done \
             | xargs)
           echo "files=$FILES" >> $GITHUB_OUTPUT
-          echo "PHP files changed in the last 24h: ${FILES:-none}" >> $GITHUB_STEP_SUMMARY
+          echo "PHP files changed by this pull request: ${FILES:-none}" >> $GITHUB_STEP_SUMMARY
 
       - name: Detect coding standard violations
         if: steps.changes.outputs.files != ''


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

PHPCS was schedule-only: a daily cron inspected every PHP file that had reached `develop` in the previous 24 hours. That meant a coding-standards violation was not reported until the day *after* the pull request introducing it had already merged — the check could not block anything, only document it.

This restores the pull request trigger, scoped to the files each pull request actually changes.

#### `on:` — one trigger

```yaml
on:
  pull_request:
    paths:
      - '**.php'
```

The `paths` allowlist means a frontend-only pull request does not spend a runner on a job with nothing to inspect.

`schedule` and `workflow_dispatch` are both removed. Every PHP file reaches this repository through a pull request, so once pull requests are covered the daily sweep only re-inspects what a pull request run already checked.

#### File selection collapses to one command

The 24-hour `git log` window existed only to answer "what did the cron miss". With the cron gone, the question is just "what does this pull request change":

```bash
git diff --name-only HEAD^1 HEAD -- '*.php'
```

A `pull_request` checkout is the merge commit, whose first parent is the base branch tip and second parent is the pull request head. Diffing against the first parent gives this pull request's changes and excludes anything that landed on the base branch meanwhile.

Deleted files are still dropped by the `-f` test, and an empty result still skips the phpcs step through the existing `if: steps.changes.outputs.files != ''` guard.

#### Checkout drops from full history to depth 2

`fetch-depth: 0` was there so the 24-hour window could resolve commits. The diff above reads exactly two commits, so `fetch-depth: 2` is sufficient and avoids cloning the entire repository on every pull request. `persist-credentials: false` is unchanged.

### How to test the changes in this Pull Request:

* This pull request touches no PHP, so the `paths` filter should keep `PHPCS Inspections` from running on it at all — that skip is the first half of the test.
* Push a pull request that edits one PHP file and confirm the run inspects that file only. The job summary prints the selected list (`PHP files changed by this pull request: …`).
* Introduce a deliberate violation in that file and confirm it is annotated inline on the diff via `cs2pr`.

### Changelog entry

*Run PHPCS on pull requests instead of on a daily schedule*

PHPCS previously ran once a day against everything that had landed on `develop` in the previous 24 hours, so violations surfaced only after the offending pull request had merged. It now runs on each pull request that touches a PHP file and inspects only that pull request's changed files, so the feedback arrives while the change is still reviewable. The scheduled and manual-dispatch triggers are removed, and the checkout no longer clones full history.

### Notes for the reviewer

* **Conflicted pull requests are the one gap.** When a pull request has merge conflicts GitHub does not publish a merge ref, and `actions/checkout` falls back to the head commit — `HEAD^1` is then the head's parent rather than the base tip, so the selected file list is wrong. Such a pull request needs rebasing before it can merge anyway, so I did not add a fallback fetch for it.
* The parent-order claim rests on `refs/pull/N/merge` semantics rather than on a local reproduction: the most recent merge on `develop` is a squash commit with a single parent, so it cannot exercise the two-parent case. The first pull request that runs this workflow proves it.
* Removing `workflow_dispatch` means PHPCS can no longer be started by hand from the Actions tab. Say so if that is worth keeping — restoring it costs one line, but the 24-hour selection branch would have to come back with it, since a manual run has no pull request to diff against.
