### PR TITLE
fix(admin): let the Status and Pro Features scripts load their translations

### DIFF
--- a/includes/Admin/Dashboard/Pages/ProFeatures.php
+++ b/includes/Admin/Dashboard/Pages/ProFeatures.php
@@ -115,6 +115,8 @@ class ProFeatures extends AbstractPage {
             ]
         );
 
+        wp_set_script_translations( 'dokan-pro-features', 'dokan-lite' );
+
         wp_register_style( 'dokan-pro-features', DOKAN_PLUGIN_ASSEST . '/css/dokan-pro-features.css', [], $asset_file['version'] );
     }
 }

--- a/includes/Admin/Dashboard/Pages/Status.php
+++ b/includes/Admin/Dashboard/Pages/Status.php
@@ -73,5 +73,7 @@ class Status extends AbstractPage {
                 'in_footer' => true,
             ]
         );
+
+        wp_set_script_translations( 'dokan-status', 'dokan-lite' );
     }
 }

--- a/src/ProFeatures/components/DokanMarketplaceUI.tsx
+++ b/src/ProFeatures/components/DokanMarketplaceUI.tsx
@@ -329,7 +329,7 @@ function DokanMarketplaceUI() {
                                 ? 'border-[#7C3AED] bg-white text-[#7C3AED] hover:bg-[#7C3AED] hover:text-white cursor-pointer'
                                 : 'border-gray-300 bg-white text-gray-400 cursor-not-allowed'
                         }` }
-                        aria-label="Scroll left"
+                        aria-label={ __( 'Scroll left', 'dokan-lite' ) }
                     >
                         <span className="text-lg font-bold">
                             <ChevronLeft />
@@ -343,7 +343,7 @@ function DokanMarketplaceUI() {
                                 ? 'border-[#7C3AED] bg-white text-[#7C3AED] hover:bg-[#7C3AED] hover:text-white cursor-pointer'
                                 : 'border-gray-300 bg-white text-gray-400 cursor-not-allowed'
                         }` }
-                        aria-label="Scroll right"
+                        aria-label={ __( 'Scroll right', 'dokan-lite' ) }
                     >
                         <span className="text-lg font-bold">
                             <ChevronRight />

--- a/src/ProFeatures/components/FeaturesSlider.tsx
+++ b/src/ProFeatures/components/FeaturesSlider.tsx
@@ -130,7 +130,10 @@ function FeaturesSlider() {
         <div>
             <div className="flex justify-between items-center mb-6">
                 <h3 className="font-bold text-2xl leading-[130%] tracking-normal">
-                    Curated Features for Your Thriving Marketplace
+                    { __(
+                        'Curated Features for Your Thriving Marketplace',
+                        'dokan-lite'
+                    ) }
                 </h3>
                 <div className="flex space-x-2">
                     <button
@@ -141,7 +144,7 @@ function FeaturesSlider() {
                                 ? 'border-[#7C3AED] bg-white text-[#7C3AED] hover:bg-[#7C3AED] hover:text-white cursor-pointer'
                                 : 'border-gray-300 bg-gray-100 text-gray-400 cursor-not-allowed opacity-50'
                         }` }
-                        aria-label="Scroll left"
+                        aria-label={ __( 'Scroll left', 'dokan-lite' ) }
                     >
                         <span className="text-lg font-bold">
                             <ChevronLeft />
@@ -155,7 +158,7 @@ function FeaturesSlider() {
                                 ? 'border-[#7C3AED] bg-white text-[#7C3AED] hover:bg-[#7C3AED] hover:text-white cursor-pointer'
                                 : 'border-gray-300 bg-gray-100 text-gray-400 cursor-not-allowed opacity-50'
                         }` }
-                        aria-label="Scroll right"
+                        aria-label={ __( 'Scroll right', 'dokan-lite' ) }
                     >
                         <span className="text-lg font-bold">
                             <ChevronRight />

--- a/src/Status/Tab.tsx
+++ b/src/Status/Tab.tsx
@@ -47,7 +47,7 @@ const Tab = ( {
                     <div className="border-b border-gray-200">
                         <nav
                             className="-mb-px flex space-x-8"
-                            aria-label="Tabs"
+                            aria-label={ __( 'Tabs', 'dokan-lite' ) }
                         >
                             { tabs.map( ( tab ) => {
                                 return (

--- a/tests/php/src/Admin/AdminDashboardScriptTranslationsTest.php
+++ b/tests/php/src/Admin/AdminDashboardScriptTranslationsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin;
+
+use WeDevs\Dokan\Admin\Dashboard\Pages\ProFeatures;
+use WeDevs\Dokan\Admin\Dashboard\Pages\Status;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Admin dashboard page scripts carry a text domain, so their JS strings can localize.
+ *
+ * Covers getdokan/dokan-pro#6131: `dokan-status` and `dokan-pro-features` were registered
+ * without wp_set_script_translations(), so WordPress never loaded their translation JSON
+ * and every string in those bundles stayed English no matter what the locale was.
+ *
+ * @group dokan-admin-dashboard
+ *
+ * @covers \WeDevs\Dokan\Admin\Dashboard\Pages\Status::register
+ * @covers \WeDevs\Dokan\Admin\Dashboard\Pages\ProFeatures::register
+ */
+class AdminDashboardScriptTranslationsTest extends DokanTestCase {
+
+    /**
+     * Text domain every Lite script translates against.
+     */
+    const TEXT_DOMAIN = 'dokan-lite';
+
+    /**
+     * Assert a registered script is set up for JS translations.
+     *
+     * @param string $handle Script handle.
+     *
+     * @return void
+     */
+    protected function assertScriptIsTranslatable( string $handle ): void {
+        $script = wp_scripts()->registered[ $handle ] ?? null;
+
+        $this->assertNotNull( $script, sprintf( 'The %s script must be registered.', $handle ) );
+        $this->assertSame(
+            self::TEXT_DOMAIN,
+            $script->textdomain ?? '',
+            sprintf( 'The %s script must declare a text domain, or its JS strings cannot localize.', $handle )
+        );
+        $this->assertContains(
+            'wp-i18n',
+            (array) $script->deps,
+            sprintf( 'The %s script must depend on wp-i18n so the translation data has somewhere to land.', $handle )
+        );
+    }
+
+    /**
+     * The Status page script can load translations.
+     *
+     * @return void
+     */
+    public function test_status_script_is_translatable(): void {
+        ( new Status() )->register();
+
+        $this->assertScriptIsTranslatable( 'dokan-status' );
+    }
+
+    /**
+     * The Pro Features page script can load translations.
+     *
+     * @return void
+     */
+    public function test_pro_features_script_is_translatable(): void {
+        if ( dokan()->is_pro_exists() ) {
+            $this->markTestSkipped( 'The Pro Features page only registers its script when Dokan Pro is absent.' );
+        }
+
+        ( new ProFeatures() )->register();
+
+        $this->assertScriptIsTranslatable( 'dokan-pro-features' );
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

**1. The two page scripts never declared a text domain**

`Status::register()` and `ProFeatures::register()` called `wp_register_script()` and stopped there. Without `wp_set_script_translations()` WordPress never runs the JSON lookup for that handle, so `wp.i18n` has no locale data and every `__()` in those bundles returns the English source string — even with a complete catalog installed.

This is only true of these two. Their siblings in the same subsystem (`dokan-admin-dashboard`, `dokan-admin-panel-header`, `dokan-admin-setup-guide`) have declared `dokan-lite` since 4.0, which is why the rest of the admin dashboard localizes and these two pages silently do not.

```php
wp_set_script_translations( 'dokan-status', 'dokan-lite' );
wp_set_script_translations( 'dokan-pro-features', 'dokan-lite' );
```

Two arguments, matching `Dashboard.php`: with no path, WordPress resolves the plugin's own `languages/` directory from the text domain registry and then falls back to `WP_LANG_DIR/plugins`, so both a bundled catalog and a WPML/Loco-generated one are found.

**2. Strings that could not be translated even in principle**

The Pro Features slider heading was hard-coded, so it never reached the catalog at all:

```diff
-    Curated Features for Your Thriving Marketplace
+    { __( 'Curated Features for Your Thriving Marketplace', 'dokan-lite' ) }
```

Five `aria-label` attributes in the same two bundles had the same problem — `Scroll left` / `Scroll right` in `FeaturesSlider` and `DokanMarketplaceUI`, and `Tabs` in the Status tab nav. These are what a screen reader announces, so they are user-facing text; wrapped them alongside the reported string rather than leaving the same defect in the same files.

`__` was already imported in all three components.

**Note on the .pot:** `npm run makepot` scans the compiled `assets/js` bundles, and the release build runs it. The new strings enter `languages/dokan-lite.pot` there, so this PR does not carry a regenerated catalog.

### Related Pull Request(s)

* None — both files live in Dokan Lite.

### Closes

* Closes getdokan/dokan-pro#6131

### How to test the changes in this Pull Request:

1. Set your admin user's language to any non-English locale (Users → Profile → Language).
2. Drop a script translation for the Status bundle at
   `wp-content/languages/plugins/dokan-lite-<locale>-<md5 of "assets/js/dokan-status.js">.json`
   containing a `locale_data.messages` entry for `"Status"`.
3. Open **Dokan → Dashboard → Status** (`admin.php?page=dokan-dashboard#/status`).
   * **Expected (this PR):** the heading renders your translation.
   * **On `develop`:** it renders `Status`, and no `dokan-status-js-translations` inline script is emitted at all.
4. For the Pro Features page, deactivate Dokan Pro (the page only registers its script when Pro is absent), repeat with the `assets/js/dokan-pro-features.js` md5, and check the slider heading.

Automated coverage: `tests/php/src/Admin/AdminDashboardScriptTranslationsTest.php` asserts both handles register with the `dokan-lite` text domain and a `wp-i18n` dependency. Both tests fail on `develop`. Full Lite suite: `OK (439 tests, 1603 assertions)`.

### Changelog entry

*Fix: admin Status and Pro Features pages ignored JavaScript translations*

**Previous behaviour** — the `dokan-status` and `dokan-pro-features` scripts were registered without `wp_set_script_translations()`, so WordPress never loaded their translation files. Every string on the Dokan → Status and Dokan → Pro Features pages stayed in English on translated sites, even when a full catalog was installed. The Pro Features slider heading and several screen-reader labels were hard-coded on top of that, so they never reached the translation catalog in the first place.

**New behaviour** — both scripts declare the `dokan-lite` text domain, so their strings localize like the rest of the admin dashboard, and the previously hard-coded heading and accessibility labels are translatable.

### Before Changes

Admin locale set to `fr_FR` with a translation file installed for the Status bundle: the page still renders `Status` and `Latest Version:` in English, and the page emits no `dokan-status-js-translations` script.

### After Changes

Same locale, same translation file: the page renders the translated strings. The Pro Features slider heading, which previously could not be translated at all, now localizes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFhWbDeWfYzgPjgXkGNCv8
