### PR TITLE
fix(product-editor): show the category the vendor picked, not its parent

### DIFF
--- a/includes/Product/Hooks.php
+++ b/includes/Product/Hooks.php
@@ -36,6 +36,8 @@ class Hooks {
         // Add WooCommerce product brands support.
         add_action( 'dokan_new_product_added', [ $this, 'update_product_brands_by_id' ], 10, 2 );
         add_action( 'dokan_product_updated', [ $this, 'update_product_brands_by_id' ], 10, 2 );
+        // Creating a product has to record its chosen category too, or nothing downstream knows what was picked.
+        add_action( 'dokan_new_product_added', [ $this, 'sync_category_data_for_commission' ] );
         add_action( 'dokan_product_updated', [ $this, 'sync_category_data_for_commission' ] );
         add_action( 'dokan_product_edit_after_pricing_fields', [ $this, 'add_product_brand_template_in_edit_product' ] );
         add_action( 'dokan_new_product_after_product_category', [ $this, 'add_product_brand_template_in_add_product' ] );
@@ -636,7 +638,7 @@ class Hooks {
      *
      * @since 5.0.6
      *
-     * @param int   $product_id   The ID of the product being updated.
+     * @param int   $product_id   The ID of the product being created or updated.
      *
      * @return void
      */

--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -661,8 +661,7 @@ class FormSchema {
                 'variant'          => 'async_select',
                 'placeholder'      => __( 'Select product categories', 'dokan-lite' ),
                 'value'            => [],
-                // Loaded on demand as a nested tree instead of embedding the whole
-                // category hierarchy in the schema, which bloats memory on large catalogs.
+                // Loaded on demand as a nested tree so the whole category hierarchy never bloats the schema on large catalogs.
                 'api_endpoint'     => '/dokan/v1/products/categories/tree',
                 'tree'             => true,
                 // Honor the admin "single vs. multiple" category selection setting.
@@ -679,8 +678,7 @@ class FormSchema {
                 'variant'          => 'async_select',
                 'placeholder'      => 'on' === $can_create_tags ? __( 'Select tags/Add tags', 'dokan-lite' ) : __( 'Select product tags', 'dokan-lite' ),
                 'value'            => [],
-                // Tags load on demand from WooCommerce core (searchable/paginated) instead of
-                // embedding the whole tag taxonomy in the schema, which can exhaust memory on large stores.
+                // Tags load on demand from WooCommerce core (searchable/paginated) so the whole tag taxonomy never bloats the schema on large stores.
                 'api_endpoint'     => '/wc/v3/products/tags',
                 'creatable'        => 'on' === $can_create_tags,
                 'visibility'       => true,
@@ -1170,12 +1168,10 @@ class FormSchema {
                     $chosen_categories = array_slice( $chosen_categories, 0, 1 );
                 }
 
-                // Async select expects [ { value, label }, ... ] so selected categories render
-                // without the full category tree being embedded in the schema.
+                // Async select expects [ { value, label }, ... ] so selections render without embedding the whole tree.
                 return self::terms_to_async_options( $chosen_categories, 'product_cat' );
             case Elements::TAGS:
-                // Async select expects [ { value, label }, ... ] so selected tags render
-                // without the full tag list being embedded in the schema.
+                // Async select expects [ { value, label }, ... ] so selections render without embedding the whole tag list.
                 return self::terms_to_async_options( $product->get_tag_ids(), 'product_tag' );
             case Elements::BRANDS:
                 if ( method_exists( $product, 'get_brand_ids' ) ) {

--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -1161,20 +1161,18 @@ class FormSchema {
                 $chosen_categories = ProductCategoryHelper::get_product_chosen_category( $product );
 
                 if ( empty( $chosen_categories ) ) {
-                    // Products saved outside Dokan recorded no selection, so fall back to the deepest term of each branch.
+                    // Products saved outside Dokan recorded no selection, so fall back to the deepest term of each branch (not get_saved_products_category(), which self-heals by writing terms and a read must not).
                     $chosen_categories = ProductCategoryHelper::generate_chosen_categories( $product->get_category_ids() );
+                }
+
+                // Single-category stores keep one selection; narrow before building options, because terms_to_async_options() re-sorts by name and slicing after it would surface the alphabetically-first category rather than the one the vendor picked.
+                if ( ProductCategoryHelper::product_category_selection_is_single() ) {
+                    $chosen_categories = array_slice( $chosen_categories, 0, 1 );
                 }
 
                 // Async select expects [ { value, label }, ... ] so selected categories render
                 // without the full category tree being embedded in the schema.
-                $category_options = self::terms_to_async_options( $chosen_categories, 'product_cat' );
-
-                // Single-category stores keep one selection; surface only the first chosen term.
-                if ( ProductCategoryHelper::product_category_selection_is_single() ) {
-                    return array_slice( $category_options, 0, 1 );
-                }
-
-                return $category_options;
+                return self::terms_to_async_options( $chosen_categories, 'product_cat' );
             case Elements::TAGS:
                 // Async select expects [ { value, label }, ... ] so selected tags render
                 // without the full tag list being embedded in the schema.

--- a/includes/ProductEditor/FormSchema.php
+++ b/includes/ProductEditor/FormSchema.php
@@ -1157,11 +1157,19 @@ class FormSchema {
                 $to = $product->get_date_on_sale_to( 'edit' );
                 return $to ? $to->date( 'Y-m-d' ) : '';
             case Elements::CATEGORIES:
+                // The term list carries every ancestor of the picked category, so read back what the vendor chose.
+                $chosen_categories = ProductCategoryHelper::get_product_chosen_category( $product );
+
+                if ( empty( $chosen_categories ) ) {
+                    // Products saved outside Dokan recorded no selection, so fall back to the deepest term of each branch.
+                    $chosen_categories = ProductCategoryHelper::generate_chosen_categories( $product->get_category_ids() );
+                }
+
                 // Async select expects [ { value, label }, ... ] so selected categories render
                 // without the full category tree being embedded in the schema.
-                $category_options = self::terms_to_async_options( $product->get_category_ids(), 'product_cat' );
+                $category_options = self::terms_to_async_options( $chosen_categories, 'product_cat' );
 
-                // Single-category stores keep one selection; surface only the first saved term.
+                // Single-category stores keep one selection; surface only the first chosen term.
                 if ( ProductCategoryHelper::product_category_selection_is_single() ) {
                     return array_slice( $category_options, 0, 1 );
                 }

--- a/tests/php/src/REST/ProductEditorCategoryFieldTest.php
+++ b/tests/php/src/REST/ProductEditorCategoryFieldTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace WeDevs\Dokan\Test\REST;
+
+use WeDevs\Dokan\ProductCategory\Helper as ProductCategoryHelper;
+use WeDevs\Dokan\ProductEditor\Elements;
+use WeDevs\Dokan\REST\ProductControllerV3;
+use WeDevs\Dokan\Test\DokanTestCase;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * The product editor's Categories field reflects the category the vendor picked.
+ *
+ * Covers getdokan/dokan-pro#6129: a product carries every ancestor of the picked category as a
+ * term, so a field populated from the raw term list showed the top-level parent instead of the
+ * child, and the next save wrote that parent back over the vendor's choice.
+ *
+ * @group dokan-product-controller-v3
+ * @group dokan-product-editor
+ *
+ * @covers \WeDevs\Dokan\ProductEditor\FormSchema::resolve_field_value
+ * @covers \WeDevs\Dokan\Product\Hooks::sync_category_data_for_commission
+ */
+class ProductEditorCategoryFieldTest extends DokanTestCase {
+
+    /**
+     * REST namespace for this controller.
+     *
+     * @var string
+     */
+    protected $namespace = 'dokan/v3';
+
+    /**
+     * Top-level category.
+     *
+     * @var int
+     */
+    protected int $parent_id;
+
+    /**
+     * Child of the top-level category.
+     *
+     * @var int
+     */
+    protected int $child_id;
+
+    /**
+     * Grandchild the vendor picks in these tests.
+     *
+     * @var int
+     */
+    protected int $grandchild_id;
+
+    /**
+     * Product owned by the acting vendor.
+     *
+     * @var int
+     */
+    protected int $product_id;
+
+    /**
+     * Setup test environment.
+     *
+     * @return void
+     */
+    public function set_up() {
+        parent::set_up();
+
+        $controller = new ProductControllerV3();
+        $controller->register_routes();
+
+        // register_routes() only arms the payload resolver once per process, and WordPress restores
+        // hooks between tests, so re-add it here to keep every test on the editor's real save path.
+        add_filter( 'rest_pre_dispatch', [ $controller, 'resolve_product_payload_before_validation' ], 1, 3 );
+
+        // Names run parent < grandchild < child alphabetically, so a field that reads the raw term
+        // list cannot accidentally land on the picked category through ordering.
+        $this->parent_id     = $this->create_category( 'aaa-gadgets' );
+        $this->child_id      = $this->create_category( 'zzz-wearables', $this->parent_id );
+        $this->grandchild_id = $this->create_category( 'mmm-smartwatches', $this->child_id );
+
+        $this->set_category_style( 'single' );
+
+        $this->product_id = $this->factory()->product
+            ->set_seller_id( $this->seller_id1 )
+            ->create(
+                [
+					'name'          => 'Categorised Product',
+					'regular_price' => '10',
+				]
+            );
+
+        wp_set_current_user( $this->seller_id1 );
+    }
+
+    /**
+     * Create a product category.
+     *
+     * @param string $name      Category name.
+     * @param int    $parent_id Parent category id.
+     *
+     * @return int
+     */
+    protected function create_category( string $name, int $parent_id = 0 ): int {
+        $term = wp_insert_term( $name, 'product_cat', [ 'parent' => $parent_id ] );
+
+        return (int) $term['term_id'];
+    }
+
+    /**
+     * Set the admin "single vs. multiple" category selection setting.
+     *
+     * @param string $style Either 'single' or 'multiple'.
+     *
+     * @return void
+     */
+    protected function set_category_style( string $style ): void {
+        $settings                           = get_option( 'dokan_selling', [] );
+        $settings['product_category_style'] = $style;
+
+        update_option( 'dokan_selling', $settings );
+    }
+
+    /**
+     * Dispatch a JSON request, the way the product form does.
+     *
+     * @param string $method HTTP method.
+     * @param string $route  Route below the namespace.
+     * @param array  $body   Request payload.
+     *
+     * @return WP_REST_Response
+     */
+    protected function json_request( string $method, string $route, array $body ): WP_REST_Response {
+        $request = new WP_REST_Request( $method, $this->get_route( $route ) );
+        $request->add_header( 'Content-Type', 'application/json' );
+        $request->set_body( wp_json_encode( $body ) );
+
+        return $this->server->dispatch( $request );
+    }
+
+    /**
+     * Save the product with the given categories, the way the editor does.
+     *
+     * @param array $category_ids Categories the vendor picked.
+     *
+     * @return WP_REST_Response
+     */
+    protected function save_categories( array $category_ids ): WP_REST_Response {
+        return $this->json_request( 'PUT', '/products/' . $this->product_id, [ Elements::CATEGORIES => $category_ids ] );
+    }
+
+    /**
+     * Read the Categories field back out of the editor's form schema.
+     *
+     * @param int|null $product_id Product to read, defaults to the test product.
+     *
+     * @return array Term ids the field is populated with.
+     */
+    protected function get_field_category_ids( ?int $product_id = null ): array {
+        $product_id = $product_id ?? $this->product_id;
+
+        $request = new WP_REST_Request( 'GET', $this->get_route( '/products/' . $product_id . '/fields' ) );
+        $request->set_param( 'id', $product_id );
+
+        $data = $this->server->dispatch( $request )->get_data();
+
+        foreach ( $data['form_items'] ?? [] as $item ) {
+            if ( Elements::CATEGORIES === ( $item['id'] ?? '' ) ) {
+                return wp_list_pluck( (array) ( $item['value'] ?? [] ), 'value' );
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * The categories currently stored on the test product.
+     *
+     * @return array
+     */
+    protected function get_stored_term_ids(): array {
+        $terms = wp_get_post_terms( $this->product_id, 'product_cat', [ 'fields' => 'ids' ] );
+
+        sort( $terms );
+
+        return array_map( 'absint', $terms );
+    }
+
+    /**
+     * Saving a grandchild stores the whole chain but keeps the grandchild as the chosen category.
+     *
+     * @return void
+     */
+    public function test_saving_a_grandchild_keeps_it_as_the_chosen_category(): void {
+        $this->save_categories( [ $this->grandchild_id ] );
+
+        $expected_chain = [ $this->parent_id, $this->child_id, $this->grandchild_id ];
+        sort( $expected_chain );
+
+        $this->assertSame( $expected_chain, $this->get_stored_term_ids(), 'The ancestor chain must stay on the product.' );
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            array_values( ProductCategoryHelper::get_product_chosen_category( $this->product_id ) ),
+            'The picked grandchild must be the chosen category.'
+        );
+    }
+
+    /**
+     * The editor field shows the picked grandchild, not its top-level ancestor.
+     *
+     * @return void
+     */
+    public function test_field_shows_the_picked_child_not_its_ancestor(): void {
+        $this->save_categories( [ $this->grandchild_id ] );
+
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            $this->get_field_category_ids(),
+            'The field must show the category the vendor picked.'
+        );
+    }
+
+    /**
+     * Re-saving whatever the field shows leaves the vendor's choice intact.
+     *
+     * @return void
+     */
+    public function test_resaving_the_field_value_does_not_overwrite_the_choice(): void {
+        $this->save_categories( [ $this->grandchild_id ] );
+
+        // A vendor who reopens the product and edits something unrelated sends the field back as-is.
+        $this->save_categories( $this->get_field_category_ids() );
+
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            $this->get_field_category_ids(),
+            'Re-saving the form must not walk the selection up to the parent.'
+        );
+    }
+
+    /**
+     * With multiple selection on, the field lists the picked categories only.
+     *
+     * @return void
+     */
+    public function test_multiple_selection_lists_chosen_categories_without_ancestors(): void {
+        $this->set_category_style( 'multiple' );
+
+        $unrelated_id = $this->create_category( 'bbb-apparel' );
+
+        $this->save_categories( [ $this->grandchild_id, $unrelated_id ] );
+
+        $shown = $this->get_field_category_ids();
+        sort( $shown );
+
+        $expected = [ $this->grandchild_id, $unrelated_id ];
+        sort( $expected );
+
+        $this->assertSame( $expected, $shown, 'Only the picked categories belong in the field.' );
+    }
+
+    /**
+     * A product that never recorded a selection falls back to the deepest term of its branch.
+     *
+     * @return void
+     */
+    public function test_product_without_a_recorded_selection_falls_back_to_the_deepest_term(): void {
+        wp_set_object_terms( $this->product_id, [ $this->parent_id, $this->child_id, $this->grandchild_id ], 'product_cat' );
+        delete_post_meta( $this->product_id, 'chosen_product_cat' );
+
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            $this->get_field_category_ids(),
+            'Products saved outside Dokan must still resolve to the most specific category.'
+        );
+    }
+
+    /**
+     * Creating a product records the chosen category the same way updating one does.
+     *
+     * @return void
+     */
+    public function test_create_records_the_chosen_category_like_update_does(): void {
+        $response = $this->json_request(
+            'POST',
+            '/products',
+            [
+                'name'               => 'Created Product',
+                'regular_price'      => '10',
+                'description'        => 'Created through the editor.',
+                Elements::CATEGORIES => [ $this->grandchild_id ],
+            ]
+        );
+
+        $this->assertSame( 201, $response->get_status(), 'The product must be created.' );
+
+        $created_id = (int) $response->get_data()['id'];
+
+        $expected_chain = [ $this->parent_id, $this->child_id, $this->grandchild_id ];
+        sort( $expected_chain );
+
+        $stored = array_map( 'absint', wp_get_post_terms( $created_id, 'product_cat', [ 'fields' => 'ids' ] ) );
+        sort( $stored );
+
+        $this->assertSame( $expected_chain, $stored, 'A created product must carry the ancestor chain too.' );
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            array_values( ProductCategoryHelper::get_product_chosen_category( $created_id ) ),
+            'A created product must record its chosen category.'
+        );
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            $this->get_field_category_ids( $created_id ),
+            'The editor must show the created product the category it was given.'
+        );
+    }
+}

--- a/tests/php/src/REST/ProductEditorCategoryFieldTest.php
+++ b/tests/php/src/REST/ProductEditorCategoryFieldTest.php
@@ -70,12 +70,10 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
         $controller = new ProductControllerV3();
         $controller->register_routes();
 
-        // register_routes() only arms the payload resolver once per process, and WordPress restores
-        // hooks between tests, so re-add it here to keep every test on the editor's real save path.
+        // register_routes() arms the payload resolver only once per process, so re-add it here since WordPress restores hooks between tests.
         add_filter( 'rest_pre_dispatch', [ $controller, 'resolve_product_payload_before_validation' ], 1, 3 );
 
-        // Names run parent < grandchild < child alphabetically, so a field that reads the raw term
-        // list cannot accidentally land on the picked category through ordering.
+        // Names sort parent < grandchild < child, so a field reading the raw term list cannot land on the picked category by ordering.
         $this->parent_id     = $this->create_category( 'aaa-gadgets' );
         $this->child_id      = $this->create_category( 'zzz-wearables', $this->parent_id );
         $this->grandchild_id = $this->create_category( 'mmm-smartwatches', $this->child_id );
@@ -240,8 +238,7 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
     public function test_resaving_the_field_value_does_not_overwrite_the_choice(): void {
         $this->save_categories( [ $this->grandchild_id ] );
 
-        // A vendor who reopens the product and edits something unrelated sends the field back as-is:
-        // the async select posts whole option objects, not bare ids, so exercise that round trip.
+        // A reopened form posts whole option objects back, not bare ids, so exercise that round trip.
         $this->save_categories( $this->get_field_category_value() );
 
         $this->assertSame(

--- a/tests/php/src/REST/ProductEditorCategoryFieldTest.php
+++ b/tests/php/src/REST/ProductEditorCategoryFieldTest.php
@@ -86,9 +86,9 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
             ->set_seller_id( $this->seller_id1 )
             ->create(
                 [
-					'name'          => 'Categorised Product',
-					'regular_price' => '10',
-				]
+                    'name'          => 'Categorised Product',
+                    'regular_price' => '10',
+                ]
             );
 
         wp_set_current_user( $this->seller_id1 );
@@ -158,6 +158,17 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
      * @return array Term ids the field is populated with.
      */
     protected function get_field_category_ids( ?int $product_id = null ): array {
+        return wp_list_pluck( $this->get_field_category_value( $product_id ), 'value' );
+    }
+
+    /**
+     * Read the raw Categories field value, the async-select option objects the editor renders.
+     *
+     * @param int|null $product_id Product to read, defaults to the test product.
+     *
+     * @return array Option objects: [ { value, label }, ... ].
+     */
+    protected function get_field_category_value( ?int $product_id = null ): array {
         $product_id = $product_id ?? $this->product_id;
 
         $request = new WP_REST_Request( 'GET', $this->get_route( '/products/' . $product_id . '/fields' ) );
@@ -167,7 +178,7 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
 
         foreach ( $data['form_items'] ?? [] as $item ) {
             if ( Elements::CATEGORIES === ( $item['id'] ?? '' ) ) {
-                return wp_list_pluck( (array) ( $item['value'] ?? [] ), 'value' );
+                return array_values( (array) ( $item['value'] ?? [] ) );
             }
         }
 
@@ -229,13 +240,40 @@ class ProductEditorCategoryFieldTest extends DokanTestCase {
     public function test_resaving_the_field_value_does_not_overwrite_the_choice(): void {
         $this->save_categories( [ $this->grandchild_id ] );
 
-        // A vendor who reopens the product and edits something unrelated sends the field back as-is.
-        $this->save_categories( $this->get_field_category_ids() );
+        // A vendor who reopens the product and edits something unrelated sends the field back as-is:
+        // the async select posts whole option objects, not bare ids, so exercise that round trip.
+        $this->save_categories( $this->get_field_category_value() );
 
         $this->assertSame(
             [ $this->grandchild_id ],
             $this->get_field_category_ids(),
             'Re-saving the form must not walk the selection up to the parent.'
+        );
+    }
+
+    /**
+     * Single mode surfaces the first chosen category, not whichever sorts first by name.
+     *
+     * A product can carry more than one chosen category — a store switched from multiple to single,
+     * or terms spanning two branches — and the field must not let the name sort decide the winner.
+     *
+     * @return void
+     */
+    public function test_single_mode_keeps_the_first_chosen_id_regardless_of_name_order(): void {
+        // 'bbb-apparel' sorts before the grandchild 'mmm-smartwatches', so a name-sorted read would pick it.
+        $unrelated_id = $this->create_category( 'bbb-apparel' );
+
+        wp_set_object_terms(
+            $this->product_id,
+            [ $this->parent_id, $this->child_id, $this->grandchild_id, $unrelated_id ],
+            'product_cat'
+        );
+        update_post_meta( $this->product_id, 'chosen_product_cat', [ $this->grandchild_id, $unrelated_id ] );
+
+        $this->assertSame(
+            [ $this->grandchild_id ],
+            $this->get_field_category_ids(),
+            'Single mode must keep the first chosen category, not the one that sorts first by name.'
         );
     }
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

The new product editor discarded a vendor's sub-category and showed the top-level parent instead. Two things were wrong, both in Lite.

**1. The field read the wrong source (`includes/ProductEditor/FormSchema.php`)**

A Dokan product deliberately carries *every ancestor* of the picked category as a `product_cat` term, so the storefront can browse by parent. `resolve_field_value()` populated the Categories field from that raw term list:

```php
$category_options = self::terms_to_async_options( $product->get_category_ids(), 'product_cat' );

if ( ProductCategoryHelper::product_category_selection_is_single() ) {
    return array_slice( $category_options, 0, 1 );
}
```

`terms_to_async_options()` sorts by `name ASC`, so the slice lands on whichever *ancestor* sorts first — never reliably the category the vendor picked. That is why the reporter saw `gadgets` even when the child was listed first in the term array.

The storage was never wrong: `chosen_product_cat` held the picked category correctly the whole time. So the field now reads that instead, and falls back to `generate_chosen_categories()` (deepest term per branch) for products saved outside Dokan that never recorded a selection.

This also corrects **multiple**-select stores, which were listing ancestors the vendor never chose.

**2. Create and update disagreed (`includes/Product/Hooks.php`)**

`sync_category_data_for_commission()` was hooked only on `dokan_product_updated`. A product created through `POST /dokan/v3/products` therefore recorded no chosen category and got no ancestor chain, while the very same payload sent as an update did both:

```
POST /dokan/v3/products  category_ids: [smartwatches]  -> terms [smartwatches],                    chosen_product_cat: (unset)
PUT  /dokan/v3/products/N category_ids: [smartwatches]  -> terms [gadgets, wearables, smartwatches], chosen_product_cat: [smartwatches]
```

Hooking `dokan_new_product_added` as well makes creation behave like an edit. This is the concrete half of the issue's "make the routes agree"; the ancestor-chain storage itself is intentional and is left alone.

**3. Single mode read the wrong term out of the chosen set (`includes/ProductEditor/FormSchema.php`)**

The single-select branch sliced the option list *after* `terms_to_async_options()` re-sorts it by name, so a product carrying more than one chosen category — a store switched from multiple to single, or terms spanning two branches — surfaced the alphabetically-first category rather than the one the vendor picked. That is the same name-sort defect as (1), one layer down. The chosen ids are now narrowed *before* the options are built, matching the legacy editor's `[ reset( $chosen_cat ) ]`.

### Related Pull Request(s)

* None — Pro needs no change. Nothing in `dokan-pro` overrides this field or its save path.

### Closes

* Closes getdokan/dokan-pro#6129

### How to test the changes in this Pull Request:

1. Create a nested tree, e.g. `gadgets -> wearables -> smartwatches`.
2. Dokan -> Settings -> Appearance -> **Vendor Product Editor = Latest**; Selling -> **Category style = single**.
3. As a vendor, edit a product in the new editor, pick the grandchild `smartwatches`, fill Title/Price/Description, click **Update Product**.
4. Reload the product.
   * **Expected (this PR):** the field still shows `smartwatches`.
   * **On `develop`:** it shows `gadgets`.
5. Click **Update Product** again without changing anything, reload once more — the sub-category must survive (on `develop` it is now permanently `gadgets`).
6. Set **Category style = multiple** and confirm the field lists only the picked categories, not their ancestors.
7. Multi-chosen single mode: give a product two chosen categories (e.g. save `smartwatches` **and** a top-level `kitchen` under **Category style = multiple**), switch back to **single**, reload the editor. The field must show `smartwatches` (the first picked), not `kitchen` (which merely sorts first by name).

Automated coverage: `tests/php/src/REST/ProductEditorCategoryFieldTest.php` (7 tests, incl. a regression test for the single-mode name-sort in (3) that fails on the first commit). Full Lite suite: `OK (443 tests)` on PHP 8.3.

### Changelog entry

*Fix: the new product editor reverted a selected sub-category to its top-level parent*

**Previous behaviour** — after a vendor picked a child category and saved, reopening the product in the 5.0 editor showed the top-level ancestor instead. Because the field is single-select, the next save wrote that parent back, so a vendor who reopened the product and edited anything unrelated silently lost the sub-category. Marketplaces organised by sub-category ended up with products collected at the top level, affecting storefront browsing and any category-based commission or restriction rules. With multiple selection the field also listed ancestors the vendor never chose. Separately, a product created through `dokan/v3` recorded no chosen category at all, so create and update produced different data for the same vendor action.

**New behaviour** — the Categories field shows exactly what the vendor picked, in both single and multiple mode, and re-saving the form no longer overwrites it. Products saved outside Dokan resolve to the most specific category of their branch. Creating a product now records its chosen category and ancestor chain the same way editing one does.

### Before Changes

Product stores `chosen_product_cat = smartwatches`; terms are the full chain `[gadgets, wearables, smartwatches]`. The editor's Categories field renders **`gadgets`**.

### After Changes

Same product, same data — the field renders **`smartwatches`**, with only `smartwatches` ticked in the category tree. Verified in the browser by swapping only `FormSchema.php` between the two page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFhWbDeWfYzgPjgXkGNCv8

