### PR TITLE
fix(rest): link the route that served the request in pagination headers

### DIFF
--- a/includes/REST/DokanBaseController.php
+++ b/includes/REST/DokanBaseController.php
@@ -46,7 +46,11 @@ abstract class DokanBaseController extends WP_REST_Controller {
         $max_pages = ceil( $total_items / $per_page );
 
         $response->header( 'X-WP-TotalPages', (int) $max_pages );
-        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->base ?? $this->rest_base ) ) );
+
+        // Link the route that served the request: vendor controllers share `vendor` as rest_base, and some bases still hold an unresolved regex.
+        $route = $request->get_route();
+        $path  = ! empty( $route ) ? $route : sprintf( '/%s/%s', $this->namespace, $this->base ?? $this->rest_base );
+        $base  = add_query_arg( $request->get_query_params(), rest_url( $path ) );
 
         if ( $page > 1 ) {
             $prev_page = $page - 1;


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

`DokanBaseController::format_collection_response()` built its pagination `Link` header by
reconstructing a URL from the controller's `namespace` and `rest_base` rather than from the route
that actually served the request.

Every controller extending `DokanBaseVendorController` shares `rest_base = 'vendor'`, so a route
registered at `vendor/reports/statement` advertised its next page as `/dokan/v1/vendor`. Nothing is
registered there, so the link the server hands out returns `404 rest_no_route`. A `rest_base` that
still holds an unresolved regex — Pro's `manual-orders/(?P<order_id>[\d]+)/shipping_methods` — leaked
the raw regex into the link the same way.

Any REST client that follows the `Link` header breaks on these routes. WordPress ships one by
default: `@wordpress/api-fetch`'s `fetchAllMiddleware` intercepts `per_page=-1`, rewrites it to
`per_page=100` and walks the `Link` header to collect the remaining pages.

This PR builds the link base from `$request->get_route()`, which is the path that matched, and keeps
the old `namespace`/`rest_base` construct as a fallback for the case where no route is set on the
request.

### Related Pull Request(s)

* Dokan Pro: https://github.com/getdokan/dokan-pro/pull/6148

This PR fixes the `Link` header; the Pro PR fixes the statement collection's entry count and the
pagination-dependent parts of the report. Merge this one first.

### Closes

* Closes getdokan/dokan-pro#6137

### How to test the changes in this Pull Request:

1. Install WordPress, WooCommerce, Dokan Lite and Dokan Pro.
2. Create a vendor, publish a product for that vendor, place an order for it and mark it Completed
   so it reaches the vendor balance ledger.
3. Log in as that vendor, open any vendor dashboard page, and request page 1 of a vendor collection
   with a page size smaller than the number of entries:

   ```js
   const n = window.wpApiSettings.nonce;
   const r = await fetch( '/wp-json/dokan/v1/vendor/reports/statement?per_page=1&page=1',
                          { headers: { 'X-WP-Nonce': n }, credentials: 'same-origin' } );
   console.log( r.status, r.headers.get( 'x-wp-totalpages' ), r.headers.get( 'link' ) );
   ```

4. The `Link` header names `/dokan/v1/vendor/reports/statement`, the route that served the request.
5. Follow that exact URL. It returns `200` with the next page of the same collection, not
   `404 rest_no_route`.

### Changelog entry

*Fix: REST pagination `Link` headers pointed at routes that do not exist*

Collection endpoints built their `Link` header from the controller's `rest_base` rather than from the
route that served the request. Vendor routes all share `vendor` as their base, so every paginated
vendor collection advertised `/dokan/v1/vendor` as its next page, which is not a registered route and
returns `404 rest_no_route`; bases holding an unresolved regex leaked that regex into the link. Any
client following the header — including `@wordpress/api-fetch`'s `fetchAllMiddleware`, which every
`per_page=-1` request goes through — failed on those collections. The header now names the route the
request was served from.

### Before Changes

```
GET /wp-json/dokan/v1/vendor/reports/statement?per_page=1&page=1

HTTP 200
X-WP-Total: 2      X-WP-TotalPages: 2
Link: <https://example.test/wp-json/dokan/v1/vendor?per_page=1&page=2>; rel="next"

GET /wp-json/dokan/v1/vendor?per_page=1&page=2
HTTP 404 {"code":"rest_no_route", ...}
```

### After Changes

```
GET /wp-json/dokan/v1/vendor/reports/statement?per_page=5&page=1

HTTP 200
X-WP-Total: 2347   X-WP-TotalPages: 470
Link: <https://example.test/wp-json/dokan/v1/vendor/reports/statement?per_page=5&page=2&start_date=…&end_date=…>; rel="next"

Page 2 carries both links:
Link: <…&page=1>; rel="prev", <…&page=3>; rel="next"

Page 470 (last) carries only:
Link: <…&page=469>; rel="prev"
```
