### PR TITLE
fix: admin settings fields ship defaults outside their own option lists

### DIFF
--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -986,7 +986,10 @@ class SettingsSchema {
                 'section_id'  => 'cod_payments_section',
                 'title'       => esc_html__( 'COD Payments', 'dokan-lite' ),
                 'description' => esc_html__( 'If an order is paid with Cash on Delivery (COD), then exclude that payment from vendor balance.', 'dokan-lite' ),
-                'default'     => 'include',
+                // 'on' (Include) is the mirror of the legacy `exclude_cod_payment`
+                // default of 'off' through InvertOnOffTransformer, so an unsaved
+                // site reads the same either side of the bridge.
+                'default'     => 'on',
                 'options'     => [
                     [
 						'title' => esc_html__( 'Include', 'dokan-lite' ),

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2347,24 +2347,37 @@ class SettingsSchema {
 
         // Build model options + default model id defensively — providers may
         // not implement get_models_by_type / get_default_model_id.
+        $model_const   = 'image' === ( $cfg['model_kind'] ?? '' )
+            ? '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_IMAGE'
+            : '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_TEXT';
         $model_options = [];
-        if ( method_exists( $provider, 'get_models_by_type' ) ) {
-            $model_const = 'image' === ( $cfg['model_kind'] ?? '' )
-                ? '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_IMAGE'
-                : '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_TEXT';
-            try {
-                $models = $provider->get_models_by_type( constant( $model_const ) );
+        $default_model = '';
+
+        try {
+            $model_type = constant( $model_const );
+
+            if ( method_exists( $provider, 'get_models_by_type' ) ) {
+                $models = $provider->get_models_by_type( $model_type );
                 foreach ( $models as $model_id => $model ) {
                     $model_options[] = [
 						'title' => $model->get_title(),
 						'value' => (string) $model_id,
 					];
                 }
-            } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-                unset( $e );
             }
+
+            // Resolve the default against this field's generation type. A provider
+            // serving both text and image cannot express one default valid for
+            // both, so the untyped getter is only a fallback for providers that
+            // predate the typed one.
+            if ( method_exists( $provider, 'get_default_model_id_by_type' ) ) {
+                $default_model = (string) $provider->get_default_model_id_by_type( $model_type );
+            } elseif ( method_exists( $provider, 'get_default_model_id' ) ) {
+                $default_model = (string) $provider->get_default_model_id();
+            }
+        } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            unset( $e );
         }
-        $default_model = method_exists( $provider, 'get_default_model_id' ) ? (string) $provider->get_default_model_id() : '';
 
         $api_key_url = method_exists( $provider, 'get_api_key_url' ) ? (string) $provider->get_api_key_url() : '';
         $image_url   = method_exists( $provider, 'get_image_url' ) ? (string) $provider->get_image_url() : '';

--- a/includes/Intelligence/Admin/Settings.php
+++ b/includes/Intelligence/Admin/Settings.php
@@ -90,7 +90,9 @@ class Settings implements Hookable {
                 'type'    => 'select',
                 'options' => array_map( fn( $model ) => $model->get_title(), $provider->get_models_by_type( Model::SUPPORTS_TEXT ) ),
                 'desc'    => __( 'More advanced models provide higher quality output but may cost more per generation.', 'dokan-lite' ),
-                'default' => $provider->get_default_model_id(),
+                'default' => method_exists( $provider, 'get_default_model_id_by_type' )
+                    ? $provider->get_default_model_id_by_type( Model::SUPPORTS_TEXT )
+                    : $provider->get_default_model_id(),
                 'is_lite' => true,
                 'show_if' => [
                     'dokan_ai_engine' => [

--- a/includes/Intelligence/Services/Provider.php
+++ b/includes/Intelligence/Services/Provider.php
@@ -73,6 +73,37 @@ abstract class Provider implements AIProviderInterface, Hookable {
 
     abstract public function get_default_model_id(): string;
 
+    /**
+     * Get the default model id for a specific generation type.
+     *
+     * A provider that serves more than one generation type cannot express its
+     * default as a single id — a text model id is never a valid image model id,
+     * so `get_default_model_id()` is necessarily wrong for one of them. Honour
+     * the declared default only when it actually supports the requested type,
+     * and otherwise fall back to the first registered model of that type, so
+     * the returned id is always one the caller can offer.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string $type The generation type (e.g. 'text', 'image').
+     *
+     * @return string A model id supporting $type, or an empty string when the
+     *                provider registers no model of that type.
+     */
+    public function get_default_model_id_by_type( string $type ): string {
+        $declared = $this->get_default_model_id();
+        $model    = '' !== $declared ? $this->get_model( $declared ) : null;
+
+        if ( $model instanceof AIModelInterface && $model->supports( $type ) ) {
+            return $declared;
+        }
+
+        $models = $this->get_models_by_type( $type );
+        $first  = ! empty( $models ) ? reset( $models ) : null;
+
+        return $first instanceof AIModelInterface ? $first->get_id() : '';
+    }
+
 	/**
 	 * @inheritDoc
 	 */

--- a/includes/Intelligence/Services/Providers/Gemini.php
+++ b/includes/Intelligence/Services/Providers/Gemini.php
@@ -28,7 +28,7 @@ class Gemini extends Provider {
 	}
 
 	public function get_default_model_id(): string {
-		return 'gemini-2.0-flash';
+		return 'gemini-2.5-flash';
 	}
 
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s)

### Changes proposed in this Pull Request:

Three of the four fields reported in getdokan/dokan-pro#6050 ship a `default` that is not a member of their own `options`, so the control cannot represent what is configured. `SettingsRegistry` hands the default straight to the UI when no value is stored, and nothing validates that it is selectable:

```php
$element['value'] = $stored[ $id ] ?? ( $element['default'] ?? '' );
```

One commit per fix.

**1. `Gemini::get_default_model_id()` returned a model that does not exist**

`gemini-2.0-flash` was a valid id in the flat list `GeminiResponseService::get_models()` used to expose (`gemini-1.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`). The commit that replaced that list with Model classes registered only the 2.5 models but wrote the new provider default with the old id — so it was dead from the moment the method existed.

Beyond the unselectable control, `Provider::get_default_model()` resolved it through `get_model()` to `null` rather than to a usable model. Now points at `gemini-2.5-flash`.

**2. One default cannot serve two generation types**

A provider exposes a single `get_default_model_id()`, but it feeds both the text Model field and the image Model field, whose option lists share no values. Gemini serves both types, so its default was necessarily wrong for one — fixing the declared id above corrects text and leaves image broken, and no single value can satisfy both.

Adds `Provider::get_default_model_id_by_type()`, which honours the declared default only when it actually supports the requested type and otherwise falls back to the first registered model of that type. The settings builders now pass the type they are rendering, so options and default always come from the same model list.

It lands on the abstract `Provider` rather than `AIProviderInterface` so third-party classes implementing the interface directly keep working, and call sites guard with `method_exists()` for providers that predate it.

Side effect worth noting: a dead declared id can no longer render an unselectable control, because resolution falls back to a real model of the right type. That closes the class of bug in (1), not just the instance.

**3. `include_cod_payments_in_balance` used a label where a value belongs**

The field declared `'default' => 'include'` while its radio capsule offers `on` (Include) and `off` (Exclude), so neither button was active on a site with no stored value.

`'on'` is correct on two counts: it is the option meaning Include, and it is the mirror of the legacy `exclude_cod_payment` default of `'off'` through `InvertOnOffTransformer` — so a fresh install reads the same state either side of the bridge.

Runtime was never affected: `'on' === 'include'` is false, so the stale value resolved to "include" anyway, which is the intended default. No vendor balance was ever computed wrongly. This repairs the control and stops `'include'` being mirrored into the legacy `dokan_withdraw` row.

This is the only one of the four the settings refactor introduced; the other three predate it and reproduce on the legacy screens too.

### Related Pull Request(s)

* Dokan Pro: getdokan/dokan-pro#6136 — fixes the two Pro-side fields (`ai_product_image_engine`, `image_gemini_model`) and consumes `get_default_model_id_by_type()` added here. **Merge this PR first or together**; the Pro PR depends on it.

### Closes

* Partially addresses getdokan/dokan-pro#6050 (the three Lite-side fields; together with getdokan/dokan-pro#6136 this closes the issue)

### How to test the changes in this Pull Request:

The bad defaults are only visible while the key is absent from `dokan_admin_settings` — a fresh install, or after clearing it. `include_cod_payments_in_balance` additionally needs the legacy key cleared, because `InvertOnOffTransformer` derives a valid `'on'` from it and masks the bug entirely (which is likely why it went unnoticed: only a site with no legacy COD value at all is affected).

```bash
wp eval '
$o = get_option("dokan_admin_settings", []);
foreach ( ["text_gemini_model","include_cod_payments_in_balance"] as $k ) { unset( $o[$k] ); }
update_option( "dokan_admin_settings", $o );
$w = get_option("dokan_withdraw", []); unset( $w["exclude_cod_payment"] ); update_option( "dokan_withdraw", $w );'
```

**Before (on `refactor/simplify-settings-to-flat-array`)**

1. **Dokan → Settings → AI Assist → Content Generation** → set **Engine = Gemini**. The **Model** dropdown lists the three 2.5 models but shows no selection (or the first option); the value is `gemini-2.0-flash`.
2. **Dokan → Settings → Transaction → Withdraw** → **COD Payments**. Neither *Include* nor *Exclude* is active.

Both reproduce on the legacy screen too (**Dokan → Settings → AI Assist**), since it reads the same provider methods.

**After**

Model shows *Gemini 2.5 Flash*; COD Payments shows *Include* selected.

**Assert it directly:**

```bash
wp eval '
$reg  = dokan()->get_container()->get( \WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry::class );
$flat = [];
$walk = function ( $items ) use ( &$walk, &$flat ) {
    foreach ( $items as $it ) { if ( is_array( $it ) ) {
        if ( isset( $it["id"] ) ) { $flat[ $it["id"] ] = $it; }
        foreach ( $it as $v ) { if ( is_array( $v ) ) { $walk( [ $v ] ); } } } }
};
$walk( $reg->get_schema( true ) );
$bad = 0;
foreach ( $flat as $id => $e ) {
    if ( empty( $e["options"] ) || ! array_key_exists( "default", $e ) || is_array( $e["default"] ) ) { continue; }
    $vals = array_column( $e["options"], "value" );
    if ( $vals && ! in_array( $e["default"], $vals, true ) ) { $bad++; printf( "%s = %s (opts: %s)\n", $id, var_export( $e["default"], true ), implode( ",", $vals ) ); }
}
printf( "%d field(s) ship a default outside their own options.\n", $bad );'
```

Expected after this PR (with Pro #6136 applied for the two Pro fields): `0 field(s)`.

The e2e sweep in `tests/pw/tests/e2e/adminSettings/adminSettingsCoverage.spec.ts` (`should offer every field a default it can actually select`) covers this across the whole live schema.

### Changelog entry

*Fix: Several admin settings showed a selection that did not match the stored value*

Previously, the AI **Model** setting defaulted to a Gemini model that no longer exists — so the dropdown showed no selection while a different model was stored and used, and the default resolved to no model at all at runtime — and the **COD Payments** setting defaulted to a value neither of its two buttons could represent, leaving both unselected. These defaults now always come from the options the control actually offers, so the settings screen shows what is really configured. Vendor balances were never calculated incorrectly by the COD issue.

### Before Changes

Gemini Model select renders blank (or falls back to its first option) while holding `gemini-2.0-flash`; COD Payments capsule has neither button active while holding `include`.

### After Changes

Model resolves to `gemini-2.5-flash` (and `gemini-2.5-flash-image` for the image field via Pro #6136); COD Payments resolves to `on` (*Include*). Verified against the live schema: no field ships a default outside its own options.

### PR Self Review Checklist:

* PHPCS clean on all changed files.
* Backwards compatible: `get_default_model_id_by_type()` is added to the abstract `Provider`, not to `AIProviderInterface`, and every call site guards with `method_exists()` — a third-party provider implementing the interface directly, or one predating the method, falls back to the previous behaviour.
* 33 corner cases exercised locally, including: a provider with no models; a text-only provider asked for an image default; a dead declared id; a provider whose model list is filtered to empty by a third party; `get_model()` filtered to `null`; a provider implementing only the interface; and a provider with the untyped getter alone. No fatals, and every real provider/type combination resolves to a selectable id.
* COD polarity verified in both directions through `InvertOnOffTransformer`, including the round trip via the legacy `dokan_withdraw` row.
* The COD fix is not retroactive — a site that saved the page while the bad default was live has `'include'` stored, and a stored value takes precedence over the default. Behaviour there stays correct; only the control stays blank. A stored-value clamp or an upgrade routine would be needed to self-heal those sites, which felt out of scope for a default fix — happy to add either if reviewers prefer.
